### PR TITLE
Provide override for conditionalUpdate* aync provider variants

### DIFF
--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
@@ -87,4 +87,50 @@ public extension DynamoDBCompositePrimaryKeyTable {
             }
         }
     }
+    
+    func conditionallyUpdateItem<AttributesType, ItemType: Codable>(
+            forKey key: CompositePrimaryKey<AttributesType>,
+            withRetries retries: Int = 10,
+            updatedPayloadProvider: @escaping (ItemType) -> EventLoopFuture<ItemType>) -> EventLoopFuture<Void> {
+        guard retries > 0 else {
+            let error = SmokeDynamoDBError.concurrencyError(partitionKey: key.partitionKey,
+                                                            sortKey: key.sortKey,
+                                                            message: "Unable to complete request to update versioned item in specified number of attempts")
+            
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            promise.fail(error)
+            return promise.futureResult
+        }
+        
+        return getItem(forKey: key).flatMap { (databaseItemOptional: TypedDatabaseItem<AttributesType, ItemType>?) in
+            guard let databaseItem = databaseItemOptional else {
+                let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: key.partitionKey,
+                                                                    sortKey: key.sortKey,
+                                                                    message: "Item not present in database.")
+                
+                let promise = self.eventLoop.makePromise(of: Void.self)
+                promise.fail(error)
+                return promise.futureResult
+            }
+            
+            let updatedPayloadFuture = updatedPayloadProvider(databaseItem.rowValue)
+            
+            return updatedPayloadFuture.flatMap { updatedPayload in
+                let updatedDatabaseItem = databaseItem.createUpdatedItem(withValue: updatedPayload)
+                
+                return self.updateItem(newItem: updatedDatabaseItem, existingItem: databaseItem).flatMapError { error in
+                    if case SmokeDynamoDBError.conditionalCheckFailed = error {
+                        // try again
+                        return self.conditionallyUpdateItem(forKey: key, withRetries: retries - 1,
+                                                            updatedPayloadProvider: updatedPayloadProvider)
+                    } else {
+                        // propagate the error as its not an error causing a retry
+                        let promise = self.eventLoop.makePromise(of: Void.self)
+                        promise.fail(error)
+                        return promise.futureResult
+                    }
+                }
+            }
+        }
+    }
 }

--- a/Tests/SmokeDynamoDBTests/DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests.swift
+++ b/Tests/SmokeDynamoDBTests/DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests.swift
@@ -42,6 +42,16 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         return TestTypeA(firstly: "firstlyX2", secondly: "secondlyX2")
     }
     
+    func getUpdatedPayloadProviderAsync(on eventLoop: EventLoop) -> ((TestTypeA) -> EventLoopFuture<TestTypeA>) {
+        func provider(item: TestTypeA) -> EventLoopFuture<TestTypeA> {
+            let promise = eventLoop.makePromise(of: TestTypeA.self)
+            promise.succeed(TestTypeA(firstly: "firstlyX2", secondly: "secondlyX2"))
+            return promise.futureResult
+        }
+        
+        return provider
+    }
+    
     func testUpdateItemConditionallyAtKey() {
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
@@ -59,6 +69,32 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         XCTAssertEqual(databaseItem.rowValue.secondly, retrievedItem.rowValue.secondly)
         
         XCTAssertNoThrow(try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: updatedPayloadProvider).wait())
+        
+        let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual("sortId", secondRetrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual("firstlyX2", secondRetrievedItem.rowValue.firstly)
+        XCTAssertEqual("secondlyX2", secondRetrievedItem.rowValue.secondly)
+    }
+    
+    func testUpdateItemConditionallyAtKeyWithAsyncProvider() {
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
+        
+        let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
+                                                     sortKey: "sortId")
+        let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
+        
+        XCTAssertNoThrow(try table.insertItem(databaseItem).wait())
+        
+        let retrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual(databaseItem.compositePrimaryKey.sortKey, retrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual(databaseItem.rowValue.firstly, retrievedItem.rowValue.firstly)
+        XCTAssertEqual(databaseItem.rowValue.secondly, retrievedItem.rowValue.secondly)
+        
+        let asyncUpdatedPayloadProvider = getUpdatedPayloadProviderAsync(on: self.eventLoop)
+        XCTAssertNoThrow(try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: asyncUpdatedPayloadProvider).wait())
         
         let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
         
@@ -95,6 +131,35 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         XCTAssertEqual("secondlyX2", secondRetrievedItem.rowValue.secondly)
     }
     
