### PR TITLE
Use async-http-client as the underlying http client

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "async-http-client",
+        "repositoryURL": "https://github.com/swift-server/async-http-client.git",
+        "state": {
+          "branch": null,
+          "revision": "e2636a4c24e646d3e480fc666da0c090818beb09",
+          "version": "1.1.0"
+        }
+      },
+      {
         "package": "Cryptor",
         "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
         "state": {
@@ -14,18 +23,18 @@
         "package": "SmokeAWS",
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
-          "branch": null,
-          "revision": "46d969a9b27fe8ee48035fe615282654125355cf",
-          "version": "2.0.0-alpha.4"
+          "branch": "async-http-client",
+          "revision": "ca9c34df5f3ecd35f228e1a8a5b6419043a9cfe2",
+          "version": null
         }
       },
       {
         "package": "SmokeHTTP",
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
-          "branch": null,
-          "revision": "da6596f8602cc293a1d026f0c0dac3bd39e78ab0",
-          "version": "2.0.0-alpha.6"
+          "branch": "async-http-client",
+          "revision": "ae6944abc219a199a9739a43b8c03862755574c7",
+          "version": null
         }
       },
       {
@@ -53,6 +62,15 @@
           "branch": null,
           "revision": "16ab4d657e1ad4e77bd5f8b94af8538561643053",
           "version": "2.14.0"
+        }
+      },
+      {
+        "package": "swift-nio-extras",
+        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "b4dbfacff47fb8d0f9e0a422d8d37935a9f10570",
+          "version": "1.4.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,18 +23,18 @@
         "package": "SmokeAWS",
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
-          "branch": "async-http-client",
-          "revision": "ca9c34df5f3ecd35f228e1a8a5b6419043a9cfe2",
-          "version": null
+          "branch": null,
+          "revision": "bbc082c45f69fb44d190e9b377520737cd16f1f8",
+          "version": "2.0.0-alpha.5"
         }
       },
       {
         "package": "SmokeHTTP",
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
-          "branch": "async-http-client",
-          "revision": "ae6944abc219a199a9739a43b8c03862755574c7",
-          "version": null
+          "branch": null,
+          "revision": "ae8003b3605c0b368925558254055222237b1da4",
+          "version": "2.0.0-alpha.7"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "09b72f68ed9b01b614c12855fc7e22876b97a97e",
-          "version": "1.2.1"
+          "revision": "708b960b4605abb20bc55d65abf6bad607252200",
+          "version": "2.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,8 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.4"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", .branch("async-http-client")),
+        .package(url: "https://github.com/amzn/smoke-http.git", .branch("async-http-client")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,8 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", .branch("async-http-client")),
-        .package(url: "https://github.com/amzn/smoke-http.git", .branch("async-http-client")),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.5"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.7"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
     ],

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -21,6 +21,7 @@ import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
+import AsyncHTTPClient
 
 public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPClientCoreInvocationReporting>: DynamoDBCompositePrimaryKeyTable {
     internal let dynamodb: AWSDynamoDBClient<InvocationReportingType>
@@ -37,7 +38,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     public init(accessKeyId: String, secretAccessKey: String,
                 region: AWSRegion, reporting: InvocationReportingType,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -55,7 +56,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     public init(credentialsProvider: CredentialsProvider,
                 region: AWSRegion, reporting: InvocationReportingType,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         self.logger = reporting.logger
         self.dynamodb = AWSDynamoDBClient(credentialsProvider: credentialsProvider,
                                           awsRegion: region, reporting: reporting,
@@ -78,16 +79,8 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
      Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times.
      */
-    public func close() {
-        dynamodb.close()
-    }
-
-    /**
-     Waits for the client behind this table to be closed. If close() is not called,
-     this will block forever.
-     */
-    public func wait() {
-        dynamodb.wait()
+    public func close() throws {
+        try dynamodb.close()
     }
 
     internal func getInputForInsert<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) throws

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
@@ -21,6 +21,7 @@ import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
+import AsyncHTTPClient
 
 public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
     internal let dynamodbGenerator: AWSDynamoDBClientGenerator
@@ -29,7 +30,7 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
     public init(accessKeyId: String, secretAccessKey: String,
                 region: AWSRegion,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -44,7 +45,7 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
     public init(credentialsProvider: CredentialsProvider,
                 region: AWSRegion,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         self.dynamodbGenerator = AWSDynamoDBClientGenerator(credentialsProvider: credentialsProvider,
                                                             awsRegion: region,
                                                             endpointHostName: endpointHostName,
@@ -56,16 +57,8 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
      Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times.
      */
-    public func close() {
-        dynamodbGenerator.close()
-    }
-
-    /**
-     Waits for the client behind this table to be closed. If close() is not called,
-     this will block forever.
-     */
-    public func wait() {
-        dynamodbGenerator.wait()
+    public func close() throws {
+        try dynamodbGenerator.close()
     }
     
     public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
@@ -21,6 +21,7 @@ import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
+import AsyncHTTPClient
 
 public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: HTTPClientCoreInvocationReporting>: DynamoDBCompositePrimaryKeysProjection {
     internal let dynamodb: AWSDynamoDBClient<InvocationReportingType>
@@ -35,7 +36,7 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
     public init(accessKeyId: String, secretAccessKey: String,
                 region: AWSRegion, reporting: InvocationReportingType,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -53,7 +54,7 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
     public init(credentialsProvider: CredentialsProvider,
                 region: AWSRegion, reporting: InvocationReportingType,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         self.logger = reporting.logger
         self.dynamodb = AWSDynamoDBClient(credentialsProvider: credentialsProvider,
                                           awsRegion: region, reporting: reporting,
@@ -76,15 +77,7 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
      Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times.
      */
-    public func close() {
-        dynamodb.close()
-    }
-
-    /**
-     Waits for the client behind this table to be closed. If close() is not called,
-     this will block forever.
-     */
-    public func wait() {
-        dynamodb.wait()
+    public func close() throws {
+        try dynamodb.close()
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjectionGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjectionGenerator.swift
@@ -21,6 +21,7 @@ import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
+import AsyncHTTPClient
 
 public class AWSDynamoDBCompositePrimaryKeysProjectionGenerator {
     internal let dynamodbGenerator: AWSDynamoDBClientGenerator
@@ -29,7 +30,7 @@ public class AWSDynamoDBCompositePrimaryKeysProjectionGenerator {
     public init(accessKeyId: String, secretAccessKey: String,
                 region: AWSRegion,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -44,7 +45,7 @@ public class AWSDynamoDBCompositePrimaryKeysProjectionGenerator {
     public init(credentialsProvider: CredentialsProvider,
                 region: AWSRegion,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         self.dynamodbGenerator = AWSDynamoDBClientGenerator(credentialsProvider: credentialsProvider,
                                                             awsRegion: region,
                                                             endpointHostName: endpointHostName,
@@ -56,16 +57,8 @@ public class AWSDynamoDBCompositePrimaryKeysProjectionGenerator {
      Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times.
      */
-    public func close() {
-        dynamodbGenerator.close()
-    }
-
-    /**
-     Waits for the client behind this table to be closed. If close() is not called,
-     this will block forever.
-     */
-    public func wait() {
-        dynamodbGenerator.wait()
+    public func close() throws {
+        try dynamodbGenerator.close()
     }
     
     public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(

--- a/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjection.swift
@@ -21,6 +21,7 @@ import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
+import AsyncHTTPClient
 
 public class AWSDynamoDBKeysProjection<InvocationReportingType: HTTPClientCoreInvocationReporting>: DynamoDBKeysProjection {
     internal let dynamodb: AWSDynamoDBClient<InvocationReportingType>
@@ -35,7 +36,7 @@ public class AWSDynamoDBKeysProjection<InvocationReportingType: HTTPClientCoreIn
     public init(accessKeyId: String, secretAccessKey: String,
                 region: AWSRegion, reporting: InvocationReportingType,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -53,7 +54,7 @@ public class AWSDynamoDBKeysProjection<InvocationReportingType: HTTPClientCoreIn
     public init(credentialsProvider: CredentialsProvider,
                 region: AWSRegion, reporting: InvocationReportingType,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         self.logger = reporting.logger
         self.dynamodb = AWSDynamoDBClient(credentialsProvider: credentialsProvider,
                                           awsRegion: region, reporting: reporting,
@@ -76,15 +77,7 @@ public class AWSDynamoDBKeysProjection<InvocationReportingType: HTTPClientCoreIn
      Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times.
      */
-    public func close() {
-        dynamodb.close()
-    }
-
-    /**
-     Waits for the client behind this table to be closed. If close() is not called,
-     this will block forever.
-     */
-    public func wait() {
-        dynamodb.wait()
+    public func close() throws {
+        try dynamodb.close()
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjectionGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjectionGenerator.swift
@@ -21,6 +21,7 @@ import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
+import AsyncHTTPClient
 
 public class AWSDynamoDBKeysProjectionGenerator {
     internal let dynamodbGenerator: AWSDynamoDBClientGenerator
@@ -29,7 +30,7 @@ public class AWSDynamoDBKeysProjectionGenerator {
     public init(accessKeyId: String, secretAccessKey: String,
                 region: AWSRegion,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -44,7 +45,7 @@ public class AWSDynamoDBKeysProjectionGenerator {
     public init(credentialsProvider: CredentialsProvider,
                 region: AWSRegion,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         self.dynamodbGenerator = AWSDynamoDBClientGenerator(credentialsProvider: credentialsProvider,
                                                             awsRegion: region,
                                                             endpointHostName: endpointHostName,
@@ -56,16 +57,8 @@ public class AWSDynamoDBKeysProjectionGenerator {
      Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times.
      */
-    public func close() {
-        dynamodbGenerator.close()
-    }
-
-    /**
-     Waits for the client behind this table to be closed. If close() is not called,
-     this will block forever.
-     */
-    public func wait() {
-        dynamodbGenerator.wait()
+    public func close() throws {
+        try dynamodbGenerator.close()
     }
     
     public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTable.swift
@@ -21,6 +21,7 @@ import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
+import AsyncHTTPClient
 
 public class AWSDynamoDBTable<InvocationReportingType: HTTPClientCoreInvocationReporting>: DynamoDBTable {
     internal let dynamodb: AWSDynamoDBClient<InvocationReportingType>
@@ -37,7 +38,7 @@ public class AWSDynamoDBTable<InvocationReportingType: HTTPClientCoreInvocationR
     public init(accessKeyId: String, secretAccessKey: String,
                 region: AWSRegion, reporting: InvocationReportingType,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -55,7 +56,7 @@ public class AWSDynamoDBTable<InvocationReportingType: HTTPClientCoreInvocationR
     public init(credentialsProvider: CredentialsProvider,
                 region: AWSRegion, reporting: InvocationReportingType,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         self.logger = reporting.logger
         self.dynamodb = AWSDynamoDBClient(credentialsProvider: credentialsProvider,
                                           awsRegion: region, reporting: reporting,
@@ -78,16 +79,8 @@ public class AWSDynamoDBTable<InvocationReportingType: HTTPClientCoreInvocationR
      Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times.
      */
-    public func close() {
-        dynamodb.close()
-    }
-
-    /**
-     Waits for the client behind this table to be closed. If close() is not called,
-     this will block forever.
-     */
-    public func wait() {
-        dynamodb.wait()
+    public func close() throws {
+        try dynamodb.close()
     }
 
     internal func getInputForInsert<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) throws

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTableGenerator.swift
@@ -21,6 +21,7 @@ import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
+import AsyncHTTPClient
 
 public class AWSDynamoDBTableGenerator {
     internal let dynamodbGenerator: AWSDynamoDBClientGenerator
@@ -29,7 +30,7 @@ public class AWSDynamoDBTableGenerator {
     public init(accessKeyId: String, secretAccessKey: String,
                 region: AWSRegion,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -44,7 +45,7 @@ public class AWSDynamoDBTableGenerator {
     public init(credentialsProvider: CredentialsProvider,
                 region: AWSRegion,
                 endpointHostName: String, tableName: String,
-                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
         self.dynamodbGenerator = AWSDynamoDBClientGenerator(credentialsProvider: credentialsProvider,
                                                             awsRegion: region,
                                                             endpointHostName: endpointHostName,
@@ -56,16 +57,8 @@ public class AWSDynamoDBTableGenerator {
      Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times.
      */
-    public func close() {
-        dynamodbGenerator.close()
-    }
-
-    /**
-     Waits for the client behind this table to be closed. If close() is not called,
-     this will block forever.
-     */
-    public func wait() {
-        dynamodbGenerator.wait()
+    public func close() throws {
+        try dynamodbGenerator.close()
     }
     
     public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Use async-http-client as the underlying http client


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
