### PR TITLE
Use swift crypto when compiling with Swift 5.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "smoke-aws",
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
-          "branch": "use_swift_crypto_under_5_2",
-          "revision": "0bce612318d812651f0ec332458fe66917fe7dab",
-          "version": null
+          "branch": null,
+          "revision": "747aa0495274a51597c55c158520cfca6788a601",
+          "version": "2.0.0-alpha.6"
         }
       },
       {
@@ -35,6 +35,15 @@
           "branch": null,
           "revision": "d67ac68d09a95443303e9d6e37b34e7ba101d5f1",
           "version": "1.0.1"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
+          "version": "1.2.0"
         }
       },
       {
@@ -71,15 +80,6 @@
           "branch": null,
           "revision": "ae213938e151964aa691f0e902462fbe06baeeb6",
           "version": "2.7.1"
-        }
-      },
-      {
-        "package": "XMLCoding",
-        "repositoryURL": "https://github.com/LiveUI/XMLCoding.git",
-        "state": {
-          "branch": null,
-          "revision": "f0fbfe17e73f329e13a6133ff5437f7b174049fd",
-          "version": "0.4.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "747aa0495274a51597c55c158520cfca6788a601",
-          "version": "2.0.0-alpha.6"
+          "revision": "160eb9f262bedaef44713eabb9d6c24cbc334d84",
+          "version": "2.0.0-beta.1"
         }
       },
       {
@@ -25,7 +25,7 @@
         "state": {
           "branch": null,
           "revision": "a3fd185135fe2fc40ef609983071d44dafce36f1",
-          "version": "2.0.0-alpha.9"
+          "version": "2.0.0-beta.1"
         }
       },
       {
@@ -80,6 +80,15 @@
           "branch": null,
           "revision": "ae213938e151964aa691f0e902462fbe06baeeb6",
           "version": "2.7.1"
+        }
+      },
+      {
+        "package": "XMLCoding",
+        "repositoryURL": "https://github.com/LiveUI/XMLCoding.git",
+        "state": {
+          "branch": null,
+          "revision": "f0fbfe17e73f329e13a6133ff5437f7b174049fd",
+          "version": "0.4.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,16 +6,16 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "e2636a4c24e646d3e480fc666da0c090818beb09",
-          "version": "1.1.0"
+          "revision": "037b70291941fe43de668066eb6fb802c5e181d2",
+          "version": "1.1.1"
         }
       },
       {
-        "package": "SmokeAWS",
+        "package": "smoke-aws",
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": "use_swift_crypto_under_5_2",
-          "revision": "4d8b63cccc78bad8ad3ed270fca7632989b39ba7",
+          "revision": "6d82ff38cb9d54679340ded9aa55af47d9e784a9",
           "version": null
         }
       },
@@ -38,6 +38,15 @@
         }
       },
       {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
+          "version": "1.2.0"
+        }
+      },
+      {
         "package": "swift-metrics",
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
@@ -51,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "16ab4d657e1ad4e77bd5f8b94af8538561643053",
-          "version": "2.14.0"
+          "revision": "e876fb37410e0036b98b5361bb18e6854739572b",
+          "version": "2.16.0"
         }
       },
       {
@@ -69,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "af46d9b58fafbb76f9b01177568d435a1b024f99",
-          "version": "2.6.2"
+          "revision": "ae213938e151964aa691f0e902462fbe06baeeb6",
+          "version": "2.7.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,17 +15,17 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": "use_swift_crypto_under_5_2",
-          "revision": "6d82ff38cb9d54679340ded9aa55af47d9e784a9",
+          "revision": "0bce612318d812651f0ec332458fe66917fe7dab",
           "version": null
         }
       },
       {
-        "package": "SmokeHTTP",
+        "package": "smoke-http",
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "e61b72adebfb054204dc3c3c122a27072cb04d05",
-          "version": "2.0.0-alpha.8"
+          "revision": "a3fd185135fe2fc40ef609983071d44dafce36f1",
+          "version": "2.0.0-alpha.9"
         }
       },
       {
@@ -35,15 +35,6 @@
           "branch": null,
           "revision": "d67ac68d09a95443303e9d6e37b34e7ba101d5f1",
           "version": "1.0.1"
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
-          "version": "1.2.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,21 +11,12 @@
         }
       },
       {
-        "package": "Cryptor",
-        "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
-        "state": {
-          "branch": null,
-          "revision": "12d2bf3ec7207ec3cd004b9582f69ef5fae1da3b",
-          "version": "1.0.32"
-        }
-      },
-      {
         "package": "SmokeAWS",
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
-          "branch": null,
-          "revision": "bbc082c45f69fb44d190e9b377520737cd16f1f8",
-          "version": "2.0.0-alpha.5"
+          "branch": "use_swift_crypto_under_5_2",
+          "revision": "4d8b63cccc78bad8ad3ed270fca7632989b39ba7",
+          "version": null
         }
       },
       {
@@ -33,17 +24,17 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "ae8003b3605c0b368925558254055222237b1da4",
-          "version": "2.0.0-alpha.7"
+          "revision": "e61b72adebfb054204dc3c3c122a27072cb04d05",
+          "version": "2.0.0-alpha.8"
         }
       },
       {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
-          "version": "1.2.0"
+          "revision": "d67ac68d09a95443303e9d6e37b34e7ba101d5f1",
+          "version": "1.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,8 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.6"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.9"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-beta.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", .branch("use_swift_crypto_under_5_2")),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.6"),
         .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.9"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amzn/smoke-aws.git", .branch("use_swift_crypto_under_5_2")),
