### PR TITLE
Update to SmokeHTTP 2 and SmokeAWS 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,22 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=no
+      env: DOCKER_IMAGE_TAG=swift:5.1-bionic USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.0.1-bionic USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.0.1-xenial USE_SWIFT_LINT=yes
-    - os: linux
-      dist: xenial
-      sudo: required
-      ervices: docker
-      env: DOCKER_IMAGE_TAG=swift:4.2.1 USE_SWIFT_LINT=no
-    - os: linux
-      dist: xenial
-      sudo: required
-      ervices: docker
-      env: DOCKER_IMAGE_TAG=swift:4.1.3 USE_SWIFT_LINT=no
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "LoggerAPI",
-        "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
+        "package": "Cryptor",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
         "state": {
           "branch": null,
-          "revision": "3357dd9526cdf9436fa63bb792b669e6efdc43da",
-          "version": "1.9.0"
+          "revision": "12d2bf3ec7207ec3cd004b9582f69ef5fae1da3b",
+          "version": "1.0.32"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "36a4d11942ed209129427185c25dabb03007eb92",
-          "version": "1.25.3"
+          "revision": "422976305717430c8b5679779ef7b4ef419da2a1",
+          "version": "2.0.0-alpha.2"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "705553c6f59d15f8b9fe2fd458a0ad3755ef9bc4",
-          "version": "1.0.1"
+          "revision": "705a512220e9308c3268e85ea4db8535b54294eb",
+          "version": "2.0.0-alpha.4"
         }
       },
       {
@@ -33,8 +33,17 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "eba9b323b5ba542c119ff17382a4ce737bcdc0b8",
-          "version": "0.0.0"
+          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "swift-metrics",
+        "repositoryURL": "https://github.com/apple/swift-metrics.git",
+        "state": {
+          "branch": null,
+          "revision": "09b72f68ed9b01b614c12855fc7e22876b97a97e",
+          "version": "1.2.1"
         }
       },
       {
@@ -42,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "ba7970fe396e8198b84c6c1b44b38a1d4e2eb6bd",
-          "version": "1.14.1"
+          "revision": "16ab4d657e1ad4e77bd5f8b94af8538561643053",
+          "version": "2.14.0"
         }
       },
       {
@@ -51,26 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "0f3999f3e3c359cc74480c292644c3419e44a12f",
-          "version": "1.4.0"
-        }
-      },
-      {
-        "package": "swift-nio-ssl-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl-support.git",
-        "state": {
-          "branch": null,
-          "revision": "c02eec4e0e6d351cd092938cf44195a8e669f555",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
+          "revision": "af46d9b58fafbb76f9b01177568d435a1b024f99",
+          "version": "2.6.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.1
+// swift-tools-version:5.0
 //
 // Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -17,22 +17,27 @@ import PackageDescription
 
 let package = Package(
     name: "SmokeDynamoDB",
+    platforms: [
+        .macOS(.v10_12), .iOS(.v10)
+        ],
     products: [
         .library(
             name: "SmokeDynamoDB",
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/amzn/smoke-http.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "1.0.0"),
     ],
     targets: [
         .target(
             name: "SmokeDynamoDB",
-            dependencies: ["LoggerAPI", "DynamoDBClient", "SmokeHTTPClient"]),
+            dependencies: ["Metrics", "Logging", "DynamoDBClient", "SmokeHTTPClient"]),
         .testTarget(
             name: "SmokeDynamoDBTests",
             dependencies: ["SmokeDynamoDB", "SmokeHTTPClient"]),
-    ]
+    ],
+    swiftLanguageVersions: [.v5]
 )

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
@@ -19,7 +19,7 @@ import Foundation
 import SmokeAWSCore
 import DynamoDBModel
 import SmokeHTTPClient
-import LoggerAPI
+import Logging
 
 /// DynamoDBTable conformance async functions
 public extension AWSDynamoDBCompositePrimaryKeyTable {
@@ -54,31 +54,31 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
     }
     
     func getItemAsync<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>,