+    func testUpdateItemConditionallyAtKeyWithAcceptableConcurrencyWithAsyncProvider() {
+        let wrappedTable = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
+        let table = SimulateConcurrencyDynamoDBCompositePrimaryKeyTable(wrappedDynamoDBTable: wrappedTable, eventLoop: eventLoop,
+                                                     simulateConcurrencyModifications: 5,
+                                                     simulateOnInsertItem: false)
+        
+        let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
+                                                     sortKey: "sortId")
+        let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
+        
+        XCTAssertNoThrow(try table.insertItem(databaseItem).wait())
+        
+        let retrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual(databaseItem.compositePrimaryKey.sortKey, retrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual(databaseItem.rowValue.firstly, retrievedItem.rowValue.firstly)
+        XCTAssertEqual(databaseItem.rowValue.secondly, retrievedItem.rowValue.secondly)
+        
+        let asyncUpdatedPayloadProvider = getUpdatedPayloadProviderAsync(on: self.eventLoop)
+        XCTAssertNoThrow(try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: asyncUpdatedPayloadProvider).wait())
+        
+        let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual("sortId", secondRetrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual("firstlyX2", secondRetrievedItem.rowValue.firstly)
+        XCTAssertEqual("secondlyX2", secondRetrievedItem.rowValue.secondly)
+    }
+    
     func testUpdateItemConditionallyAtKeyWithUnacceptableConcurrency() {
         let wrappedTable = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         let table = SimulateConcurrencyDynamoDBCompositePrimaryKeyTable(wrappedDynamoDBTable: wrappedTable, eventLoop: eventLoop,
@@ -116,6 +181,44 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         
         do {
             try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: updatedPayloadProvider).wait()
+            
+            XCTFail("Expected concurrency error not thrown.")
+        } catch SmokeDynamoDBError.concurrencyError {
+            // expected error thrown
+        } catch {
+            XCTFail("Unexpected error thrown: \(error).")
+        }
+        
+        let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual("sortId", secondRetrievedItem.compositePrimaryKey.sortKey)
+        // Check the item hasn't been updated
+        XCTAssertEqual("firstly", secondRetrievedItem.rowValue.firstly)
+        XCTAssertEqual("secondly", secondRetrievedItem.rowValue.secondly)
+    }
+    
+    func testUpdateItemConditionallyAtKeyWithUnacceptableConcurrencyWithAsyncProvider() {
+        let wrappedTable = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
+        let table = SimulateConcurrencyDynamoDBCompositePrimaryKeyTable(wrappedDynamoDBTable: wrappedTable, eventLoop: eventLoop,
+                                                     simulateConcurrencyModifications: 100,
+                                                     simulateOnInsertItem: false)
+        
+        let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
+                                                     sortKey: "sortId")
+        let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
+        
+        XCTAssertNoThrow(try table.insertItem(databaseItem).wait())
+        
+        let retrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual(databaseItem.compositePrimaryKey.sortKey, retrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual(databaseItem.rowValue.firstly, retrievedItem.rowValue.firstly)
+        XCTAssertEqual(databaseItem.rowValue.secondly, retrievedItem.rowValue.secondly)
+        
+        let asyncUpdatedPayloadProvider = getUpdatedPayloadProviderAsync(on: self.eventLoop)
+        do {
+            try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: asyncUpdatedPayloadProvider).wait()
             
             XCTFail("Expected concurrency error not thrown.")
         } catch SmokeDynamoDBError.concurrencyError {
@@ -185,6 +288,58 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         XCTAssertEqual("secondly", secondRetrievedItem.rowValue.secondly)
     }
     