-        .package(name: "SmokeHTTP", url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.8"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.9"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
     ],
@@ -37,12 +37,12 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Metrics", package: "swift-metrics"),
                 .product(name: "DynamoDBClient", package: "smoke-aws"),
-                .product(name: "SmokeHTTPClient", package: "SmokeHTTP"),
+                .product(name: "SmokeHTTPClient", package: "smoke-http"),
             ]),
         .testTarget(
             name: "SmokeDynamoDBTests", dependencies: [
                 .target(name: "SmokeDynamoDB"),
-                .product(name: "SmokeHTTPClient", package: "SmokeHTTP"),
+                .product(name: "SmokeHTTPClient", package: "smoke-http"),
             ]),
     ],
     swiftLanguageVersions: [.v5]

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "SmokeDynamoDB",
+    name: "smoke-dynamodb",
     platforms: [
         .macOS(.v10_15), .iOS(.v10)
         ],
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(name: "SmokeAWS", url: "https://github.com/amzn/smoke-aws.git", .branch("use_swift_crypto_under_5_2")),
+        .package(url: "https://github.com/amzn/smoke-aws.git", .branch("use_swift_crypto_under_5_2")),
         .package(name: "SmokeHTTP", url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.8"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
@@ -36,7 +36,7 @@ let package = Package(
             name: "SmokeDynamoDB", dependencies: [
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Metrics", package: "swift-metrics"),
-                .product(name: "DynamoDBClient", package: "SmokeAWS"),
+                .product(name: "DynamoDBClient", package: "smoke-aws"),
                 .product(name: "SmokeHTTPClient", package: "SmokeHTTP"),
             ]),
         .testTarget(

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -26,8 +26,8 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.5"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.7"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-beta.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
     ],

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.0
 //
 // Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "SmokeDynamoDB",
     platforms: [
-        .macOS(.v10_15), .iOS(.v10)
+        .macOS(.v10_12), .iOS(.v10)
         ],
     products: [
         .library(
@@ -26,24 +26,18 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(name: "SmokeAWS", url: "https://github.com/amzn/smoke-aws.git", .branch("use_swift_crypto_under_5_2")),
-        .package(name: "SmokeHTTP", url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.8"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.5"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.7"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
     ],
     targets: [
         .target(
-            name: "SmokeDynamoDB", dependencies: [
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "Metrics", package: "swift-metrics"),
-                .product(name: "DynamoDBClient", package: "SmokeAWS"),
-                .product(name: "SmokeHTTPClient", package: "SmokeHTTP"),
-            ]),
+            name: "SmokeDynamoDB",
+            dependencies: ["Metrics", "Logging", "DynamoDBClient", "SmokeHTTPClient"]),
         .testTarget(
-            name: "SmokeDynamoDBTests", dependencies: [
-                .target(name: "SmokeDynamoDB"),
-                .product(name: "SmokeHTTPClient", package: "SmokeHTTP"),
-            ]),
+            name: "SmokeDynamoDBTests",
+            dependencies: ["SmokeDynamoDB", "SmokeHTTPClient"]),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -26,8 +26,8 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.5"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.7"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-beta.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
     ],

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.0
 //
 // Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "SmokeDynamoDB",
     platforms: [
-        .macOS(.v10_15), .iOS(.v10)
+        .macOS(.v10_12), .iOS(.v10)
         ],
     products: [
         .library(
@@ -26,24 +26,18 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(name: "SmokeAWS", url: "https://github.com/amzn/smoke-aws.git", .branch("use_swift_crypto_under_5_2")),
-        .package(name: "SmokeHTTP", url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.8"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.5"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha.7"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
     ],
     targets: [
         .target(
-            name: "SmokeDynamoDB", dependencies: [
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "Metrics", package: "swift-metrics"),
-                .product(name: "DynamoDBClient", package: "SmokeAWS"),
-                .product(name: "SmokeHTTPClient", package: "SmokeHTTP"),
-            ]),
+            name: "SmokeDynamoDB",
+            dependencies: ["Metrics", "Logging", "DynamoDBClient", "SmokeHTTPClient"]),
         .testTarget(
-            name: "SmokeDynamoDBTests", dependencies: [
-                .target(name: "SmokeDynamoDB"),
-                .product(name: "SmokeHTTPClient", package: "SmokeHTTP"),
-            ]),
+            name: "SmokeDynamoDBTests",
+            dependencies: ["SmokeDynamoDB", "SmokeHTTPClient"]),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
@@ -20,6 +20,7 @@ import Logging
 import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
+import SmokeAWSHttp
 import SmokeHTTPClient
 import AsyncHTTPClient
 