-                                                completion: @escaping (HTTPResult<TypedDatabaseItem<AttributesType, ItemType>?>) -> ())
+                                                completion: @escaping (SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>?>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, ItemType: Decodable, ItemType: Encodable {
             let putItemInput = try getInputForGetItem(forKey: key)
             
-            Log.verbose("dynamodb.getItem with key: \(key) and table name \(targetTableName)")
+            self.logger.debug("dynamodb.getItem with key: \(key) and table name \(targetTableName)")
             try dynamodb.getItemAsync(input: putItemInput) { result in
                 switch result {
-                case .response(let attributeValue):
+                case .success(let attributeValue):
                     if let item = attributeValue.item {
-                        Log.verbose("Value returned from DynamoDB.")
+                        self.logger.debug("Value returned from DynamoDB.")
                         
                         do {
                             let decodedItem: TypedDatabaseItem<AttributesType, ItemType>? =
-                                try AWSDynamoDBCompositePrimaryKeyTable.dynamodbDecoder.decode(DynamoDBModel.AttributeValue(M: item))
-                            completion(.response(decodedItem))
+                                try DynamoDBDecoder().decode(DynamoDBModel.AttributeValue(M: item))
+                            completion(.success(decodedItem))
                         } catch {
-                            completion(.error(error))
+                            completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
                         }
                     } else {
-                        Log.verbose("No item returned from DynamoDB.")
+                        self.logger.debug("No item returned from DynamoDB.")
                         
-                        completion(.response(nil))
+                        completion(.success(nil))
                     }
-                case .error(let error):
-                    completion(.error(error))
+                case .failure(let error):
+                    completion(.failure(error.asSmokeDynamoDBError()))
                 }
             }
     }
@@ -88,13 +88,13 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         throws where AttributesType: PrimaryKeyAttributes {
             let deleteItemInput = try getInputForDeleteItem(forKey: key)
         
-            Log.verbose("dynamodb.deleteItem with key: \(key) and table name \(targetTableName)")
+            self.logger.debug("dynamodb.deleteItem with key: \(key) and table name \(targetTableName)")
             try dynamodb.deleteItemAsync(input: deleteItemInput) { result in
                 switch result {
-                case .response:
+                case .success:
                     // complete the putItem
                     completion(nil)
-                case .error(let error):
+                case .failure(let error):
                     completion(error)
                 }
             }
@@ -103,7 +103,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
     func queryAsync<AttributesType, PossibleTypes>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            completion: @escaping (HTTPResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             let partialResults = QueryPaginationResults<AttributesType, PossibleTypes>()
             
@@ -117,11 +117,11 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         forPartitionKey partitionKey: String,
         sortKeyCondition: AttributeCondition?,
         partialResults: QueryPaginationResults<AttributesType, PossibleTypes>,
-        completion: @escaping (HTTPResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
+        completion: @escaping (SmokeDynamoDBErrorResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
-            func handleQueryResult(result: HTTPResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) {
+            func handleQueryResult(result: SmokeDynamoDBErrorResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) {
                 switch result {
-                case .response(let paginatedItems):
+                case .success(let paginatedItems):
                     partialResults.items += paginatedItems.0
             
                     // if there are more items
@@ -134,14 +134,14 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                                                   partialResults: partialResults,
                                                   completion: completion)
                         } catch {
-                            completion(.error(error))
+                            completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
                         }
                     } else {
                         // we have all the items
-                        completion(.response(partialResults.items))
+                        completion(.success(partialResults.items))
                     }
-                case .error(let error):
-                    completion(.error(error))
+                case .failure(let error):
+                    completion(.failure(error))
                 }
             }
             
@@ -156,7 +156,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
             limit: Int?, exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             try queryAsync(forPartitionKey: partitionKey,
                            sortKeyCondition: sortKeyCondition,
@@ -170,7 +170,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
             limit: Int?, scanIndexForward: Bool, exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             let queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(forPartitionKey: partitionKey, targetTableName: targetTableName,
                                                                               primaryKeyType: AttributesType.self,
@@ -178,15 +178,15 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                                                                               scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
             try dynamodb.queryAsync(input: queryInput) { result in
                 switch result {
-                case .response(let queryOutput):
+                case .success(let queryOutput):
                     let lastEvaluatedKey: String?
                     if let returnedLastEvaluatedKey = queryOutput.lastEvaluatedKey {
                         let encodedLastEvaluatedKey: Data
                         
                         do {
-                            encodedLastEvaluatedKey = try AWSDynamoDBCompositePrimaryKeyTable.jsonEncoder.encode(returnedLastEvaluatedKey)
+                            encodedLastEvaluatedKey = try JSONEncoder().encode(returnedLastEvaluatedKey)
                         } catch {
-                            return completion(.error(error))
+                            return completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
                         }
                         
                         lastEvaluatedKey = String(data: encodedLastEvaluatedKey, encoding: .utf8)
@@ -201,18 +201,18 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                             items = try outputAttributeValues.map { values in
                                 let attributeValue = DynamoDBModel.AttributeValue(M: values)
                                 
-                                return try AWSDynamoDBCompositePrimaryKeyTable.dynamodbDecoder.decode(attributeValue)
+                                return try DynamoDBDecoder().decode(attributeValue)
                             }
                         } catch {
-                            return completion(.error(error))
+                            return completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
                         }
                         
-                        completion(.response((items, lastEvaluatedKey)))
+                        completion(.success((items, lastEvaluatedKey)))
                     } else {
-                        completion(.response(([], lastEvaluatedKey)))
+                        completion(.success(([], lastEvaluatedKey)))
                     }
-                case .error(let error):
-                    return completion(.error(error))
+                case .failure(let error):
+                    return completion(.failure(error.asSmokeDynamoDBError()))
                 }
             }
     }
@@ -223,26 +223,26 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         do {
             _ = try dynamodb.putItemAsync(input: putItemInput) { result in
                 switch result {
-                case .response:
+                case .success:
                     // complete the putItem
                     completion(nil)
-                case .error(let error):
+                case .failure(let error):
                     switch error {
                     case DynamoDBError.conditionalCheckFailed(let errorPayload):
                         completion(SmokeDynamoDBError.conditionalCheckFailed(partitionKey: compositePrimaryKey.partitionKey,
                                                                            sortKey: compositePrimaryKey.sortKey,
                                                                            message: errorPayload.message))
                     default:
-                        Log.warning("Error from AWSDynamoDBTable: \(error)")
+                        self.logger.warning("Error from AWSDynamoDBTable: \(error)")
             
-                        completion(SmokeDynamoDBError.databaseError(reason: "\(error)"))
+                        completion(SmokeDynamoDBError.databaseError(cause: error))
                     }
                 }
             }
         } catch {
-            Log.warning("Error from AWSDynamoDBTable: \(error)")
+            self.logger.warning("Error from AWSDynamoDBTable: \(error)")
             
-            throw SmokeDynamoDBError.databaseError(reason: "\(error)")
+            throw SmokeDynamoDBError.databaseError(cause: error)
         }
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -16,20 +16,16 @@
 //
 
 import Foundation
-import LoggerAPI
+import Logging
 import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
 
-public class AWSDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryKeyTable {
-    internal let dynamodb: AWSDynamoDBClient
+public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: SmokeAWSInvocationReporting>: DynamoDBCompositePrimaryKeyTable {
+    internal let dynamodb: AWSDynamoDBClient<InvocationReportingType>
     internal let targetTableName: String
-
-    static internal let dynamodbEncoder = DynamoDBEncoder()
-    static internal let dynamodbDecoder = DynamoDBDecoder()
-    static internal let jsonEncoder = JSONEncoder()
-    static internal let jsonDecoder = JSONDecoder()
+    internal let logger: Logger
 
     internal let defaultPaginationLimit = 100
 
@@ -39,33 +35,43 @@ public class AWSDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryKeyTab
     }
 
     public init(accessKeyId: String, secretAccessKey: String,
-                region: AWSRegion, endpointHostName: String,
-                tableName: String,
+                region: AWSRegion, reporting: InvocationReportingType,
+                endpointHostName: String, tableName: String,
                 eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
 
+        self.logger = reporting.logger
         self.dynamodb = AWSDynamoDBClient(credentialsProvider: staticCredentials,
-                                          awsRegion: region,
+                                          awsRegion: region, reporting: reporting,
                                           endpointHostName: endpointHostName,
                                           eventLoopProvider: eventLoopProvider)
         self.targetTableName = tableName
 
-        Log.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
+        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
 
     public init(credentialsProvider: CredentialsProvider,
-                region: AWSRegion, endpointHostName: String,
-                tableName: String,
+                region: AWSRegion, reporting: InvocationReportingType,
+                endpointHostName: String, tableName: String,
                 eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+        self.logger = reporting.logger
         self.dynamodb = AWSDynamoDBClient(credentialsProvider: credentialsProvider,
-                                          awsRegion: region,
+                                          awsRegion: region, reporting: reporting,
                                           endpointHostName: endpointHostName,
                                           eventLoopProvider: eventLoopProvider)
         self.targetTableName = tableName
 
-        Log.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
+        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
+    }
+    
+    internal init(dynamodb: AWSDynamoDBClient<InvocationReportingType>,
+                  targetTableName: String,
+                  logger: Logger) {
+        self.dynamodb = dynamodb
+        self.targetTableName = targetTableName
+        self.logger = logger
     }
 
     /**
@@ -116,38 +122,38 @@ public class AWSDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryKeyTab
 
     internal func getAttributes<AttributesType, ItemType>(forItem item: TypedDatabaseItem<AttributesType, ItemType>) throws
         -> [String: DynamoDBModel.AttributeValue] {
-            let attributeValue = try AWSDynamoDBCompositePrimaryKeyTable.dynamodbEncoder.encode(item)
+            let attributeValue = try DynamoDBEncoder().encode(item)
 
             let attributes: [String: DynamoDBModel.AttributeValue]
             if let itemAttributes = attributeValue.M {
                 attributes = itemAttributes
             } else {
-                throw SmokeDynamoDBError.databaseError(reason: "Expected a map.")
+                throw SmokeDynamoDBError.unexpectedResponse(reason: "Expected a map.")
             }
 
             return attributes
     }
 
     internal func getInputForGetItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>) throws -> DynamoDBModel.GetItemInput {
-        let attributeValue = try AWSDynamoDBCompositePrimaryKeyTable.dynamodbEncoder.encode(key)
+        let attributeValue = try DynamoDBEncoder().encode(key)
 
         if let keyAttributes = attributeValue.M {
             return DynamoDBModel.GetItemInput(consistentRead: true,
                                               key: keyAttributes,
                                               tableName: targetTableName)
         } else {
-            throw SmokeDynamoDBError.databaseError(reason: "Expected a structure.")
+            throw SmokeDynamoDBError.unexpectedResponse(reason: "Expected a structure.")
         }
     }
 
     internal func getInputForDeleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>) throws -> DynamoDBModel.DeleteItemInput {
-        let attributeValue = try AWSDynamoDBCompositePrimaryKeyTable.dynamodbEncoder.encode(key)
+        let attributeValue = try DynamoDBEncoder().encode(key)
 
         if let keyAttributes = attributeValue.M {
             return DynamoDBModel.DeleteItemInput(key: keyAttributes,
                                                  tableName: targetTableName)
         } else {
-            throw SmokeDynamoDBError.databaseError(reason: "Expected a structure.")
+            throw SmokeDynamoDBError.unexpectedResponse(reason: "Expected a structure.")
         }
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  AWSDynamoDBKeysProjection.swift
+//  AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
 //  SmokeDynamoDB
 //
 
@@ -22,54 +22,34 @@ import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
 
-public class AWSDynamoDBKeysProjection<InvocationReportingType: SmokeAWSInvocationReporting>: DynamoDBKeysProjection {
-    internal let dynamodb: AWSDynamoDBClient<InvocationReportingType>
+public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
+    internal let dynamodbGenerator: AWSDynamoDBClientGenerator
     internal let targetTableName: String
-    internal let logger: Logger
-
-    internal class QueryPaginationResults<AttributesType: PrimaryKeyAttributes> {
-        var items: [CompositePrimaryKey<AttributesType>] = []
-        var exclusiveStartKey: String?
-    }
 
     public init(accessKeyId: String, secretAccessKey: String,
-                region: AWSRegion, reporting: InvocationReportingType,
+                region: AWSRegion,
                 endpointHostName: String, tableName: String,
                 eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
 
-        self.logger = reporting.logger
-        self.dynamodb = AWSDynamoDBClient(credentialsProvider: staticCredentials,
-                                          awsRegion: region, reporting: reporting,
-                                          endpointHostName: endpointHostName,
-                                          eventLoopProvider: eventLoopProvider)
+        self.dynamodbGenerator = AWSDynamoDBClientGenerator(credentialsProvider: staticCredentials,
+                                                            awsRegion: region,
+                                                            endpointHostName: endpointHostName,
+                                                            eventLoopProvider: eventLoopProvider)
         self.targetTableName = tableName
-
-        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
 
     public init(credentialsProvider: CredentialsProvider,
-                region: AWSRegion, reporting: InvocationReportingType,
+                region: AWSRegion,
                 endpointHostName: String, tableName: String,
                 eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
-        self.logger = reporting.logger
-        self.dynamodb = AWSDynamoDBClient(credentialsProvider: credentialsProvider,
-                                          awsRegion: region, reporting: reporting,
-                                          endpointHostName: endpointHostName,
-                                          eventLoopProvider: eventLoopProvider)
+        self.dynamodbGenerator = AWSDynamoDBClientGenerator(credentialsProvider: credentialsProvider,
+                                                            awsRegion: region,
+                                                            endpointHostName: endpointHostName,
+                                                            eventLoopProvider: eventLoopProvider)
         self.targetTableName = tableName
-
-        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
-    }
-    
-    internal init(dynamodb: AWSDynamoDBClient<InvocationReportingType>,
-                  targetTableName: String,
-                  logger: Logger) {
-        self.dynamodb = dynamodb
-        self.targetTableName = targetTableName
-        self.logger = logger
     }
 
     /**
@@ -77,7 +57,7 @@ public class AWSDynamoDBKeysProjection<InvocationReportingType: SmokeAWSInvocati
      will handle being called multiple times.
      */
     public func close() {
-        dynamodb.close()
+        dynamodbGenerator.close()
     }
 
     /**
@@ -85,6 +65,14 @@ public class AWSDynamoDBKeysProjection<InvocationReportingType: SmokeAWSInvocati
      this will block forever.
      */
     public func wait() {
-        dynamodb.wait()
+        dynamodbGenerator.wait()
+    }
+    
+    public func with<NewInvocationReportingType: SmokeAWSInvocationReporting>(
+            reporting: NewInvocationReportingType) -> AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType> {
+        return AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType>(
+            dynamodb: self.dynamodbGenerator.with(reporting: reporting),
+            targetTableName: self.targetTableName,
+            logger: reporting.logger)
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionAsync.swift
@@ -19,7 +19,7 @@ import Foundation
 import SmokeAWSCore
 import DynamoDBModel
 import SmokeHTTPClient
-import LoggerAPI
+import Logging
 
 /// DynamoDBKeysProjection conformance async functions
 public extension AWSDynamoDBCompositePrimaryKeysProjection {
@@ -27,7 +27,7 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
     func queryAsync<AttributesType>(
         forPartitionKey partitionKey: String,
         sortKeyCondition: AttributeCondition?,
-        completion: @escaping (HTTPResult<[CompositePrimaryKey<AttributesType>]>) -> ())
+        completion: @escaping (SmokeDynamoDBErrorResult<[CompositePrimaryKey<AttributesType>]>) -> ())
         throws where AttributesType: PrimaryKeyAttributes {
             let partialResults = QueryPaginationResults<AttributesType>()
             
@@ -41,11 +41,11 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
         forPartitionKey partitionKey: String,
         sortKeyCondition: AttributeCondition?,
         partialResults: QueryPaginationResults<AttributesType>,
-        completion: @escaping (HTTPResult<[CompositePrimaryKey<AttributesType>]>) -> ())
+        completion: @escaping (SmokeDynamoDBErrorResult<[CompositePrimaryKey<AttributesType>]>) -> ())
         throws where AttributesType: PrimaryKeyAttributes {
-            func handleQueryResult(result: HTTPResult<([CompositePrimaryKey<AttributesType>], String?)>) {
+            func handleQueryResult(result: SmokeDynamoDBErrorResult<([CompositePrimaryKey<AttributesType>], String?)>) {
                 switch result {
-                case .response(let paginatedItems):
+                case .success(let paginatedItems):
                     partialResults.items += paginatedItems.0
             
                     // if there are more items
@@ -58,14 +58,14 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
                                                   partialResults: partialResults,
                                                   completion: completion)
                         } catch {
-                            completion(.error(error))
+                            completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
                         }
                     } else {
                         // we have all the items
-                        completion(.response(partialResults.items))
+                        completion(.success(partialResults.items))
                     }
-                case .error(let error):
-                    completion(.error(error))
+                case .failure(let error):
+                    completion(.failure(error))
                 }
             }
             
@@ -80,7 +80,7 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
             limit: Int?, exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes {
             try queryAsync(forPartitionKey: partitionKey,
                            sortKeyCondition: sortKeyCondition,
@@ -96,7 +96,7 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
         limit: Int?,
         scanIndexForward: Bool,
         exclusiveStartKey: String?,
-        completion: @escaping (HTTPResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ())
+        completion: @escaping (SmokeDynamoDBErrorResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes {
             let queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(forPartitionKey: partitionKey, targetTableName: targetTableName,
                                                                               primaryKeyType: AttributesType.self,
@@ -104,15 +104,15 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
                                                                               scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
             try dynamodb.queryAsync(input: queryInput) { result in
                 switch result {
-                case .response(let queryOutput):
+                case .success(let queryOutput):
                     let lastEvaluatedKey: String?
                     if let returnedLastEvaluatedKey = queryOutput.lastEvaluatedKey {
                         let encodedLastEvaluatedKey: Data
                         
                         do {
-                            encodedLastEvaluatedKey = try AWSDynamoDBCompositePrimaryKeyTable.jsonEncoder.encode(returnedLastEvaluatedKey)
+                            encodedLastEvaluatedKey = try JSONEncoder().encode(returnedLastEvaluatedKey)
                         } catch {
-                            return completion(.error(error))
+                            return completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
                         }
                         
                         lastEvaluatedKey = String(data: encodedLastEvaluatedKey, encoding: .utf8)
@@ -127,18 +127,18 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
                             items = try outputAttributeValues.map { values in
                                 let attributeValue = DynamoDBModel.AttributeValue(M: values)
                                 
-                                return try AWSDynamoDBCompositePrimaryKeyTable.dynamodbDecoder.decode(attributeValue)
+                                return try DynamoDBDecoder().decode(attributeValue)
                             }
                         } catch {
-                            return completion(.error(error))
+                            return completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
                         }
                         
-                        completion(.response((items, lastEvaluatedKey)))
+                        completion(.success((items, lastEvaluatedKey)))
                     } else {
-                        completion(.response(([], lastEvaluatedKey)))
+                        completion(.success(([], lastEvaluatedKey)))
                     }
-                case .error(let error):
-                    return completion(.error(error))
+                case .failure(let error):
+                    return completion(.failure(error.asSmokeDynamoDBError()))
                 }
             }
     }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionSync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionSync.swift
@@ -19,7 +19,7 @@ import Foundation
 import SmokeAWSCore
 import DynamoDBModel
 import SmokeHTTPClient
-import LoggerAPI
+import Logging
 
 /// DynamoDBKeysProjection conformance sync functions
 public extension AWSDynamoDBCompositePrimaryKeysProjection {
@@ -79,7 +79,7 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
             
             let lastEvaluatedKey: String?
             if let returnedLastEvaluatedKey = queryOutput.lastEvaluatedKey {
-                let encodedLastEvaluatedKey = try AWSDynamoDBCompositePrimaryKeyTable.jsonEncoder.encode(returnedLastEvaluatedKey)
+                let encodedLastEvaluatedKey = try JSONEncoder().encode(returnedLastEvaluatedKey)
                 
                 lastEvaluatedKey = String(data: encodedLastEvaluatedKey, encoding: .utf8)
             } else {
@@ -90,7 +90,7 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
                 let items: [CompositePrimaryKey<AttributesType>] = try outputAttributeValues.map { values in
                     let attributeValue = DynamoDBModel.AttributeValue(M: values)
                     
-                    return try AWSDynamoDBCompositePrimaryKeyTable.dynamodbDecoder.decode(attributeValue)
+                    return try DynamoDBDecoder().decode(attributeValue)
                 }
                 
                 return (items, lastEvaluatedKey)

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
@@ -16,20 +16,16 @@
 //
 
 import Foundation
-import LoggerAPI
+import Logging
 import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
 
-public class AWSDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePrimaryKeysProjection {
-    internal let dynamodb: AWSDynamoDBClient
+public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: SmokeAWSInvocationReporting>: DynamoDBCompositePrimaryKeysProjection {
+    internal let dynamodb: AWSDynamoDBClient<InvocationReportingType>
     internal let targetTableName: String
-
-    static internal let dynamodbEncoder = DynamoDBEncoder()
-    static internal let dynamodbDecoder = DynamoDBDecoder()
-    static internal let jsonEncoder = JSONEncoder()
-    static internal let jsonDecoder = JSONDecoder()
+    internal let logger: Logger
 
     internal class QueryPaginationResults<AttributesType: PrimaryKeyAttributes> {
         var items: [CompositePrimaryKey<AttributesType>] = []
@@ -37,33 +33,43 @@ public class AWSDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePrimary
     }
 
     public init(accessKeyId: String, secretAccessKey: String,
-                region: AWSRegion, endpointHostName: String,
-                tableName: String,
+                region: AWSRegion, reporting: InvocationReportingType,
+                endpointHostName: String, tableName: String,
                 eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
 
+        self.logger = reporting.logger
         self.dynamodb = AWSDynamoDBClient(credentialsProvider: staticCredentials,
-                                          awsRegion: region,
+                                          awsRegion: region, reporting: reporting,
                                           endpointHostName: endpointHostName,
                                           eventLoopProvider: eventLoopProvider)
         self.targetTableName = tableName
 
-        Log.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
+        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
 
     public init(credentialsProvider: CredentialsProvider,
-                region: AWSRegion, endpointHostName: String,
-                tableName: String,
+                region: AWSRegion, reporting: InvocationReportingType,
+                endpointHostName: String, tableName: String,
                 eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+        self.logger = reporting.logger
         self.dynamodb = AWSDynamoDBClient(credentialsProvider: credentialsProvider,
-                                          awsRegion: region,
+                                          awsRegion: region, reporting: reporting,
                                           endpointHostName: endpointHostName,
                                           eventLoopProvider: eventLoopProvider)
         self.targetTableName = tableName
 
-        Log.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
+        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
+    }
+    
+    internal init(dynamodb: AWSDynamoDBClient<InvocationReportingType>,
+                  targetTableName: String,
+                  logger: Logger) {
+        self.dynamodb = dynamodb
+        self.targetTableName = targetTableName
+        self.logger = logger
     }
 
     /**

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjectionGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjectionGenerator.swift
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  AWSDynamoDBKeysProjection.swift
+//  AWSDynamoDBCompositePrimaryKeysProjectionGenerator.swift
 //  SmokeDynamoDB
 //
 
@@ -22,54 +22,34 @@ import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
 
-public class AWSDynamoDBKeysProjection<InvocationReportingType: SmokeAWSInvocationReporting>: DynamoDBKeysProjection {
-    internal let dynamodb: AWSDynamoDBClient<InvocationReportingType>
+public class AWSDynamoDBCompositePrimaryKeysProjectionGenerator {
+    internal let dynamodbGenerator: AWSDynamoDBClientGenerator
     internal let targetTableName: String
-    internal let logger: Logger
-
-    internal class QueryPaginationResults<AttributesType: PrimaryKeyAttributes> {
-        var items: [CompositePrimaryKey<AttributesType>] = []
-        var exclusiveStartKey: String?
-    }
 
     public init(accessKeyId: String, secretAccessKey: String,
-                region: AWSRegion, reporting: InvocationReportingType,
+                region: AWSRegion,
                 endpointHostName: String, tableName: String,
                 eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
 
-        self.logger = reporting.logger
-        self.dynamodb = AWSDynamoDBClient(credentialsProvider: staticCredentials,
-                                          awsRegion: region, reporting: reporting,
-                                          endpointHostName: endpointHostName,
-                                          eventLoopProvider: eventLoopProvider)
+        self.dynamodbGenerator = AWSDynamoDBClientGenerator(credentialsProvider: staticCredentials,
+                                                            awsRegion: region,
+                                                            endpointHostName: endpointHostName,
+                                                            eventLoopProvider: eventLoopProvider)
         self.targetTableName = tableName
-
-        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
 
     public init(credentialsProvider: CredentialsProvider,
-                region: AWSRegion, reporting: InvocationReportingType,
+                region: AWSRegion,
                 endpointHostName: String, tableName: String,
                 eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
-        self.logger = reporting.logger
-        self.dynamodb = AWSDynamoDBClient(credentialsProvider: credentialsProvider,
-                                          awsRegion: region, reporting: reporting,
-                                          endpointHostName: endpointHostName,
-                                          eventLoopProvider: eventLoopProvider)
+        self.dynamodbGenerator = AWSDynamoDBClientGenerator(credentialsProvider: credentialsProvider,
+                                                            awsRegion: region,
+                                                            endpointHostName: endpointHostName,
+                                                            eventLoopProvider: eventLoopProvider)
         self.targetTableName = tableName
-
-        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
-    }
-    
-    internal init(dynamodb: AWSDynamoDBClient<InvocationReportingType>,
-                  targetTableName: String,
-                  logger: Logger) {
-        self.dynamodb = dynamodb
-        self.targetTableName = targetTableName
-        self.logger = logger
     }
 
     /**
@@ -77,7 +57,7 @@ public class AWSDynamoDBKeysProjection<InvocationReportingType: SmokeAWSInvocati
      will handle being called multiple times.
      */
     public func close() {
-        dynamodb.close()
+        dynamodbGenerator.close()
     }
 
     /**
@@ -85,6 +65,14 @@ public class AWSDynamoDBKeysProjection<InvocationReportingType: SmokeAWSInvocati
      this will block forever.
      */
     public func wait() {
-        dynamodb.wait()
+        dynamodbGenerator.wait()
+    }
+    
+    public func with<NewInvocationReportingType: SmokeAWSInvocationReporting>(
+            reporting: NewInvocationReportingType) -> AWSDynamoDBCompositePrimaryKeysProjection<NewInvocationReportingType> {
+        return AWSDynamoDBCompositePrimaryKeysProjection<NewInvocationReportingType>(
+            dynamodb: self.dynamodbGenerator.with(reporting: reporting),
+            targetTableName: self.targetTableName,
+            logger: reporting.logger)
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjection+DynamoDBKeysProjectionSync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjection+DynamoDBKeysProjectionSync.swift
@@ -19,7 +19,7 @@ import Foundation
 import SmokeAWSCore
 import DynamoDBModel
 import SmokeHTTPClient
-import LoggerAPI
+import Logging
 
 /// DynamoDBKeysProjection conformance sync functions
 public extension AWSDynamoDBKeysProjection {
@@ -64,7 +64,7 @@ public extension AWSDynamoDBKeysProjection {
             
             let lastEvaluatedKey: String?
             if let returnedLastEvaluatedKey = queryOutput.lastEvaluatedKey {
-                let encodedLastEvaluatedKey = try AWSDynamoDBTable.jsonEncoder.encode(returnedLastEvaluatedKey)
+                let encodedLastEvaluatedKey = try JSONEncoder().encode(returnedLastEvaluatedKey)
                 
                 lastEvaluatedKey = String(data: encodedLastEvaluatedKey, encoding: .utf8)
             } else {
@@ -75,7 +75,7 @@ public extension AWSDynamoDBKeysProjection {
                 let items: [CompositePrimaryKey<AttributesType>] = try outputAttributeValues.map { values in
                     let attributeValue = DynamoDBModel.AttributeValue(M: values)
                     
-                    return try AWSDynamoDBTable.dynamodbDecoder.decode(attributeValue)
+                    return try DynamoDBDecoder().decode(attributeValue)
                 }
                 
                 return (items, lastEvaluatedKey)

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTableGenerator.swift
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  AWSDynamoDBKeysProjection.swift
+//  AWSDynamoDBTableGenerator.swift
 //  SmokeDynamoDB
 //
 
@@ -22,54 +22,34 @@ import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
 
-public class AWSDynamoDBKeysProjection<InvocationReportingType: SmokeAWSInvocationReporting>: DynamoDBKeysProjection {
-    internal let dynamodb: AWSDynamoDBClient<InvocationReportingType>
+public class AWSDynamoDBTableGenerator {
+    internal let dynamodbGenerator: AWSDynamoDBClientGenerator
     internal let targetTableName: String
-    internal let logger: Logger
-
-    internal class QueryPaginationResults<AttributesType: PrimaryKeyAttributes> {
-        var items: [CompositePrimaryKey<AttributesType>] = []
-        var exclusiveStartKey: String?
-    }
 
     public init(accessKeyId: String, secretAccessKey: String,
-                region: AWSRegion, reporting: InvocationReportingType,
+                region: AWSRegion,
                 endpointHostName: String, tableName: String,
                 eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
 
-        self.logger = reporting.logger
-        self.dynamodb = AWSDynamoDBClient(credentialsProvider: staticCredentials,
-                                          awsRegion: region, reporting: reporting,
-                                          endpointHostName: endpointHostName,
-                                          eventLoopProvider: eventLoopProvider)
+        self.dynamodbGenerator = AWSDynamoDBClientGenerator(credentialsProvider: staticCredentials,
+                                                            awsRegion: region,
+                                                            endpointHostName: endpointHostName,
+                                                            eventLoopProvider: eventLoopProvider)
         self.targetTableName = tableName
-
-        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
 
     public init(credentialsProvider: CredentialsProvider,
-                region: AWSRegion, reporting: InvocationReportingType,
+                region: AWSRegion,
                 endpointHostName: String, tableName: String,
                 eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
-        self.logger = reporting.logger
-        self.dynamodb = AWSDynamoDBClient(credentialsProvider: credentialsProvider,
-                                          awsRegion: region, reporting: reporting,
-                                          endpointHostName: endpointHostName,
-                                          eventLoopProvider: eventLoopProvider)
+        self.dynamodbGenerator = AWSDynamoDBClientGenerator(credentialsProvider: credentialsProvider,
+                                                            awsRegion: region,
+                                                            endpointHostName: endpointHostName,
+                                                            eventLoopProvider: eventLoopProvider)
         self.targetTableName = tableName
-
-        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
-    }
-    
-    internal init(dynamodb: AWSDynamoDBClient<InvocationReportingType>,
-                  targetTableName: String,
-                  logger: Logger) {
-        self.dynamodb = dynamodb
-        self.targetTableName = targetTableName
-        self.logger = logger
     }
 
     /**
@@ -77,7 +57,7 @@ public class AWSDynamoDBKeysProjection<InvocationReportingType: SmokeAWSInvocati
      will handle being called multiple times.
      */
     public func close() {
-        dynamodb.close()
+        dynamodbGenerator.close()
     }
 
     /**
@@ -85,6 +65,14 @@ public class AWSDynamoDBKeysProjection<InvocationReportingType: SmokeAWSInvocati
      this will block forever.
      */
     public func wait() {
-        dynamodb.wait()
+        dynamodbGenerator.wait()
+    }
+    
+    public func with<NewInvocationReportingType: SmokeAWSInvocationReporting>(
+            reporting: NewInvocationReportingType) -> AWSDynamoDBTable<NewInvocationReportingType> {
+        return AWSDynamoDBTable<NewInvocationReportingType>(
+            dynamodb: self.dynamodbGenerator.with(reporting: reporting),
+            targetTableName: self.targetTableName,
+            logger: reporting.logger)
     }
 }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
@@ -17,7 +17,8 @@
 
 import Foundation
 import SmokeHTTPClient
-import LoggerAPI
+import Logging
+import DynamoDBModel
 
 public extension DynamoDBCompositePrimaryKeyTable {
     /**
@@ -76,9 +77,9 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                                     message: "Unable to complete request to update versioned item in specified number of attempts")
         }
         
-        func handleGetItemResult(result: HTTPResult<TypedDatabaseItem<AttributesType, ItemType>?>) {
+        func handleGetItemResult(result: SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>?>) {
             switch result {
-            case .response(let databaseItemOptional):
+            case .success(let databaseItemOptional):
                 guard let databaseItem = databaseItemOptional else {
                     let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: key.partitionKey,
                                                                         sortKey: key.sortKey,
@@ -114,7 +115,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                 } catch {
                     completion(error)
                 }
-            case .error(let error):
+            case .failure(let error):
                 completion(error)
             }
         }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import SmokeHTTPClient
+import DynamoDBModel
 
 /**
  Protocol presenting a Keys Only projection of a DynamoDB table such as a Keys Only GSI projection.
@@ -37,7 +38,7 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
     func queryAsync<AttributesType>(
         forPartitionKey partitionKey: String,
         sortKeyCondition: AttributeCondition?,
-        completion: @escaping (HTTPResult<[CompositePrimaryKey<AttributesType>]>) -> ()) throws
+        completion: @escaping (SmokeDynamoDBErrorResult<[CompositePrimaryKey<AttributesType>]>) -> ()) throws
 
     /**
      * Queries a partition in the database table and optionally a sort key condition. If the
@@ -55,7 +56,7 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
         sortKeyCondition: AttributeCondition?,
         limit: Int?,
         exclusiveStartKey: String?,
-        completion: @escaping (HTTPResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ()) throws
+        completion: @escaping (SmokeDynamoDBErrorResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ()) throws
     
     func querySync<AttributesType>(forPartitionKey partitionKey: String,
                                    sortKeyCondition: AttributeCondition?,
@@ -70,5 +71,5 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
         limit: Int?,
         scanIndexForward: Bool,
         exclusiveStartKey: String?,
-        completion: @escaping (HTTPResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ()) throws
+        completion: @escaping (SmokeDynamoDBErrorResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ()) throws
 }

--- a/Sources/SmokeDynamoDB/DynamoDBKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBKeysProjection.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import SmokeHTTPClient
+import DynamoDBModel
 
 /**
  Protocol presenting a Keys Only projection of a DynamoDB table such as a Keys Only GSI projection.
@@ -37,7 +38,7 @@ public protocol DynamoDBKeysProjection {
     func queryAsync<AttributesType>(
         forPartitionKey partitionKey: String,
         sortKeyCondition: AttributeCondition?,
-        completion: @escaping (HTTPResult<[CompositePrimaryKey<AttributesType>]>) -> ()) throws
+        completion: @escaping (SmokeDynamoDBErrorResult<[CompositePrimaryKey<AttributesType>]>) -> ()) throws
 
     /**
      * Queries a partition in the database table and optionally a sort key condition. If the
@@ -55,5 +56,5 @@ public protocol DynamoDBKeysProjection {
         sortKeyCondition: AttributeCondition?,
         limit: Int?,
         exclusiveStartKey: String?,
-        completion: @escaping (HTTPResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ()) throws
+        completion: @escaping (SmokeDynamoDBErrorResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ()) throws
 }

--- a/Sources/SmokeDynamoDB/DynamoDBTable+conditionallyUpdateItem.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBTable+conditionallyUpdateItem.swift
@@ -17,7 +17,8 @@
 
 import Foundation
 import SmokeHTTPClient
-import LoggerAPI
+import Logging
+import DynamoDBModel
 
 public extension DynamoDBTable {
     /**
@@ -76,9 +77,9 @@ public extension DynamoDBTable {
                                                     message: "Unable to complete request to update versioned item in specified number of attempts")
         }
         
-        func handleGetItemResult(result: HTTPResult<TypedDatabaseItem<AttributesType, ItemType>?>) {
+        func handleGetItemResult(result: SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>?>) {
             switch result {
-            case .response(let databaseItemOptional):
+            case .success(let databaseItemOptional):
                 guard let databaseItem = databaseItemOptional else {
                     let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: key.partitionKey,
                                                                         sortKey: key.sortKey,
@@ -114,7 +115,7 @@ public extension DynamoDBTable {
                 } catch {
                     completion(error)
                 }
-            case .error(let error):
+            case .failure(let error):
                 completion(error)
             }
         }

--- a/Sources/SmokeDynamoDB/DynamoDBTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBTable.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import SmokeHTTPClient
+import DynamoDBModel
 
 public protocol DynamoDBTable {
 
@@ -55,7 +56,7 @@ public protocol DynamoDBTable {
     func getItemSync<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>) throws -> TypedDatabaseItem<AttributesType, ItemType>?
 
     func getItemAsync<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>,
-                                                completion: @escaping (HTTPResult<TypedDatabaseItem<AttributesType, ItemType>?>)  -> ()) throws
+                                                completion: @escaping (SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>?>)  -> ()) throws
 
     /**
      * Removes an item from the database table. Is an idempotent operation; running it multiple times
@@ -79,7 +80,7 @@ public protocol DynamoDBTable {
     func queryAsync<AttributesType, PossibleTypes>(
         forPartitionKey partitionKey: String,
         sortKeyCondition: AttributeCondition?,
-        completion: @escaping (HTTPResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ()) throws
+        completion: @escaping (SmokeDynamoDBErrorResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ()) throws
 
     /**
      * Queries a partition in the database table and optionally a sort key condition. If the
@@ -97,5 +98,5 @@ public protocol DynamoDBTable {
         sortKeyCondition: AttributeCondition?,
         limit: Int,
         exclusiveStartKey: String?,
-        completion: @escaping (HTTPResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ()) throws
+        completion: @escaping (SmokeDynamoDBErrorResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ()) throws
 }

--- a/Sources/SmokeDynamoDB/DynamoDBTableHistoricalItemExtensions.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBTableHistoricalItemExtensions.swift
@@ -17,8 +17,9 @@
 //
 
 import Foundation
-import LoggerAPI
+import Logging
 import SmokeHTTPClient
+import DynamoDBModel
 
 public extension DynamoDBTable {
 
@@ -161,9 +162,9 @@ public extension DynamoDBTable {
             }
         }
 
-        func handleGetItemResult(result: HTTPResult<TypedDatabaseItem<AttributesType, ItemType>?>) {
+        func handleGetItemResult(result: SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>?>) {
             switch result {
-            case .response(let existingItemOptional):
+            case .success(let existingItemOptional):
                 do {
                     if let existingItem = existingItemOptional {
                         let newItem: TypedDatabaseItem<AttributesType, ItemType> = primaryItemProvider(existingItem)
@@ -179,7 +180,7 @@ public extension DynamoDBTable {
                 } catch {
                     completion(error)
                 }
-            case .error(let error):
+            case .failure(let error):
                 completion(error)
             }
         }
@@ -250,7 +251,7 @@ public extension DynamoDBTable {
             primaryItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) throws -> TypedDatabaseItem<AttributesType, ItemType>,
             historicalItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) -> TypedDatabaseItem<AttributesType, ItemType>,
             withRetries retries: Int,
-            completion: @escaping (HTTPResult<TypedDatabaseItem<AttributesType, ItemType>>) -> ()) -> (Error?) -> () {
+            completion: @escaping (SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>>) -> ()) -> (Error?) -> () {
         func handleUpdateItemResult(error: Error?) {
             // If there was a failure due to conditionalCheckFailed
             if let theError = error, case SmokeDynamoDBError.conditionalCheckFailed = theError {
@@ -261,15 +262,17 @@ public extension DynamoDBTable {
                                                                              historicalItemProvider: historicalItemProvider,
                                                                              withRetries: retries - 1,
                                                                              completion: completion)
+                } catch let updateError as SmokeDynamoDBError {
+                    completion(.failure(updateError))
                 } catch let updateError {
-                    completion(.error(updateError))
+                    completion(.failure(updateError.asUnrecognizedSmokeDynamoDBError()))
                 }
             // otherwise if there was an error, propagate it to the outer completion handler
             } else if let theError = error {
-                completion(.error(theError))
+                completion(.failure(theError.asUnrecognizedSmokeDynamoDBError()))
             // otherwise there was no error; call the outer completion handler with the item that was committed to the database
             } else {
-                completion(.response(updatedItem))
+                completion(.success(updatedItem))
             }
         }
 
@@ -295,7 +298,7 @@ public extension DynamoDBTable {
         primaryItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) throws -> TypedDatabaseItem<AttributesType, ItemType>,
         historicalItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) -> TypedDatabaseItem<AttributesType, ItemType>,
         withRetries retries: Int = 10,
-        completion: @escaping (HTTPResult<TypedDatabaseItem<AttributesType, ItemType>>) -> ()) throws {
+        completion: @escaping (SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>>) -> ()) throws {
 
         guard retries > 0 else {
             throw SmokeDynamoDBError.concurrencyError(partitionKey: compositePrimaryKey.partitionKey,
@@ -303,15 +306,15 @@ public extension DynamoDBTable {
                                                     message: "Unable to complete request to update versioned item in specified number of attempts")
         }
 
-        func handleGetItemResult(result: HTTPResult<TypedDatabaseItem<AttributesType, ItemType>?>) {
+        func handleGetItemResult(result: SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>?>) {
             switch result {
-            case .response(let existingItemOptional):
+            case .success(let existingItemOptional):
                 guard let existingItem = existingItemOptional else {
                     let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: compositePrimaryKey.partitionKey,
                                                               sortKey: compositePrimaryKey.sortKey,
                                                               message: "Item not present in database.")
 
-                    return completion( .error( error ) )
+                    return completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
                 }
 
                 do {
@@ -331,10 +334,10 @@ public extension DynamoDBTable {
                                                          historicalItem: historicalItem,
                                                          completion: completionHandler)
                 } catch {
-                    completion( .error( error ) )
+                    completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
                 }
-            case .error(let error):
-                completion( .error( error ) )
+            case .failure(let error):
+                completion(.failure(error))
             }
         }
 

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -18,9 +18,10 @@
 
 import Foundation
 import SmokeHTTPClient
+import DynamoDBModel
 
 public protocol PolymorphicDatabaseItemConvertable {
-    var createDate: Date { get }
+    var createDate: Foundation.Date { get }
     var rowStatus: RowStatus { get }
 
     func convertToPolymorphicItem<AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes>() throws
@@ -181,14 +182,14 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
     }
 
     public func getItemAsync<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>,
-                                                       completion: @escaping (HTTPResult<TypedDatabaseItem<AttributesType, ItemType>?>) -> ())
+                                                       completion: @escaping (SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>?>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, ItemType: Decodable, ItemType: Encodable {
             do {
                 let item: TypedDatabaseItem<AttributesType, ItemType>? = try getItemSync(forKey: key)
 
-                completion(.response(item))
+                completion(.success(item))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
 
@@ -270,16 +271,16 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
     public func queryAsync<AttributesType, PossibleTypes>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            completion: @escaping (HTTPResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             do {
                 let items: [PolymorphicDatabaseItem<AttributesType, PossibleTypes>] =
                     try querySync(forPartitionKey: partitionKey,
                                   sortKeyCondition: sortKeyCondition)
 
-                completion(.response(items))
+                completion(.success(items))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
     
@@ -356,7 +357,7 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
             sortKeyCondition: AttributeCondition?,
             limit: Int?,
             exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             do {
                 let result: ([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?) =
@@ -366,9 +367,9 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
                                   scanIndexForward: true,
                                   exclusiveStartKey: exclusiveStartKey)
 
-                completion(.response(result))
+                completion(.success(result))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
     
@@ -378,7 +379,7 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
             limit: Int?,
             scanIndexForward: Bool,
             exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             do {
                 let result: ([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?) =
@@ -388,9 +389,9 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
                                   scanIndexForward: scanIndexForward,
                                   exclusiveStartKey: exclusiveStartKey)
 
-                completion(.response(result))
+                completion(.success(result))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
 }

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import SmokeHTTPClient
+import DynamoDBModel
 
 public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePrimaryKeysProjection {
 
@@ -88,16 +89,16 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
     public func queryAsync<AttributesType>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            completion: @escaping (HTTPResult<[CompositePrimaryKey<AttributesType>]>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<[CompositePrimaryKey<AttributesType>]>) -> ())
         throws where AttributesType: PrimaryKeyAttributes {
             do {
                 let items: [CompositePrimaryKey<AttributesType>] =
                     try querySync(forPartitionKey: partitionKey,
                                   sortKeyCondition: sortKeyCondition)
 
-                completion(.response(items))
+                completion(.success(items))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
     
@@ -163,7 +164,7 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
             sortKeyCondition: AttributeCondition?,
             limit: Int?,
             exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes {
             do {
                 let result: ([CompositePrimaryKey<AttributesType>], String?) =
@@ -173,9 +174,9 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
                                   scanIndexForward: true,
                                   exclusiveStartKey: exclusiveStartKey)
 
-                completion(.response(result))
+                completion(.success(result))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
 
@@ -185,7 +186,7 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
             limit: Int?,
             scanIndexForward: Bool,
             exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes {
             do {
                 let result: ([CompositePrimaryKey<AttributesType>], String?) =
@@ -195,9 +196,9 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
                                   scanIndexForward: scanIndexForward,
                                   exclusiveStartKey: exclusiveStartKey)
 
-                completion(.response(result))
+                completion(.success(result))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
 }

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBKeysProjection.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import SmokeHTTPClient
+import DynamoDBModel
 
 public class InMemoryDynamoDBKeysProjection: DynamoDBKeysProjection {
 
@@ -88,16 +89,16 @@ public class InMemoryDynamoDBKeysProjection: DynamoDBKeysProjection {
     public func queryAsync<AttributesType>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            completion: @escaping (HTTPResult<[CompositePrimaryKey<AttributesType>]>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<[CompositePrimaryKey<AttributesType>]>) -> ())
         throws where AttributesType: PrimaryKeyAttributes {
             do {
                 let items: [CompositePrimaryKey<AttributesType>] =
                     try querySync(forPartitionKey: partitionKey,
                                   sortKeyCondition: sortKeyCondition)
 
-                completion(.response(items))
+                completion(.success(items))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
 
@@ -142,7 +143,7 @@ public class InMemoryDynamoDBKeysProjection: DynamoDBKeysProjection {
             sortKeyCondition: AttributeCondition?,
             limit: Int?,
             exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([CompositePrimaryKey<AttributesType>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes {
             do {
                 let result: ([CompositePrimaryKey<AttributesType>], String?) =
@@ -151,9 +152,9 @@ public class InMemoryDynamoDBKeysProjection: DynamoDBKeysProjection {
                                   limit: limit,
                                   exclusiveStartKey: exclusiveStartKey)
 
-                completion(.response(result))
+                completion(.success(result))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
 }

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBTable.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import SmokeHTTPClient
+import DynamoDBModel
 
 public class InMemoryDynamoDBTable: DynamoDBTable {
 
@@ -157,14 +158,14 @@ public class InMemoryDynamoDBTable: DynamoDBTable {
     }
 
     public func getItemAsync<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>,
-                                                       completion: @escaping (HTTPResult<TypedDatabaseItem<AttributesType, ItemType>?>) -> ())
+                                                       completion: @escaping (SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>?>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, ItemType: Decodable, ItemType: Encodable {
             do {
                 let item: TypedDatabaseItem<AttributesType, ItemType>? = try getItemSync(forKey: key)
 
-                completion(.response(item))
+                completion(.success(item))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
 
@@ -246,16 +247,16 @@ public class InMemoryDynamoDBTable: DynamoDBTable {
     public func queryAsync<AttributesType, PossibleTypes>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            completion: @escaping (HTTPResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             do {
                 let items: [PolymorphicDatabaseItem<AttributesType, PossibleTypes>] =
                     try querySync(forPartitionKey: partitionKey,
                                   sortKeyCondition: sortKeyCondition)
 
-                completion(.response(items))
+                completion(.success(items))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
 
@@ -311,7 +312,7 @@ public class InMemoryDynamoDBTable: DynamoDBTable {
             sortKeyCondition: AttributeCondition?,
             limit: Int,
             exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             do {
                 let result: ([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?) =
@@ -320,9 +321,9 @@ public class InMemoryDynamoDBTable: DynamoDBTable {
                                   limit: limit,
                                   exclusiveStartKey: exclusiveStartKey)
 
-                completion(.response(result))
+                completion(.success(result))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
 }

--- a/Sources/SmokeDynamoDB/InternalSingleValueEncodingContainer.swift
+++ b/Sources/SmokeDynamoDB/InternalSingleValueEncodingContainer.swift
@@ -17,7 +17,7 @@
 
 import Foundation
 import DynamoDBModel
-import LoggerAPI
+import Logging
 
 internal class InternalSingleValueEncodingContainer: SingleValueEncodingContainer {
     internal private(set) var containerValue: ContainerValueType?

--- a/Sources/SmokeDynamoDB/QueryInput+forSortKeyCondition.swift
+++ b/Sources/SmokeDynamoDB/QueryInput+forSortKeyCondition.swift
@@ -74,8 +74,8 @@ extension QueryInput {
 
         let inputExclusiveStartKey: [String: DynamoDBModel.AttributeValue]?
         if let exclusiveStartKey = exclusiveStartKey?.data(using: .utf8) {
-            inputExclusiveStartKey = try AWSDynamoDBCompositePrimaryKeyTable.jsonDecoder.decode([String: DynamoDBModel.AttributeValue].self,
-                                                            from: exclusiveStartKey)
+            inputExclusiveStartKey = try JSONDecoder().decode([String: DynamoDBModel.AttributeValue].self,
+                                                              from: exclusiveStartKey)
         } else {
             inputExclusiveStartKey = nil
         }

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import SmokeHTTPClient
+import DynamoDBModel
 
 /**
  Implementation of the DynamoDBTable protocol that simulates concurrent access
@@ -122,14 +123,14 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
     }
     
     public func getItemAsync<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>,
-                                                       completion: @escaping (HTTPResult<TypedDatabaseItem<AttributesType, ItemType>?>) -> ())
+                                                       completion: @escaping (SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>?>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, ItemType: Decodable, ItemType: Encodable {
             do {
                 let item: TypedDatabaseItem<AttributesType, ItemType>? = try getItemSync(forKey: key)
                 
-                completion(.response(item))
+                completion(.success(item))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
     
@@ -162,16 +163,16 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
     public func queryAsync<AttributesType, PossibleTypes>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            completion: @escaping (HTTPResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             do {
                 let items: [PolymorphicDatabaseItem<AttributesType, PossibleTypes>] =
                     try wrappedDynamoDBTable.querySync(forPartitionKey: partitionKey,
                                                       sortKeyCondition: sortKeyCondition)
                 
-                completion(.response(items))
+                completion(.success(items))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
     
@@ -208,7 +209,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
             sortKeyCondition: AttributeCondition?,
             limit: Int?,
             exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             do {
                 let result: ([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?) =
@@ -217,9 +218,9 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
                                                       limit: limit,
                                                       exclusiveStartKey: exclusiveStartKey)
                 
-                completion(.response(result))
+                completion(.success(result))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
     
@@ -229,7 +230,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
             limit: Int?,
             scanIndexForward: Bool,
             exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             do {
                 let result: ([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?) =
@@ -239,9 +240,9 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
                                                       scanIndexForward: scanIndexForward,
                                                       exclusiveStartKey: exclusiveStartKey)
                 
-                completion(.response(result))
+                completion(.success(result))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
 }

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBTable.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import SmokeHTTPClient
+import DynamoDBModel
 
 /**
  Implementation of the DynamoDBTable protocol that simulates concurrent access
@@ -122,14 +123,14 @@ public class SimulateConcurrencyDynamoDBTable: DynamoDBTable {
     }
     
     public func getItemAsync<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>,
-                                                       completion: @escaping (HTTPResult<TypedDatabaseItem<AttributesType, ItemType>?>) -> ())
+                                                       completion: @escaping (SmokeDynamoDBErrorResult<TypedDatabaseItem<AttributesType, ItemType>?>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, ItemType: Decodable, ItemType: Encodable {
             do {
                 let item: TypedDatabaseItem<AttributesType, ItemType>? = try getItemSync(forKey: key)
                 
-                completion(.response(item))
+                completion(.success(item))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
     
@@ -162,16 +163,16 @@ public class SimulateConcurrencyDynamoDBTable: DynamoDBTable {
     public func queryAsync<AttributesType, PossibleTypes>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            completion: @escaping (HTTPResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<[PolymorphicDatabaseItem<AttributesType, PossibleTypes>]>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             do {
                 let items: [PolymorphicDatabaseItem<AttributesType, PossibleTypes>] =
                     try wrappedDynamoDBTable.querySync(forPartitionKey: partitionKey,
                                                       sortKeyCondition: sortKeyCondition)
                 
-                completion(.response(items))
+                completion(.success(items))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
     
@@ -193,7 +194,7 @@ public class SimulateConcurrencyDynamoDBTable: DynamoDBTable {
             sortKeyCondition: AttributeCondition?,
             limit: Int,
             exclusiveStartKey: String?,
-            completion: @escaping (HTTPResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
+            completion: @escaping (SmokeDynamoDBErrorResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ())
         throws where AttributesType: PrimaryKeyAttributes, PossibleTypes: PossibleItemTypes {
             do {
                 let result: ([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?) =
@@ -202,9 +203,9 @@ public class SimulateConcurrencyDynamoDBTable: DynamoDBTable {
                                                       limit: limit,
                                                       exclusiveStartKey: exclusiveStartKey)
                 
-                completion(.response(result))
+                completion(.success(result))
             } catch {
-                completion(.error(error))
+                completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
             }
     }
 }

--- a/Tests/SmokeDynamoDBTests/DynamoDBTableHistoricalItemExtensionsTests.swift
+++ b/Tests/SmokeDynamoDBTests/DynamoDBTableHistoricalItemExtensionsTests.swift
@@ -19,6 +19,7 @@
 import XCTest
 @testable import SmokeDynamoDB
 import SmokeHTTPClient
+import DynamoDBModel
 
 private typealias DatabaseRowType =
     TypedDatabaseItem<StandardPrimaryKeyAttributes, RowWithItemVersion<TestTypeA>>
@@ -462,13 +463,13 @@ class DynamoDBHistoricalClientTests: XCTestCase {
         try table.insertItemSync(databaseItem)
 
         var isCompleted = false
-        func completionHandler( result: HTTPResult<DatabaseRowType> ) {
+        func completionHandler( result: SmokeDynamoDBErrorResult<DatabaseRowType> ) {
             switch result {
-            case .response( let result ):
+            case .success( let result ):
                 // the result returned is the updated item
                 XCTAssertEqual( result.rowStatus.rowVersion, 2 )
                 XCTAssertEqual( result.rowValue.itemVersion, 2 )
-            case .error:
+            case .failure:
                 XCTFail()
             }
 
@@ -534,13 +535,13 @@ class DynamoDBHistoricalClientTests: XCTestCase {
         try table.insertItemSync(databaseItem)
 
         var isCompleted = false
-        func completionHandler(result: HTTPResult<DatabaseRowType>) {
+        func completionHandler(result: SmokeDynamoDBErrorResult<DatabaseRowType>) {
             switch result {
-            case .response( let result ):
+            case .success( let result ):
                 // the result returned is the updated item
                 XCTAssertEqual( result.rowStatus.rowVersion, 7 )
                 XCTAssertEqual( result.rowValue.itemVersion, 2 )
-            case .error:
+            case .failure:
                 XCTFail()
             }
 
@@ -608,7 +609,7 @@ class DynamoDBHistoricalClientTests: XCTestCase {
             forPrimaryKey: dKey,
             primaryItemProvider: conditionalUpdatePrimaryItemProvider,
             historicalItemProvider: conditionalUpdateHistoricalItemProvider) { result in
-                guard case let .error(theError) = result, case SmokeDynamoDBError.concurrencyError = theError else {
+                guard case let .failure(theError) = result, case SmokeDynamoDBError.concurrencyError = theError else {
                     return XCTFail( "Expected error not thrown" )
                 }
 
@@ -703,7 +704,9 @@ class DynamoDBHistoricalClientTests: XCTestCase {
             forPrimaryKey: dKey,
             primaryItemProvider: primaryItemProvider,
             historicalItemProvider: conditionalUpdateHistoricalItemProvider) { result in
-                guard case let .error(theError) = result, case TestError.everythingIsWrong = theError else {
+                guard case let .failure(theError) = result, case SmokeDynamoDBError.unrecognizedError(let errorType, let errorDescription) = theError,
+                    errorDescription == String(describing: TestError.everythingIsWrong),
+                    errorType == String(describing: type(of: TestError.everythingIsWrong)) else {
                     return XCTFail( "Expected error not thrown" )
                 }
 

--- a/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
@@ -18,6 +18,7 @@
 import XCTest
 @testable import SmokeDynamoDB
 import SmokeHTTPClient
+import DynamoDBModel
 
 struct TestCodableTypes: PossibleItemTypes {
     public static var types: [Codable.Type] = [TestTypeA.self]
@@ -63,8 +64,8 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         XCTAssertNoThrow(try table.insertItemSync(databaseItem))
         
         var retrievedItemOptional: StandardTypedDatabaseItem<TestTypeA>?
-        try table.getItemAsync(forKey: key) { (result: HTTPResult<StandardTypedDatabaseItem<TestTypeA>?>) in
-            if case .response(let output) = result {
+        try table.getItemAsync(forKey: key) { (result: SmokeDynamoDBErrorResult<StandardTypedDatabaseItem<TestTypeA>?>) in
+            if case .success(let output) = result {
                 retrievedItemOptional = output
             }
         }
@@ -325,12 +326,12 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         
         // get everything back from the database
         repeat {
-            func handleQueryOutput(result: HTTPResult<([StandardPolymorphicDatabaseItem<TestCodableTypes>], String?)>) {
+            func handleQueryOutput(result: SmokeDynamoDBErrorResult<([StandardPolymorphicDatabaseItem<TestCodableTypes>], String?)>) {
                 switch result {
-                case .response(let paginatedItems):
+                case .success(let paginatedItems):
                     retrievedItems += paginatedItems.0
                     exclusiveStartKey = paginatedItems.1
-                case .error(_):
+                case .failure(_):
                     XCTFail()
                 }
             }
@@ -378,12 +379,12 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         
         // get everything back from the database
         repeat {
-            func handleQueryOutput(result: HTTPResult<([StandardPolymorphicDatabaseItem<TestCodableTypes>], String?)>) {
+            func handleQueryOutput(result: SmokeDynamoDBErrorResult<([StandardPolymorphicDatabaseItem<TestCodableTypes>], String?)>) {
                 switch result {
-                case .response(let paginatedItems):
+                case .success(let paginatedItems):
                     retrievedItems += paginatedItems.0
                     exclusiveStartKey = paginatedItems.1
-                case .error(_):
+                case .failure(_):
                     XCTFail()
                 }
             }
@@ -459,11 +460,11 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         }
         
         var retrievedItems: [StandardPolymorphicDatabaseItem<TestCodableTypes>] = []
-        func handleQueryResult(result: HTTPResult<[StandardPolymorphicDatabaseItem<TestCodableTypes>]>) {
+        func handleQueryResult(result: SmokeDynamoDBErrorResult<[StandardPolymorphicDatabaseItem<TestCodableTypes>]>) {
             switch result {
-            case .response(let queryItems):
+            case .success(let queryItems):
                 retrievedItems.append(contentsOf: queryItems)
-            case .error:
+            case .failure:
                 XCTFail()
             }
         }

--- a/Tests/SmokeDynamoDBTests/InMemoryDynamoDBTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/InMemoryDynamoDBTableTests.swift
@@ -18,6 +18,7 @@
 import XCTest
 @testable import SmokeDynamoDB
 import SmokeHTTPClient
+import DynamoDBModel
 
 class InMemoryDynamoDBTableTests: XCTestCase {
     
@@ -59,8 +60,8 @@ class InMemoryDynamoDBTableTests: XCTestCase {
         XCTAssertNoThrow(try table.insertItemSync(databaseItem))
         
         var retrievedItemOptional: StandardTypedDatabaseItem<TestTypeA>?
-        try table.getItemAsync(forKey: key) { (result: HTTPResult<StandardTypedDatabaseItem<TestTypeA>?>) in
-            if case .response(let output) = result {
+        try table.getItemAsync(forKey: key) { (result: SmokeDynamoDBErrorResult<StandardTypedDatabaseItem<TestTypeA>?>) in
+            if case .success(let output) = result {
                 retrievedItemOptional = output
             }
         }
@@ -263,12 +264,12 @@ class InMemoryDynamoDBTableTests: XCTestCase {
         
         // get everything back from the database
         repeat {
-            func handleQueryOutput(result: HTTPResult<([StandardPolymorphicDatabaseItem<TestCodableTypes>], String?)>) {
+            func handleQueryOutput(result: SmokeDynamoDBErrorResult<([StandardPolymorphicDatabaseItem<TestCodableTypes>], String?)>) {
                 switch result {
-                case .response(let paginatedItems):
+                case .success(let paginatedItems):
                     retrievedItems += paginatedItems.0
                     exclusiveStartKey = paginatedItems.1
-                case .error(_):
+                case .failure(_):
                     XCTFail()
                 }
             }
@@ -340,11 +341,11 @@ class InMemoryDynamoDBTableTests: XCTestCase {
         }
         
         var retrievedItems: [StandardPolymorphicDatabaseItem<TestCodableTypes>] = []
-        func handleQueryResult(result: HTTPResult<[StandardPolymorphicDatabaseItem<TestCodableTypes>]>) {
+        func handleQueryResult(result: SmokeDynamoDBErrorResult<[StandardPolymorphicDatabaseItem<TestCodableTypes>]>) {
             switch result {
-            case .response(let queryItems):
+            case .success(let queryItems):
                 retrievedItems.append(contentsOf: queryItems)
-            case .error:
+            case .failure:
                 XCTFail()
             }
         }

--- a/Tests/SmokeDynamoDBTests/SimulateConcurrencyDynamoDBTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/SimulateConcurrencyDynamoDBTableTests.swift
@@ -18,6 +18,7 @@
 import XCTest
 @testable import SmokeDynamoDB
 import SmokeHTTPClient
+import DynamoDBModel
 
 private typealias DatabaseRowType = StandardTypedDatabaseItem<TestTypeA>
 private typealias QueryRowType = StandardPolymorphicDatabaseItem<ExpectedTypes>
@@ -105,16 +106,16 @@ class SimulateConcurrencyDynamoDBTableTests: XCTestCase {
         
         var getItemCompletionCount = 0
         for _ in 0..<10 {
-            try table.getItemAsync(forKey: key) { (result: HTTPResult<DatabaseRowType?>) in
+            try table.getItemAsync(forKey: key) { (result: SmokeDynamoDBErrorResult<DatabaseRowType?>) in
                 switch result {
-                case .response(let itemOptional):
+                case .success(let itemOptional):
                     guard let item = itemOptional else {
                         return XCTFail("Expected to retrieve item and there was none")
                     }
                     
                     try! table.updateItemAsync(newItem: item.createUpdatedItem(withValue: item.rowValue),
                                                 existingItem: item, completion: updateItemCompletion)
-                case .error(_):
+                case .failure(_):
                     XCTFail()
                 }
                 
@@ -268,9 +269,9 @@ class SimulateConcurrencyDynamoDBTableTests: XCTestCase {
         
         var queryCompletionCount = 0
         for _ in 0..<10 {
-            func handleQueryResult(result: HTTPResult<[QueryRowType]>) {
+            func handleQueryResult(result: SmokeDynamoDBErrorResult<[QueryRowType]>) {
                 switch result {
-                case .response(let query):
+                case .success(let query):
                     guard query.count == 1, let firstValue = query[0].rowValue as? TestTypeA else {
                         return XCTFail("Expected to retrieve item and there wasn't the correct number or type.")
                     }
@@ -294,7 +295,7 @@ class SimulateConcurrencyDynamoDBTableTests: XCTestCase {
                     } catch {
                         errorCount += 1
                     }
-                case .error:
+                case .failure:
                     XCTFail()
                 }
                 
@@ -369,9 +370,9 @@ class SimulateConcurrencyDynamoDBTableTests: XCTestCase {
         var updateCompletionCount = 0
         var clobberCompletionCount = 0
         for _ in 0..<10 {
-            func handleGetItemResult(result: HTTPResult<DatabaseRowType?>) {
+            func handleGetItemResult(result: SmokeDynamoDBErrorResult<DatabaseRowType?>) {
                 switch result {
-                case .response(let itemOptional):
+                case .success(let itemOptional):
                     guard let item = itemOptional else {
                         return XCTFail("Expected to retrieve item and there was none")
                     }
@@ -381,7 +382,7 @@ class SimulateConcurrencyDynamoDBTableTests: XCTestCase {
                     try! wrappedTable.updateItemAsync(newItem: item.createUpdatedItem(withValue: item.rowValue),
                                                        existingItem: item) { _ in updateCompletionCount += 1 }
                     XCTAssertNoThrow(try table.clobberItemAsync(item) { _ in clobberCompletionCount += 1 })
-                case .error(_):
+                case .failure(_):
                     XCTFail()
                 }
                 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Update to SmokeHTTP 2 and SmokeAWS 2.

1. Use Swift.Result
2. Pass through the invocation reporting instance to tables and projections.
 3. Add generators to create tables and projections with a specific invocation reporting instance.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
