### PR TITLE
Add getItems and monomorphicGetItems APIs

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+getItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+getItems.swift
@@ -1,0 +1,167 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AWSDynamoDBCompositePrimaryKeyTable+getItems.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeAWSCore
+import DynamoDBModel
+import SmokeHTTPClient
+import Logging
+import NIO
+
+// BatchGetItem has a maximum of 100 of items per request
+// https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html
+private let maximumKeysPerGetItemBatch = 100
+
+/// DynamoDBTable conformance getItems function
+public extension AWSDynamoDBCompositePrimaryKeyTable {
+    /**
+     Helper type that manages the state of a getItems request.
+     
+     As suggested here - https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html - this helper type
+     monitors the unprocessed items returned in the response from DynamoDB and uses an exponential backoff algorithm to retry those items using
+     the same retry configuration as the underlying DynamoDB client.
+     */
+    private class GetItemsRetriable<ReturnedType: PolymorphicOperationReturnType & BatchCapableReturnType> {
+        typealias OutputType = [CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType]
+        
+        let dynamodb: _AWSDynamoDBClient<InvocationReportingType>
+        let eventLoop: EventLoop
+        
+        private let retryQueue =
+            DispatchQueue(label: "com.amazon.SmokeDynamoDB.AWSDynamoDBCompositePrimaryKeyTable.GetItemsRetriable.retryQueue")
+        
+        var retriesRemaining: Int
+        var input: BatchGetItemInput
+        var outputItems: OutputType = [:]
+        
+        init(initialInput: BatchGetItemInput,
+             dynamodb: _AWSDynamoDBClient<InvocationReportingType>,
+             eventLoopOverride eventLoop: EventLoop) {
+            self.dynamodb = dynamodb
+            self.eventLoop = eventLoop
+            self.retriesRemaining = dynamodb.retryConfiguration.numRetries
+            self.input = initialInput
+        }
+        
+        func batchGetItem() -> EventLoopFuture<OutputType> {
+            // submit the asynchronous request
+            return self.dynamodb.batchGetItem(input: self.input).flatMap { output -> EventLoopFuture<OutputType> in
+                let errors = output.responses?.flatMap({ (tableName, itemList) -> [Error] in
+                    return itemList.compactMap { values -> Error? in
+                        do {
+                            let attributeValue = DynamoDBModel.AttributeValue(M: values)
+                            
+                            let decodedItem: ReturnTypeDecodable<ReturnedType> = try DynamoDBDecoder().decode(attributeValue)
+                            let decodedValue = decodedItem.decodedValue
+                            let key = decodedValue.getItemKey()
+                                                            
+                            self.outputItems[key] = decodedValue
+                            return nil
+                        } catch {
+                            return error
+                        }
+                    }
+                }) ?? []
+                
+                if !errors.isEmpty {
+                    let promise = self.eventLoop.makePromise(of: OutputType.self)
+                    let error = SmokeDynamoDBError.multipleUnexpectedErrors(cause: errors)
+                    promise.fail(error)
+                    return promise.futureResult
+                }
+                
+                if let requestItems = output.unprocessedKeys, !requestItems.isEmpty {
+                    self.input = BatchGetItemInput(requestItems: requestItems)
+                    
+                    return self.getNextFuture()
+                }
+                
+                let promise = self.eventLoop.makePromise(of: OutputType.self)
+                promise.succeed(self.outputItems)
+                return promise.futureResult
+            }
+        }
+        
+        func getNextFuture() -> EventLoopFuture<OutputType> {
+            let promise = self.eventLoop.makePromise(of: OutputType.self)
+            let logger = self.dynamodb.reporting.logger
+            
+            // if there are retries remaining
+            if retriesRemaining > 0 {
+                // determine the required interval
+                let retryInterval = Int(self.dynamodb.retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
+                
+                let currentRetriesRemaining = retriesRemaining
+                retriesRemaining -= 1
+                
+                let remainingKeysCount = self.input.requestItems.count
+                
+                logger.warning(
+                    "Request retried for remaining items: \(remainingKeysCount). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
+                let deadline = DispatchTime.now() + .milliseconds(retryInterval)
+                retryQueue.asyncAfter(deadline: deadline) {
+                    logger.debug("Reattempting request due to remaining retries: \(currentRetriesRemaining)")
+                    
+                    let nextFuture = self.batchGetItem()
+                    
+                    promise.completeWith(nextFuture)
+                }
+                
+                // return the future that will be completed with the future retry.
+                return promise.futureResult
+            }
+            
+            let error = SmokeDynamoDBError.batchAPIExceededRetries(retryCount: self.dynamodb.retryConfiguration.numRetries)
+            promise.fail(error)
+            
+            return promise.futureResult
+        }
+    }
+    
+    func getItems<ReturnedType: PolymorphicOperationReturnType & BatchCapableReturnType>(
+        forKeys keys: [CompositePrimaryKey<ReturnedType.AttributesType>])
+    -> EventLoopFuture<[CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType]> {
+        let chunkedList = keys.chunked(by: maximumKeysPerGetItemBatch)
+        
+        let futures = chunkedList.map { chunk -> EventLoopFuture<[CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType]> in
+            let input: BatchGetItemInput
+            do {
+                input = try getInputForBatchGetItem(forKeys: chunk)
+            } catch {
+                let promise = self.eventLoop.makePromise(of: [CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType].self)
+                promise.fail(error)
+                return promise.futureResult
+            }
+            
+            let retriable = GetItemsRetriable<ReturnedType>(
+                initialInput: input,
+                dynamodb: self.dynamodb,
+                eventLoopOverride: self.eventLoop)
+            
+            return retriable.batchGetItem()
+        }
+        
+        // maps is of type [[CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType]]
+        // with each map coming from each chunk of the original key list
+        return EventLoopFuture.whenAllSucceed(futures, on: self.eventLoop) .map { maps in
+            return maps.reduce([:]) { (partialMap, chunkMap) in
+                // reduce the maps from the chunks into a single map
+                return partialMap.merging(chunkMap) { (_, new) in new }
+            }
+        }
+    }
+}

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+monomorphicGetItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+monomorphicGetItems.swift
@@ -1,0 +1,166 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AWSDynamoDBCompositePrimaryKeyTable+monomorphicGetItems.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeAWSCore
+import DynamoDBModel
+import SmokeHTTPClient
+import Logging
+import NIO
+
+// BatchGetItem has a maximum of 100 of items per request
+// https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html
+private let maximumKeysPerGetItemBatch = 100
+
+/// DynamoDBTable conformance monomorphicGetItems function
+public extension AWSDynamoDBCompositePrimaryKeyTable {
+    /**
+     Helper type that manages the state of a monomorphicGetItems request.
+     
+     As suggested here - https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html - this helper type
+     monitors the unprocessed items returned in the response from DynamoDB and uses an exponential backoff algorithm to retry those items using
+     the same retry configuration as the underlying DynamoDB client.
+     */
+    private class MonomorphicGetItemsRetriable<AttributesType: PrimaryKeyAttributes, ItemType: Codable> {
+        typealias OutputType = [CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>]
+        
+        let dynamodb: _AWSDynamoDBClient<InvocationReportingType>
+        let eventLoop: EventLoop
+        
+        private let retryQueue =
+            DispatchQueue(label: "com.amazon.SmokeDynamoDB.AWSDynamoDBCompositePrimaryKeyTable.MonomorphicGetItemsRetriable.retryQueue")
+        
+        var retriesRemaining: Int
+        var input: BatchGetItemInput
+        var outputItems: OutputType = [:]
+        
+        init(initialInput: BatchGetItemInput,
+             dynamodb: _AWSDynamoDBClient<InvocationReportingType>,
+             eventLoopOverride eventLoop: EventLoop) {
+            self.dynamodb = dynamodb
+            self.eventLoop = eventLoop
+            self.retriesRemaining = dynamodb.retryConfiguration.numRetries
+            self.input = initialInput
+        }
+        
+        func batchGetItem() -> EventLoopFuture<OutputType> {
+            // submit the asynchronous request
+            return self.dynamodb.batchGetItem(input: self.input).flatMap { output -> EventLoopFuture<OutputType> in
+                let errors = output.responses?.flatMap({ (tableName, itemList) -> [Error] in
+                    return itemList.compactMap { values -> Error? in
+                        do {
+                            let attributeValue = DynamoDBModel.AttributeValue(M: values)
+                            
+                            let decodedValue: TypedDatabaseItem<AttributesType, ItemType> = try DynamoDBDecoder().decode(attributeValue)
+                            let key = decodedValue.compositePrimaryKey
+                                                            
+                            self.outputItems[key] = decodedValue
+                            return nil
+                        } catch {
+                            return error
+                        }
+                    }
+                }) ?? []
+                
+                if !errors.isEmpty {
+                    let promise = self.eventLoop.makePromise(of: OutputType.self)
+                    let error = SmokeDynamoDBError.multipleUnexpectedErrors(cause: errors)
+                    promise.fail(error)
+                    return promise.futureResult
+                }
+                
+                if let requestItems = output.unprocessedKeys, !requestItems.isEmpty {
+                    self.input = BatchGetItemInput(requestItems: requestItems)
+                    
+                    return self.getNextFuture()
+                }
+                
+                let promise = self.eventLoop.makePromise(of: OutputType.self)
+                promise.succeed(self.outputItems)
+                return promise.futureResult
+            }
+        }
+        
+        func getNextFuture() -> EventLoopFuture<OutputType> {
+            let promise = self.eventLoop.makePromise(of: OutputType.self)
+            let logger = self.dynamodb.reporting.logger
+            
+            // if there are retries remaining
+            if retriesRemaining > 0 {
+                // determine the required interval
+                let retryInterval = Int(self.dynamodb.retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
+                
+                let currentRetriesRemaining = retriesRemaining
+                retriesRemaining -= 1
+                
+                let remainingKeysCount = self.input.requestItems.count
+                
+                logger.warning(
+                    "Request retried for remaining items: \(remainingKeysCount). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
+                let deadline = DispatchTime.now() + .milliseconds(retryInterval)
+                retryQueue.asyncAfter(deadline: deadline) {
+                    logger.debug("Reattempting request due to remaining retries: \(currentRetriesRemaining)")
+                    
+                    let nextFuture = self.batchGetItem()
+                    
+                    promise.completeWith(nextFuture)
+                }
+                
+                // return the future that will be completed with the future retry.
+                return promise.futureResult
+            }
+            
+            let error = SmokeDynamoDBError.batchAPIExceededRetries(retryCount: self.dynamodb.retryConfiguration.numRetries)
+            promise.fail(error)
+            
+            return promise.futureResult
+        }
+    }
+    
+    func monomorphicGetItems<AttributesType, ItemType>(
+        forKeys keys: [CompositePrimaryKey<AttributesType>])
+    -> EventLoopFuture<[CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>]> {
+        let chunkedList = keys.chunked(by: maximumKeysPerGetItemBatch)
+        
+        let futures = chunkedList.map { chunk -> EventLoopFuture<[CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>]> in
+            let input: BatchGetItemInput
+            do {
+                input = try getInputForBatchGetItem(forKeys: chunk)
+            } catch {
+                let promise = self.eventLoop.makePromise(of: [CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>].self)
+                promise.fail(error)
+                return promise.futureResult
+            }
+            
+            let retriable = MonomorphicGetItemsRetriable<AttributesType, ItemType>(
+                initialInput: input,
+                dynamodb: self.dynamodb,
+                eventLoopOverride: self.eventLoop)
+            
+            return retriable.batchGetItem()
+        }
+        
+        // maps is of type [[CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>]]
+        // with each map coming from each chunk of the original key list
+        return EventLoopFuture.whenAllSucceed(futures, on: self.eventLoop) .map { maps in
+            return maps.reduce([:]) { (partialMap, chunkMap) in
+                // reduce the maps from the chunks into a single map
+                return partialMap.merging(chunkMap) { (_, new) in new }
+            }
+        }
+    }
+}

--- a/Sources/SmokeDynamoDB/CompositePrimaryKey.swift
+++ b/Sources/SmokeDynamoDB/CompositePrimaryKey.swift
@@ -56,7 +56,7 @@ struct DynamoDBAttributesTypeCodingKey: CodingKey {
     }
 }
 
-public struct CompositePrimaryKey<AttributesType: PrimaryKeyAttributes>: Codable, CustomStringConvertible {
+public struct CompositePrimaryKey<AttributesType: PrimaryKeyAttributes>: Codable, CustomStringConvertible, Hashable {
     public var description: String {
         return "CompositePrimaryKey(partitionKey: \(partitionKey), sortKey: \(sortKey))"
     }

--- a/Sources/SmokeDynamoDB/PolymorphicOperationReturnType.swift
+++ b/Sources/SmokeDynamoDB/PolymorphicOperationReturnType.swift
@@ -18,9 +18,15 @@ import Foundation
 import SmokeHTTPClient
 import DynamoDBModel
 
-public protocol PolymorphicOperationReturnType {
+public protocol BatchCapableReturnType {
     associatedtype AttributesType: PrimaryKeyAttributes
     
+    func getItemKey() -> CompositePrimaryKey<AttributesType>
+}
+
+public protocol PolymorphicOperationReturnType {
+    associatedtype AttributesType: PrimaryKeyAttributes
+        
     static var types: [(Codable.Type, PolymorphicOperationReturnOption<AttributesType, Self>)] { get }
 }
 

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -97,6 +97,13 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         return wrappedDynamoDBTable.getItem(forKey: key)
     }
     
+    public func getItems<ReturnedType: PolymorphicOperationReturnType & BatchCapableReturnType>(
+        forKeys keys: [CompositePrimaryKey<ReturnedType.AttributesType>])
+    -> EventLoopFuture<[CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType]> {
+        // simply delegate to the wrapped implementation
+        return wrappedDynamoDBTable.getItems(forKeys: keys)
+    }
+    
     public func deleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>) -> EventLoopFuture<Void> {
         // simply delegate to the wrapped implementation
         return wrappedDynamoDBTable.deleteItem(forKey: key)
@@ -139,6 +146,13 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
                                               limit: limit,
                                               scanIndexForward: scanIndexForward,
                                               exclusiveStartKey: exclusiveStartKey)
+    }
+    
+    public func monomorphicGetItems<AttributesType, ItemType>(
+        forKeys keys: [CompositePrimaryKey<AttributesType>])
+    -> EventLoopFuture<[CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>]> {
+        // simply delegate to the wrapped implementation
+        return wrappedDynamoDBTable.monomorphicGetItems(forKeys: keys)
     }
     
     public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,

--- a/Tests/SmokeDynamoDBTests/TestConfiguration.swift
+++ b/Tests/SmokeDynamoDBTests/TestConfiguration.swift
@@ -29,3 +29,26 @@ struct TestTypeB: Codable, Equatable, CustomRowTypeIdentifier {
     let thirdly: String
     let fourthly: String
 }
+
+enum TestQueryableTypes: PolymorphicOperationReturnType {
+    typealias AttributesType = StandardPrimaryKeyAttributes
+    
+    static var types: [(Codable.Type, PolymorphicOperationReturnOption<StandardPrimaryKeyAttributes, Self>)] = [
+        (TestTypeA.self, .init( {.testTypeA($0)} )),
+        (TestTypeB.self, .init( {.testTypeB($0)} )),
+        ]
+    
+    case testTypeA(StandardTypedDatabaseItem<TestTypeA>)
+    case testTypeB(StandardTypedDatabaseItem<TestTypeB>)
+}
+
+extension TestQueryableTypes: BatchCapableReturnType {
+    func getItemKey() -> CompositePrimaryKey<StandardPrimaryKeyAttributes> {
+        switch self {
+        case .testTypeA(let databaseItem):
+            return databaseItem.compositePrimaryKey
+        case .testTypeB(let databaseItem):
+            return databaseItem.compositePrimaryKey
+        }
+    }
+}


### PR DESCRIPTION
Add getItems and monomorphicGetItems that use the BatchGetItem DynamoDB API.

*Issue #, if available:* 

*Description of changes:* Add getItems and monomorphicGetItems that use the BatchGetItem DynamoDB API. Allows retrieving items from a table in the same request.

**Example usage**
```
let batch: [StandardCompositePrimaryKey: TestQueryableTypes] = try table.getItems(forKeys: [key1, key2]).wait()
        
guard case .testTypeA(let retrievedDatabaseItem1) = batch[key1] else {
    return
}
        
guard case .testTypeB(let retrievedDatabaseItem2) = batch[key2] else {
    return
}
```

```
let batch: [StandardCompositePrimaryKey: StandardTypedDatabaseItem<TestTypeA>]
    = try table.monomorphicGetItems(forKeys: [key1, key2]).wait()
        
guard let retrievedDatabaseItem1 = batch[key1] else {
    return
}
        
guard let retrievedDatabaseItem2 = batch[key2] else {
    return
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