@@ -67,5 +68,28 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
             dynamodb: self.dynamodbGenerator.with(reporting: reporting),
             targetTableName: self.targetTableName,
             logger: reporting.logger)
+    }
+    
+    public func with<NewTraceContextType: InvocationTraceContext>(
+            logger: Logging.Logger,
+            internalRequestId: String = "none",
+            traceContext: NewTraceContextType) -> AWSDynamoDBCompositePrimaryKeyTable<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
+        let reporting = StandardHTTPClientCoreInvocationReporting(
+            logger: logger,
+            internalRequestId: internalRequestId,
+            traceContext: traceContext)
+
+        return with(reporting: reporting)
+    }
+
+    public func with(
+            logger: Logging.Logger,
+            internalRequestId: String = "none") -> AWSDynamoDBCompositePrimaryKeyTable<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>> {
+        let reporting = StandardHTTPClientCoreInvocationReporting(
+            logger: logger,
+            internalRequestId: internalRequestId,
+            traceContext: AWSClientInvocationTraceContext())
+
+        return with(reporting: reporting)
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjectionGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjectionGenerator.swift
@@ -20,6 +20,7 @@ import Logging
 import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
+import SmokeAWSHttp
 import SmokeHTTPClient
 import AsyncHTTPClient
 
@@ -67,5 +68,28 @@ public class AWSDynamoDBCompositePrimaryKeysProjectionGenerator {
             dynamodb: self.dynamodbGenerator.with(reporting: reporting),
             targetTableName: self.targetTableName,
             logger: reporting.logger)
+    }
+    
+    public func with<NewTraceContextType: InvocationTraceContext>(
+            logger: Logging.Logger,
+            internalRequestId: String = "none",
+            traceContext: NewTraceContextType) -> AWSDynamoDBCompositePrimaryKeysProjection<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
+        let reporting = StandardHTTPClientCoreInvocationReporting(
+            logger: logger,
+            internalRequestId: internalRequestId,
+            traceContext: traceContext)
+
+        return with(reporting: reporting)
+    }
+
+    public func with(
+            logger: Logging.Logger,
+            internalRequestId: String = "none") -> AWSDynamoDBCompositePrimaryKeysProjection<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>> {
+        let reporting = StandardHTTPClientCoreInvocationReporting(
+            logger: logger,
+            internalRequestId: internalRequestId,
+            traceContext: AWSClientInvocationTraceContext())
+
+        return with(reporting: reporting)
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjectionGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjectionGenerator.swift
@@ -20,6 +20,7 @@ import Logging
 import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
+import SmokeAWSHttp
 import SmokeHTTPClient
 import AsyncHTTPClient
 
@@ -67,5 +68,28 @@ public class AWSDynamoDBKeysProjectionGenerator {
             dynamodb: self.dynamodbGenerator.with(reporting: reporting),
             targetTableName: self.targetTableName,
             logger: reporting.logger)
+    }
+    
+    public func with<NewTraceContextType: InvocationTraceContext>(
+            logger: Logging.Logger,
+            internalRequestId: String = "none",
+            traceContext: NewTraceContextType) -> AWSDynamoDBKeysProjection<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
+        let reporting = StandardHTTPClientCoreInvocationReporting(
+            logger: logger,
+            internalRequestId: internalRequestId,
+            traceContext: traceContext)
+
+        return with(reporting: reporting)
+    }
+
+    public func with(
+            logger: Logging.Logger,
+            internalRequestId: String = "none") -> AWSDynamoDBKeysProjection<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>> {
+        let reporting = StandardHTTPClientCoreInvocationReporting(
+            logger: logger,
+            internalRequestId: internalRequestId,
+            traceContext: AWSClientInvocationTraceContext())
+
+        return with(reporting: reporting)
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTableGenerator.swift
@@ -20,6 +20,7 @@ import Logging
 import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
+import SmokeAWSHttp
 import SmokeHTTPClient
 import AsyncHTTPClient
 
@@ -67,5 +68,28 @@ public class AWSDynamoDBTableGenerator {
             dynamodb: self.dynamodbGenerator.with(reporting: reporting),
             targetTableName: self.targetTableName,
             logger: reporting.logger)
+    }
+    
+    public func with<NewTraceContextType: InvocationTraceContext>(
+            logger: Logging.Logger,
+            internalRequestId: String = "none",
+            traceContext: NewTraceContextType) -> AWSDynamoDBTable<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
+        let reporting = StandardHTTPClientCoreInvocationReporting(
+            logger: logger,
+            internalRequestId: internalRequestId,
+            traceContext: traceContext)
+
+        return with(reporting: reporting)
+    }
+
+    public func with(
+            logger: Logging.Logger,
+            internalRequestId: String = "none") -> AWSDynamoDBTable<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>> {
+        let reporting = StandardHTTPClientCoreInvocationReporting(
+            logger: logger,
+            internalRequestId: internalRequestId,
+            traceContext: AWSClientInvocationTraceContext())
+
+        return with(reporting: reporting)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Update tools version to 5.2.
2. Add legacy manifest files for Swift 5.0 and 5.1.
3. Add additional convenience with functions for client generators.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
