### PR TITLE
Add deprecation annotations for DynamoDBTable, DynamoDBKeysProjection

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjection+DynamoDBKeysProjectionAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjection+DynamoDBKeysProjectionAsync.swift
@@ -22,6 +22,7 @@ import SmokeHTTPClient
 import Logging
 
 /// DynamoDBKeysProjection conformance async functions
+@available(swift, deprecated: 2.0, renamed: "AWSDynamoDBCompositePrimaryKeysProjection")
 public extension AWSDynamoDBKeysProjection {
     
     func queryAsync<AttributesType>(

--- a/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjection+DynamoDBKeysProjectionSync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjection+DynamoDBKeysProjectionSync.swift
@@ -22,6 +22,7 @@ import SmokeHTTPClient
 import Logging
 
 /// DynamoDBKeysProjection conformance sync functions
+@available(swift, deprecated: 2.0, renamed: "AWSDynamoDBCompositePrimaryKeysProjection")
 public extension AWSDynamoDBKeysProjection {
     
     func querySync<AttributesType>(forPartitionKey partitionKey: String,

--- a/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjection.swift
@@ -23,6 +23,7 @@ import SmokeAWSCore
 import SmokeHTTPClient
 import AsyncHTTPClient
 
+@available(swift, deprecated: 2.0, renamed: "AWSDynamoDBCompositePrimaryKeysProjection")
 public class AWSDynamoDBKeysProjection<InvocationReportingType: HTTPClientCoreInvocationReporting>: DynamoDBKeysProjection {
     internal let dynamodb: AWSDynamoDBClient<InvocationReportingType>
     internal let targetTableName: String

--- a/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjectionGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBKeysProjectionGenerator.swift
@@ -24,6 +24,7 @@ import SmokeAWSHttp
 import SmokeHTTPClient
 import AsyncHTTPClient
 
+@available(swift, deprecated: 2.0, renamed: "AWSDynamoDBCompositePrimaryKeysProjectionGenerator")
 public class AWSDynamoDBKeysProjectionGenerator {
     internal let dynamodbGenerator: AWSDynamoDBClientGenerator
     internal let targetTableName: String

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTable+DynamoDBTableAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTable+DynamoDBTableAsync.swift
@@ -22,6 +22,7 @@ import SmokeHTTPClient
 import Logging
 
 /// DynamoDBTable conformance async functions
+@available(swift, deprecated: 2.0, renamed: "AWSDynamoDBCompositePrimaryKeyTable")
 public extension AWSDynamoDBTable {
     
     func insertItemAsync<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTable+DynamoDBTableSync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTable+DynamoDBTableSync.swift
@@ -22,6 +22,7 @@ import SmokeHTTPClient
 import Logging
 
 /// DynamoDBTable conformance sync functions
+@available(swift, deprecated: 2.0, renamed: "AWSDynamoDBCompositePrimaryKeyTable")
 public extension AWSDynamoDBTable {
     
     func insertItemSync<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) throws {

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTable.swift
@@ -23,6 +23,7 @@ import SmokeAWSCore
 import SmokeHTTPClient
 import AsyncHTTPClient
 
+@available(swift, deprecated: 2.0, renamed: "AWSDynamoDBCompositePrimaryKeyTable")
 public class AWSDynamoDBTable<InvocationReportingType: HTTPClientCoreInvocationReporting>: DynamoDBTable {
     internal let dynamodb: AWSDynamoDBClient<InvocationReportingType>
     internal let targetTableName: String

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTableGenerator.swift
@@ -24,6 +24,7 @@ import SmokeAWSHttp
 import SmokeHTTPClient
 import AsyncHTTPClient
 
+@available(swift, deprecated: 2.0, renamed: "AWSDynamoDBCompositePrimaryKeyTableGenerator")
 public class AWSDynamoDBTableGenerator {
     internal let dynamodbGenerator: AWSDynamoDBClientGenerator
     internal let targetTableName: String

--- a/Sources/SmokeDynamoDB/DynamoDBKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBKeysProjection.swift
@@ -23,6 +23,7 @@ import DynamoDBModel
  Protocol presenting a Keys Only projection of a DynamoDB table such as a Keys Only GSI projection.
  Provides the ability to query the projection to get the list of keys without attempting to decode the row into a particular data type.
  */
+@available(swift, deprecated: 2.0, renamed: "DynamoDBCompositePrimaryKeysProjection")
 public protocol DynamoDBKeysProjection {
 
     /**

--- a/Sources/SmokeDynamoDB/DynamoDBTable+clobberVersionedItemWithHistoricalRow.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBTable+clobberVersionedItemWithHistoricalRow.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 
+@available(swift, deprecated: 2.0, renamed: "DynamoDBCompositePrimaryKeyTable")
 public extension DynamoDBTable {
     /**
      * This operation provide a mechanism for managing mutable database rows

--- a/Sources/SmokeDynamoDB/DynamoDBTable+conditionallyUpdateItem.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBTable+conditionallyUpdateItem.swift
@@ -20,6 +20,7 @@ import SmokeHTTPClient
 import Logging
 import DynamoDBModel
 
+@available(swift, deprecated: 2.0, renamed: "DynamoDBCompositePrimaryKeyTable")
 public extension DynamoDBTable {
     /**
      Method to conditionally update an item at the specified key for a number of retries.

--- a/Sources/SmokeDynamoDB/DynamoDBTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBTable.swift
@@ -19,6 +19,7 @@ import Foundation
 import SmokeHTTPClient
 import DynamoDBModel
 
+@available(swift, deprecated: 2.0, renamed: "DynamoDBCompositePrimaryKeyTable")
 public protocol DynamoDBTable {
 
     /**

--- a/Sources/SmokeDynamoDB/DynamoDBTableHistoricalItemExtensions.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBTableHistoricalItemExtensions.swift
@@ -21,6 +21,7 @@ import Logging
 import SmokeHTTPClient
 import DynamoDBModel
 
+@available(swift, deprecated: 2.0, renamed: "DynamoDBCompositePrimaryKeyTable")
 public extension DynamoDBTable {
 
     /**

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBKeysProjection.swift
@@ -20,6 +20,7 @@ import Foundation
 import SmokeHTTPClient
 import DynamoDBModel
 
+@available(swift, deprecated: 2.0, renamed: "InMemoryDynamoDBCompositePrimaryKeysProjection")
 public class InMemoryDynamoDBKeysProjection: DynamoDBKeysProjection {
 
     public var keys: [Any] = []

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBTable.swift
@@ -20,6 +20,7 @@ import Foundation
 import SmokeHTTPClient
 import DynamoDBModel
 
+@available(swift, deprecated: 2.0, renamed: "InMemoryDynamoDBCompositePrimaryKeyTable")
 public class InMemoryDynamoDBTable: DynamoDBTable {
 
     public var store: [String: [String: PolymorphicDatabaseItemConvertable]] = [:]

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBTable.swift
@@ -24,6 +24,7 @@ import DynamoDBModel
  to a database by incrementing a row's version every time it is added for
  a specified number of requests.
  */
+@available(swift, deprecated: 2.0, renamed: "SimulateConcurrencyDynamoDBCompositePrimaryKeyTable")
 public class SimulateConcurrencyDynamoDBTable: DynamoDBTable {
     let wrappedDynamoDBTable: DynamoDBTable
     let simulateConcurrencyModifications: Int


### PR DESCRIPTION

*Issue #, if available:* #20 

*Description of changes:* Add deprecation annotations for DynamoDBTable, DynamoDBKeysProjection protocols, their implementations and generators.

*Testing Done:* Verified warnings generated in XCode and fixits changed the code as expected.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
