### PR TITLE
Remove Swift 4.1 and 4.2 compatibility badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@
 </a>
 <img src="https://img.shields.io/badge/os-linux-green.svg?style=flat" alt="Linux">
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-4.1-orange.svg?style=flat" alt="Swift 4.1 Compatible">
-</a>
-<a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-4.2-orange.svg?style=flat" alt="Swift 4.1 Compatible">
-</a>
-<a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-5.0-orange.svg?style=flat" alt="Swift 5.0 Compatible">
 </a>
 <a href="http://swift.org">


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Remove Swift 4.1 and 4.2 compatibility badges.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
