### PR TITLE
Queue and pagination fixes.

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
@@ -163,7 +163,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                   sortKeyCondition: sortKeyCondition,
                   limit: nil,
                   scanIndexForward: true,
-                  exclusiveStartKey: nil)
+                  exclusiveStartKey: exclusiveStartKey)
         
         return queryFuture.flatMap { paginatedItems in
             // if there are more items

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+getItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+getItems.swift
@@ -41,8 +41,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         let dynamodb: _AWSDynamoDBClient<InvocationReportingType>
         let eventLoop: EventLoop
         
-        private let retryQueue =
-            DispatchQueue(label: "com.amazon.SmokeDynamoDB.AWSDynamoDBCompositePrimaryKeyTable.GetItemsRetriable.retryQueue")
+        private let retryQueue = DispatchQueue.global()
         
         var retriesRemaining: Int
         var input: BatchGetItemInput

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+monomorphicGetItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+monomorphicGetItems.swift
@@ -41,8 +41,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         let dynamodb: _AWSDynamoDBClient<InvocationReportingType>
         let eventLoop: EventLoop
         
-        private let retryQueue =
-            DispatchQueue(label: "com.amazon.SmokeDynamoDB.AWSDynamoDBCompositePrimaryKeyTable.MonomorphicGetItemsRetriable.retryQueue")
+        private let retryQueue = DispatchQueue.global()
         
         var retriesRemaining: Int
         var input: BatchGetItemInput

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionAsync.swift
@@ -45,7 +45,7 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
                   sortKeyCondition: sortKeyCondition,
                   limit: nil,
                   scanIndexForward: true,
-                  exclusiveStartKey: nil)
+                  exclusiveStartKey: exclusiveStartKey)
         
         return queryFuture.flatMap { paginatedItems in
             // if there are more items

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -38,7 +38,9 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
 
     public let eventLoop: EventLoop
     public var store: [String: [String: PolymorphicOperationReturnTypeConvertable]] = [:]
-    let accessQueue = DispatchQueue(label: "com.amazon.SmokeDynamoDB.InMemoryDynamoDBCompositePrimaryKeysProjection.accessQueue")
+    let accessQueue = DispatchQueue(
+        label: "com.amazon.SmokeDynamoDB.InMemoryDynamoDBCompositePrimaryKeysProjection.accessQueue",
+        target: DispatchQueue.global())
 
     public init(eventLoop: EventLoop) {
         self.eventLoop = eventLoop

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
@@ -25,7 +25,9 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
     public var eventLoop: EventLoop
 
     public var keys: [Any] = []
-    private let accessQueue = DispatchQueue(label: "com.amazon.SmokeDynamoDB.InMemoryDynamoDBCompositePrimaryKeysProjection.accessQueue")
+    private let accessQueue = DispatchQueue(
+        label: "com.amazon.SmokeDynamoDB.InMemoryDynamoDBCompositePrimaryKeysProjection.accessQueue",
+        target: DispatchQueue.global())
 
     public init(keys: [Any] = [], eventLoop: EventLoop) {
         self.keys = keys


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Scheduling retries doesn't need a serial queue
2. For InMemory serial queues, target the global queue to avoid thread creation
3. For automatic pagination, actually pass the exclusiveStartKey so pagination will work correctly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