+    func testUpdateItemConditionallyAtKeyWithFailingUpdateWithAsyncProvider() {
+        let wrappedTable = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
+        let table = SimulateConcurrencyDynamoDBCompositePrimaryKeyTable(wrappedDynamoDBTable: wrappedTable, eventLoop: eventLoop,
+                                                     simulateConcurrencyModifications: 100,
+                                                     simulateOnInsertItem: false)
+        
+        let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
+                                                     sortKey: "sortId")
+        let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
+        
+        XCTAssertNoThrow(try table.insertItem(databaseItem).wait())
+        
+        let retrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual(databaseItem.compositePrimaryKey.sortKey, retrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual(databaseItem.rowValue.firstly, retrievedItem.rowValue.firstly)
+        XCTAssertEqual(databaseItem.rowValue.secondly, retrievedItem.rowValue.secondly)
+        
+        var passCount = 0
+        
+        func failingUpdatedPayloadProvider(item: TestTypeA) -> EventLoopFuture<TestTypeA> {
+            let promise = eventLoop.makePromise(of: TestTypeA.self)
+            if passCount < 5 {
+                passCount += 1
+                promise.succeed(TestTypeA(firstly: "firstlyX2", secondly: "secondlyX2"))
+            } else {
+                // fail before the retry limit with a custom error
+                promise.fail(TestError.everythingIsWrong)
+            }
+            
+            return promise.futureResult
+        }
+        
+        do {
+            try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: failingUpdatedPayloadProvider).wait()
+            
+            XCTFail("Expected everythingIsWrong error not thrown.")
+        } catch TestError.everythingIsWrong {
+            // expected error thrown
+        } catch {
+            XCTFail("Unexpected error thrown: \(error).")
+        }
+        
+        let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual("sortId", secondRetrievedItem.compositePrimaryKey.sortKey)
+        // Check the item hasn't been updated
+        XCTAssertEqual("firstly", secondRetrievedItem.rowValue.firstly)
+        XCTAssertEqual("secondly", secondRetrievedItem.rowValue.secondly)
+    }
+    
     func testUpdateItemConditionallyAtKeyWithUnknownItem() {
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
@@ -206,11 +361,42 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         XCTAssertNil(secondRetrievedItem)
     }
     
+    func testUpdateItemConditionallyAtKeyWithUnknownItemWithAsyncProvider() {
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
+        
+        let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
+                                                     sortKey: "sortId")
+        
+        let asyncUpdatedPayloadProvider = getUpdatedPayloadProviderAsync(on: self.eventLoop)
+        do {
+            try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: asyncUpdatedPayloadProvider).wait()
+            
+            XCTFail("Expected concurrency error not thrown.")
+        } catch SmokeDynamoDBError.conditionalCheckFailed {
+            // expected error thrown
+        } catch {
+            XCTFail("Unexpected error thrown: \(error).")
+        }
+        
+        let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA>? = try! table.getItem(forKey: key).wait()
+        
+        XCTAssertNil(secondRetrievedItem)
+    }
+    
     static var allTests = [
         ("testUpdateItemConditionallyAtKey", testUpdateItemConditionallyAtKey),
+        ("testUpdateItemConditionallyAtKeyWithAsyncProvider", testUpdateItemConditionallyAtKeyWithAsyncProvider),
         ("testUpdateItemConditionallyAtKeyWithAcceptableConcurrency", testUpdateItemConditionallyAtKeyWithAcceptableConcurrency),
+        ("testUpdateItemConditionallyAtKeyWithAcceptableConcurrencyWithAsyncProvider",
+            testUpdateItemConditionallyAtKeyWithAcceptableConcurrencyWithAsyncProvider),
         ("testUpdateItemConditionallyAtKeyWithUnacceptableConcurrency", testUpdateItemConditionallyAtKeyWithUnacceptableConcurrency),
+        ("testUpdateItemConditionallyAtKeyWithUnacceptableConcurrencyWithAsyncProvider",
+            testUpdateItemConditionallyAtKeyWithUnacceptableConcurrencyWithAsyncProvider),
         ("testUpdateItemConditionallyAtKeyWithFailingUpdate", testUpdateItemConditionallyAtKeyWithFailingUpdate),
+        ("testUpdateItemConditionallyAtKeyWithFailingUpdateWithAsyncProvider",
+            testUpdateItemConditionallyAtKeyWithFailingUpdateWithAsyncProvider),
         ("testUpdateItemConditionallyAtKeyWithUnknownItem", testUpdateItemConditionallyAtKeyWithUnknownItem),
+        ("testUpdateItemConditionallyAtKeyWithUnknownItemWithAsyncProvider",
+            testUpdateItemConditionallyAtKeyWithUnknownItemWithAsyncProvider),
     ]
 }


### PR DESCRIPTION
Provide variants for conditionalUpdate* APIs that accept EventLoopFuture returning providers.

*Issue #, if available:*

*Description of changes:* Provide override for conditionalUpdate* APIs that accept EventLoopFuture returning providers. Allows the update provider to make additional async calls to determine if the update should proceed.

**Note:** When async/await lands, the conditionalUpdate* APIs will just be able to take an async function as the provider and Swift will handle the conversion between a sync function and an async function. Until we are fully migrated to async/await, we will need to provide distinct APIs for the two use cases


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
