### PR TITLE
Add monomorphic queries and to safely delete an existing item.

### DIFF
--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -105,11 +105,21 @@ public protocol DynamoDBCompositePrimaryKeyTable {
 
     /**
      * Removes an item from the database table. Is an idempotent operation; running it multiple times
-     * on the same item or attribute does not result in an error response.
+     * on the same item or attribute does not result in an error response. 
      */
     func deleteItemSync<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>) throws
 
     func deleteItemAsync<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>,
+                                         completion: @escaping (Error?) -> ()) throws
+    
+    /**
+     * Removes an item from the database table. Is an idempotent operation; running it multiple times
+     * on the same item or attribute does not result in an error response. This operation will not modify the table
+     * if the item at the specified key is not the existing item provided.
+     */
+    func deleteItemSync<AttributesType, ItemType>(existingItem: TypedDatabaseItem<AttributesType, ItemType>) throws
+
+    func deleteItemAsync<AttributesType, ItemType>(existingItem: TypedDatabaseItem<AttributesType, ItemType>,
                                          completion: @escaping (Error?) -> ()) throws
 
     /**
@@ -164,4 +174,41 @@ public protocol DynamoDBCompositePrimaryKeyTable {
         scanIndexForward: Bool,
         exclusiveStartKey: String?,
         completion: @escaping (SmokeDynamoDBErrorResult<([PolymorphicDatabaseItem<AttributesType, PossibleTypes>], String?)>) -> ()) throws
+    
+    // MARK: Monomorphic queries
+    
+    /**
+     * Queries a partition in the database table and optionally a sort key condition. If the
+       partition doesn't exist, this operation will return an empty list as a response. This
+       function will potentially make multiple calls to DynamoDB to retrieve all results for
+       the query.
+     */
+    func monomorphicQuerySync<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                        sortKeyCondition: AttributeCondition?) throws
+        -> [TypedDatabaseItem<AttributesType, ItemType>]
+
+    func monomorphicQueryAsync<AttributesType, ItemType>(
+        forPartitionKey partitionKey: String,
+        sortKeyCondition: AttributeCondition?,
+        completion: @escaping (SmokeDynamoDBErrorResult<[TypedDatabaseItem<AttributesType, ItemType>]>) -> ()) throws
+    
+    /**
+     * Queries a partition in the database table and optionally a sort key condition. If the
+       partition doesn't exist, this operation will return an empty list as a response. This
+       function will return paginated results based on the limit and exclusiveStartKey provided.
+     */
+    func monomorphicQuerySync<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                        sortKeyCondition: AttributeCondition?,
+                                                        limit: Int?,
+                                                        scanIndexForward: Bool,
+                                                        exclusiveStartKey: String?) throws
+        -> ([TypedDatabaseItem<AttributesType, ItemType>], String?)
+
+    func monomorphicQueryAsync<AttributesType, ItemType>(
+        forPartitionKey partitionKey: String,
+        sortKeyCondition: AttributeCondition?,
+        limit: Int?,
+        scanIndexForward: Bool,
+        exclusiveStartKey: String?,
+        completion: @escaping (SmokeDynamoDBErrorResult<([TypedDatabaseItem<AttributesType, ItemType>], String?)>) -> ()) throws
 }

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable+monomorphicQuery.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable+monomorphicQuery.swift
@@ -1,0 +1,175 @@
+// swiftlint:disable cyclomatic_complexity
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  InMemoryDynamoDBCompositePrimaryKeyTable+monomorphicQuery.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeHTTPClient
+import DynamoDBModel
+
+public extension InMemoryDynamoDBCompositePrimaryKeyTable {
+    
+    func monomorphicQuerySync<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                        sortKeyCondition: AttributeCondition?) throws
+    -> [TypedDatabaseItem<AttributesType, ItemType>]
+    where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
+        var items: [TypedDatabaseItem<AttributesType, ItemType>] = []
+
+            if let partition = store[partitionKey] {
+                let sortedPartition = partition.sorted(by: { (left, right) -> Bool in
+                    return left.key < right.key
+                })
+                
+                sortKeyIteration: for (sortKey, value) in sortedPartition {
+
+                    if let currentSortKeyCondition = sortKeyCondition {
+                        switch currentSortKeyCondition {
+                        case .equals(let value):
+                            if !(value == sortKey) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .lessThan(let value):
+                            if !(sortKey < value) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .lessThanOrEqual(let value):
+                            if !(sortKey <= value) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .greaterThan(let value):
+                            if !(sortKey > value) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .greaterThanOrEqual(let value):
+                            if !(sortKey >= value) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .between(let value1, let value2):
+                            if !(sortKey > value1 && sortKey < value2) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .beginsWith(let value):
+                            if !(sortKey.hasPrefix(value)) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        }
+                    }
+
+                    if let typedValue = value as? TypedDatabaseItem<AttributesType, ItemType> {
+                        items.append(typedValue)
+                    } else {
+                        let description = "Expected type \(TypedDatabaseItem<AttributesType, ItemType>.self), "
+                            + " was \(type(of: value))."
+                        let context = DecodingError.Context(codingPath: [], debugDescription: description)
+                        throw DecodingError.typeMismatch(TypedDatabaseItem<AttributesType, ItemType>.self,
+                                                         context)
+                    }
+                }
+            }
+
+            return items
+        }
+    
+    func monomorphicQueryAsync<AttributesType, ItemType>(
+            forPartitionKey partitionKey: String,
+            sortKeyCondition: AttributeCondition?,
+            completion: @escaping (SmokeDynamoDBErrorResult<[TypedDatabaseItem<AttributesType, ItemType>]>) -> ()) throws
+    where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
+        do {
+            let items: [TypedDatabaseItem<AttributesType, ItemType>] =
+                try monomorphicQuerySync(forPartitionKey: partitionKey,
+                                         sortKeyCondition: sortKeyCondition)
+
+            completion(.success(items))
+        } catch {
+            completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
+        }
+    }
+    
+    func monomorphicQuerySync<AttributesType, ItemType>(
+            forPartitionKey partitionKey: String,
+            sortKeyCondition: AttributeCondition?,
+            limit: Int?,
+            scanIndexForward: Bool,
+            exclusiveStartKey: String?) throws
+    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?)
+    where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
+        // get all the results
+        let rawItems: [TypedDatabaseItem<AttributesType, ItemType>] = try monomorphicQuerySync(
+            forPartitionKey: partitionKey,
+            sortKeyCondition: sortKeyCondition)
+        
+        let items: [TypedDatabaseItem<AttributesType, ItemType>]
+        if !scanIndexForward {
+            items = rawItems.reversed()
+        } else {
+            items = rawItems
+        }
+
+        let startIndex: Int
+        // if there is an exclusiveStartKey
+        if let exclusiveStartKey = exclusiveStartKey {
+            guard let storedStartIndex = Int(exclusiveStartKey) else {
+                fatalError("Unexpectedly encoded exclusiveStartKey '\(exclusiveStartKey)'")
+            }
+
+            startIndex = storedStartIndex
+        } else {
+            startIndex = 0
+        }
+
+        let endIndex: Int
+        let lastEvaluatedKey: String?
+        if let limit = limit, startIndex + limit < items.count {
+            endIndex = startIndex + limit
+            lastEvaluatedKey = String(endIndex)
+        } else {
+            endIndex = items.count
+            lastEvaluatedKey = nil
+        }
+
+        return (Array(items[startIndex..<endIndex]), lastEvaluatedKey)
+    }
+    
+    func monomorphicQueryAsync<AttributesType, ItemType>(
+            forPartitionKey partitionKey: String,
+            sortKeyCondition: AttributeCondition?,
+            limit: Int?,
+            scanIndexForward: Bool,
+            exclusiveStartKey: String?,
+            completion: @escaping (SmokeDynamoDBErrorResult<([TypedDatabaseItem<AttributesType, ItemType>], String?)>) -> ()) throws
+    where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
+        do {
+            let result: ([TypedDatabaseItem<AttributesType, ItemType>], String?) =
+                try monomorphicQuerySync(forPartitionKey: partitionKey,
+                                         sortKeyCondition: sortKeyCondition,
+                                         limit: limit,
+                                         scanIndexForward: true,
+                                         exclusiveStartKey: exclusiveStartKey)
+
+            completion(.success(result))
+        } catch {
+            completion(.failure(error.asUnrecognizedSmokeDynamoDBError()))
+        }
+    }
+}

