### PR TITLE
Make the InMemory* types thread-safe

### DIFF
--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable+monomorphicQuery.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable+monomorphicQuery.swift
@@ -26,6 +26,11 @@ public extension InMemoryDynamoDBCompositePrimaryKeyTable {
                                                         sortKeyCondition: AttributeCondition?) throws
     -> [TypedDatabaseItem<AttributesType, ItemType>]
     where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
+        semaphore.wait()
+        defer {
+            semaphore.signal()
+        }
+        
         var items: [TypedDatabaseItem<AttributesType, ItemType>] = []
 
             if let partition = store[partitionKey] {

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
@@ -23,6 +23,7 @@ import DynamoDBModel
 public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePrimaryKeysProjection {
 
     public var keys: [Any] = []
+    let semaphore = DispatchSemaphore(value: 1)
 
     public init(keys: [Any] = []) {
         self.keys = keys
@@ -31,6 +32,11 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
     public func querySync<AttributesType>(forPartitionKey partitionKey: String,
                                           sortKeyCondition: AttributeCondition?) throws
         -> [CompositePrimaryKey<AttributesType>] {
+        semaphore.wait()
+        defer {
+            semaphore.signal()
+        }
+        
         var items: [CompositePrimaryKey<AttributesType>] = []
             
         let sortedKeys = keys.compactMap { $0 as? CompositePrimaryKey<AttributesType> }.sorted(by: { (left, right) -> Bool in


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* Make the InMemory* types thread-safe by protecting the internal data structures with a semaphore. Verified consist access to classes across different accessing threads.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