--- a/Tests/SmokeDynamoDBTests/DynamoDBTableClobberVersionedItemWithHistoricalRowTests.swift
+++ b/Tests/SmokeDynamoDBTests/DynamoDBTableClobberVersionedItemWithHistoricalRowTests.swift
@@ -19,6 +19,8 @@ import Foundation
 import XCTest
 @testable import SmokeDynamoDB
 
+@available(swift, deprecated: 2.0,
+           renamed: "DynamoDBCompositePrimaryKeyTableClobberVersionedItemWithHistoricalRowTests")
 class DynamoDBTableClobberVersionedItemWithHistoricalRowTests: XCTestCase {
     
     func testClobberVersionedItemWithHistoricalRowSync() throws {

--- a/Tests/SmokeDynamoDBTests/DynamoDBTableHistoricalItemExtensionsTests.swift
+++ b/Tests/SmokeDynamoDBTests/DynamoDBTableHistoricalItemExtensionsTests.swift
@@ -52,6 +52,7 @@ fileprivate func testHistoricalItemProvider(_ item: DatabaseRowType) -> Database
                                    andValue: item.rowValue)
 }
 
+@available(swift, deprecated: 2.0, renamed: "CompositePrimaryKeyDynamoDBHistoricalClientTests")
 class DynamoDBHistoricalClientTests: XCTestCase {
 
     func testInsertItemSuccessSync() throws {

--- a/Tests/SmokeDynamoDBTests/DynamoDBTableUpdateItemConditionallyAtKeyTests.swift
+++ b/Tests/SmokeDynamoDBTests/DynamoDBTableUpdateItemConditionallyAtKeyTests.swift
@@ -18,6 +18,8 @@
 import XCTest
 @testable import SmokeDynamoDB
 
+@available(swift, deprecated: 2.0,
+           renamed: "DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests")
 class DynamoDBTableUpdateItemConditionallyAtKeyTests: XCTestCase {
     
     func updatedPayloadProvider(item: TestTypeA) -> TestTypeA {

--- a/Tests/SmokeDynamoDBTests/InMemoryDynamoDBTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/InMemoryDynamoDBTableTests.swift
@@ -20,6 +20,7 @@ import XCTest
 import SmokeHTTPClient
 import DynamoDBModel
 
+@available(swift, deprecated: 2.0, renamed: "InMemoryDynamoDBCompositePrimaryKeyTableTests")
 class InMemoryDynamoDBTableTests: XCTestCase {
     
     func testInsertAndUpdateSync() throws {

--- a/Tests/SmokeDynamoDBTests/SimulateConcurrencyDynamoDBTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/SimulateConcurrencyDynamoDBTableTests.swift
@@ -23,6 +23,8 @@ import DynamoDBModel
 private typealias DatabaseRowType = StandardTypedDatabaseItem<TestTypeA>
 private typealias QueryRowType = StandardPolymorphicDatabaseItem<ExpectedTypes>
 
+@available(swift, deprecated: 2.0,
+           renamed: "SimulateConcurrencyDynamoDBCompositePrimaryKeyTableTests")
 class SimulateConcurrencyDynamoDBTableTests: XCTestCase {
     
     func testSimulateConcurrencyOnInsertSync() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add an API to safely delete an existing item; will fail if the item has been updated from the existing item or recreated in between
2. Add monomorphic queries - an optimisation for queries where all rows are known to be of the same type. Directly returns instances of `TypedDatabaseItem`, avoiding getting back instances of `PolymorphicDatabaseItem` and having to typecast the payload into the only required type.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
