### PR TITLE
Add execute APIs based on ExecuteStatement

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+execute.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+execute.swift
@@ -29,6 +29,14 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             attributesFilter: [String]?,
             additionalWhereClause: String?,
             nextToken: String?) -> EventLoopFuture<([ReturnedType], String?)> {
+        // if there are no partitions, there will be no results to return
+        // succeed immediately with empty results
+        guard partitionKeys.count > 0 else {
+            let promise = self.eventLoop.makePromise(of: ([ReturnedType], String?).self)
+            promise.succeed(([], nil))
+            return promise.futureResult
+        }
+        
         let statement = getStatement(partitionKeys: partitionKeys,
                                      attributesFilter: attributesFilter,
                                      partitionKeyAttributeName: ReturnedType.AttributesType.partitionKeyAttributeName,
@@ -80,6 +88,14 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             attributesFilter: [String]?,
             additionalWhereClause: String?, nextToken: String?)
     -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> {
+        // if there are no partitions, there will be no results to return
+        // succeed immediately with empty results
+        guard partitionKeys.count > 0 else {
+            let promise = self.eventLoop.makePromise(of: ([TypedDatabaseItem<AttributesType, ItemType>], String?).self)
+            promise.succeed(([], nil))
+            return promise.futureResult
+        }
+        
         let statement = getStatement(partitionKeys: partitionKeys,
                                      attributesFilter: attributesFilter,
                                      partitionKeyAttributeName: AttributesType.partitionKeyAttributeName,

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+execute.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+execute.swift
@@ -1,0 +1,217 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AWSDynamoDBCompositePrimaryKeyTable+execute.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeAWSCore
+import DynamoDBModel
+import SmokeHTTPClient
+import Logging
+import NIO
+
+/// DynamoDBTable conformance execute function
+public extension AWSDynamoDBCompositePrimaryKeyTable {
+    func execute<ReturnedType: PolymorphicOperationReturnType>(
+            partitionKeys: [String],
+            attributes: [String]?,
+            additionalWhereClause: String?,
+            nextToken: String?) -> EventLoopFuture<([ReturnedType], String?)> {
+        let statement = getStatement(partitionKeys: partitionKeys,
+                                     attributes: attributes,
+                                     partitionKeyAttributeName: ReturnedType.AttributesType.partitionKeyAttributeName,
+                                     additionalWhereClause: additionalWhereClause)
+        let executeInput = ExecuteStatementInput(consistentRead: true, nextToken: nextToken, statement: statement)
+        
+        return dynamodb.executeStatement(input: executeInput).flatMapThrowing { executeOutput in
+            let nextToken = executeOutput.nextToken
+            
+            if let outputAttributeValues = executeOutput.items {
+                let items: [ReturnedType]
+                
+                do {
+                    items = try outputAttributeValues.map { values in
+                        let attributeValue = DynamoDBModel.AttributeValue(M: values)
+                        
+                        let decodedItem: ReturnTypeDecodable<ReturnedType> = try DynamoDBDecoder().decode(attributeValue)
+                                                        
+                        return decodedItem.decodedValue
+                    }
+                } catch {
+                    throw error.asUnrecognizedSmokeDynamoDBError()
+                }
+                
+                return (items, nextToken)
+            } else {
+                return ([], nextToken)
+            }
+        } .flatMapErrorThrowing { error in
+            if let typedError = error as? DynamoDBError {
+                throw typedError.asSmokeDynamoDBError()
+            }
+            
+            throw error.asUnrecognizedSmokeDynamoDBError()
+        }
+    }
+    
+    func execute<ReturnedType: PolymorphicOperationReturnType>(partitionKeys: [String],
+                                                               attributes: [String]?,
+                                                               additionalWhereClause: String?) -> EventLoopFuture<[ReturnedType]> {
+        return partialExecute(partitionKeys: partitionKeys,
+                              attributes: attributes,
+                              additionalWhereClause: additionalWhereClause,
+                              nextToken: nil)
+    }
+    
+    func monomorphicExecute<AttributesType, ItemType>(
+            partitionKeys: [String],
+            attributes: [String]?,
+            additionalWhereClause: String?, nextToken: String?)
+    -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> {
+        let statement = getStatement(partitionKeys: partitionKeys,
+                                     attributes: attributes,
+                                     partitionKeyAttributeName: AttributesType.partitionKeyAttributeName,
+                                     additionalWhereClause: additionalWhereClause)
+        let executeInput = ExecuteStatementInput(consistentRead: true, nextToken: nextToken, statement: statement)
+        
+        return dynamodb.executeStatement(input: executeInput).flatMapThrowing { executeOutput in
+            let nextToken = executeOutput.nextToken
+            
+            if let outputAttributeValues = executeOutput.items {
+                let items: [TypedDatabaseItem<AttributesType, ItemType>]
+                
+                do {
+                    items = try outputAttributeValues.map { values in
+                        let attributeValue = DynamoDBModel.AttributeValue(M: values)
+                        
+                        return try DynamoDBDecoder().decode(attributeValue)
+                    }
+                } catch {
+                    throw error.asUnrecognizedSmokeDynamoDBError()
+                }
+                
+                return (items, nextToken)
+            } else {
+                return ([], nextToken)
+            }
+        } .flatMapErrorThrowing { error in
+            if let typedError = error as? DynamoDBError {
+                throw typedError.asSmokeDynamoDBError()
+            }
+            
+            throw error.asUnrecognizedSmokeDynamoDBError()
+        }
+    }
+    
+    func monomorphicExecute<AttributesType, ItemType>(partitionKeys: [String],
+                                                      attributes: [String]?,
+                                                      additionalWhereClause: String?)
+    -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> {
+        return monomorphicPartialExecute(partitionKeys: partitionKeys,
+                                         attributes: attributes,
+                                         additionalWhereClause: additionalWhereClause,
+                                         nextToken: nil)
+    }
+    
+    // function to return a future with the results of an execute call and all future paginated calls
+    private func partialExecute<ReturnedType: PolymorphicOperationReturnType>(
+        partitionKeys: [String],
+                                                          attributes: [String]?,
+                                                          additionalWhereClause: String?,
+            nextToken: String?) -> EventLoopFuture<[ReturnedType]> {
+        let executeFuture: EventLoopFuture<([ReturnedType], String?)> =
+            execute(partitionKeys: partitionKeys,
+                    attributes: attributes,
+                    additionalWhereClause: additionalWhereClause,
+                    nextToken: nextToken)
+        
+        return executeFuture.flatMap { paginatedItems in
+            // if there are more items
+            if let returnedNextToken = paginatedItems.1 {
+                // returns a future with all the results from all later paginated calls
+                return self.partialExecute(partitionKeys: partitionKeys,
+                                           attributes: attributes,
+                                           additionalWhereClause: additionalWhereClause,
+                                           nextToken: returnedNextToken)
+                    .map { partialResult in
+                        // return the results from 'this' call and all later paginated calls
+                        return paginatedItems.0 + partialResult
+                    }
+            } else {
+                // this is it, all results have been obtained
+                let promise = self.eventLoop.makePromise(of: [ReturnedType].self)
+                promise.succeed(paginatedItems.0)
+                return promise.futureResult
+            }
+        }
+    }
+    
+    private func monomorphicPartialExecute<AttributesType, ItemType>(
+            partitionKeys: [String],
+            attributes: [String]?,
+            additionalWhereClause: String?,
+            nextToken: String?) -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> {
+        let executeFuture: EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> =
+            monomorphicExecute(partitionKeys: partitionKeys,
+                               attributes: attributes,
+                               additionalWhereClause: additionalWhereClause,
+                               nextToken: nextToken)
+        
+        return executeFuture.flatMap { paginatedItems in
+            // if there are more items
+            if let returnedNextToken = paginatedItems.1 {
+                // returns a future with all the results from all later paginated calls
+                return self.monomorphicPartialExecute(partitionKeys: partitionKeys,
+                                                      attributes: attributes,
+                                                      additionalWhereClause: additionalWhereClause,
+                                                      nextToken: returnedNextToken)
+                    .map { partialResult in
+                        // return the results from 'this' call and all later paginated calls
+                        return paginatedItems.0 + partialResult
+                    }
+            } else {
+                // this is it, all results have been obtained
+                let promise = self.eventLoop.makePromise(of: [TypedDatabaseItem<AttributesType, ItemType>].self)
+                promise.succeed(paginatedItems.0)
+                return promise.futureResult
+            }
+        }
+    }
+    
+    private func getStatement(partitionKeys: [String],
+                              attributes: [String]?,
+                              partitionKeyAttributeName: String,
+                              additionalWhereClause: String?) -> String {
+        let attributesString = attributes?.joined(separator: ", ") ?? "*"
+        
+        let partitionWhereClause: String
+        if partitionKeys.count == 1 {
+            partitionWhereClause = "\(partitionKeyAttributeName)='\(partitionKeys[0])'"
+        } else {
+            partitionWhereClause = "\(partitionKeyAttributeName) IN ['\(partitionKeys.joined(separator: "', '"))']"
+        }
+        
+        let whereClausePostfix: String
+        if let additionalWhereClause = additionalWhereClause {
+            whereClausePostfix = " \(additionalWhereClause)"
+        } else {
+            whereClausePostfix = ""
+        }
+        
+        return """
+            SELECT \(attributesString) FROM "\(self.targetTableName)" WHERE \(partitionWhereClause)\(whereClausePostfix)
+            """
+    }
+}

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -147,6 +147,27 @@ public protocol DynamoDBCompositePrimaryKeyTable {
                                                              exclusiveStartKey: String?)
         -> EventLoopFuture<([ReturnedType], String?)>
     
+    /**
+     * Uses the ExecuteStatement API to to perform batch reads or writes on data stored in DynamoDB, using PartiQL.
+     * This function will potentially make multiple calls to DynamoDB to retrieve all results.
+     *
+     * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
+     */
+    func execute<ReturnedType: PolymorphicOperationReturnType>(
+        partitionKeys: [String],
+        attributes: [String]?,
+        additionalWhereClause: String?) -> EventLoopFuture<[ReturnedType]>
+    
+    /**
+     * Uses the ExecuteStatement API to to perform batch reads or writes on data stored in DynamoDB, using PartiQL.
+     *
+     * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
+     */
+    func execute<ReturnedType: PolymorphicOperationReturnType>(
+        partitionKeys: [String],
+        attributes: [String]?,
+        additionalWhereClause: String?, nextToken: String?) -> EventLoopFuture<([ReturnedType], String?)>
+    
     // MARK: Monomorphic batch and queries
     
     /**
@@ -177,4 +198,25 @@ public protocol DynamoDBCompositePrimaryKeyTable {
                                                         scanIndexForward: Bool,
                                                         exclusiveStartKey: String?)
         -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
+    
+    /**
+     * Uses the ExecuteStatement API to to perform batch reads or writes on data stored in DynamoDB, using PartiQL.
+     * This function will potentially make multiple calls to DynamoDB to retrieve all results.
+     *
+     * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
+     */
+    func monomorphicExecute<AttributesType, ItemType>(
+        partitionKeys: [String],
+        attributes: [String]?,
+        additionalWhereClause: String?) -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
+    
+    /**
+     * Uses the ExecuteStatement API to to perform batch reads or writes on data stored in DynamoDB, using PartiQL.
+     *
+     * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
+     */
+    func monomorphicExecute<AttributesType, ItemType>(
+        partitionKeys: [String],
+        attributes: [String]?,
+        additionalWhereClause: String?, nextToken: String?) -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
 }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -155,7 +155,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      */
     func execute<ReturnedType: PolymorphicOperationReturnType>(
         partitionKeys: [String],
-        attributes: [String]?,
+        attributesFilter: [String]?,
         additionalWhereClause: String?) -> EventLoopFuture<[ReturnedType]>
     
     /**
@@ -165,7 +165,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      */
     func execute<ReturnedType: PolymorphicOperationReturnType>(
         partitionKeys: [String],
-        attributes: [String]?,
+        attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) -> EventLoopFuture<([ReturnedType], String?)>
     
     // MARK: Monomorphic batch and queries
@@ -207,7 +207,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      */
     func monomorphicExecute<AttributesType, ItemType>(
         partitionKeys: [String],
-        attributes: [String]?,
+        attributesFilter: [String]?,
         additionalWhereClause: String?) -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
     
     /**
@@ -217,6 +217,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      */
     func monomorphicExecute<AttributesType, ItemType>(
         partitionKeys: [String],
-        attributes: [String]?,
+        attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
 }

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable+execute.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable+execute.swift
@@ -25,7 +25,7 @@ public extension InMemoryDynamoDBCompositePrimaryKeyTable {
     
     func execute<ReturnedType: PolymorphicOperationReturnType>(
             partitionKeys: [String],
-            attributes: [String]?,
+            attributesFilter: [String]?,
             additionalWhereClause: String?) -> EventLoopFuture<[ReturnedType]> {
         let promise = self.eventLoop.makePromise(of: [ReturnedType].self)
         
@@ -50,7 +50,7 @@ public extension InMemoryDynamoDBCompositePrimaryKeyTable {
     
     func execute<ReturnedType: PolymorphicOperationReturnType>(
             partitionKeys: [String],
-            attributes: [String]?,
+            attributesFilter: [String]?,
             additionalWhereClause: String?,
             nextToken: String?) -> EventLoopFuture<([ReturnedType], String?)> {
         let promise = self.eventLoop.makePromise(of: ([ReturnedType], String?).self)
@@ -76,7 +76,7 @@ public extension InMemoryDynamoDBCompositePrimaryKeyTable {
     
     func monomorphicExecute<AttributesType, ItemType>(
             partitionKeys: [String],
-            attributes: [String]?,
+            attributesFilter: [String]?,
             additionalWhereClause: String?)
     -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> {
         let promise = self.eventLoop.makePromise(of: [TypedDatabaseItem<AttributesType, ItemType>].self)
@@ -111,7 +111,7 @@ public extension InMemoryDynamoDBCompositePrimaryKeyTable {
     
     func monomorphicExecute<AttributesType, ItemType>(
             partitionKeys: [String],
-            attributes: [String]?,
+            attributesFilter: [String]?,
             additionalWhereClause: String?,
             nextToken: String?)
     -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> {

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable+execute.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable+execute.swift
@@ -1,0 +1,178 @@
+// swiftlint:disable cyclomatic_complexity
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  InMemoryDynamoDBCompositePrimaryKeyTable+execute.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeHTTPClient
+import DynamoDBModel
+import NIO
+
+public extension InMemoryDynamoDBCompositePrimaryKeyTable {
+    
+    func execute<ReturnedType: PolymorphicOperationReturnType>(
+            partitionKeys: [String],
+            attributes: [String]?,
+            additionalWhereClause: String?) -> EventLoopFuture<[ReturnedType]> {
+        let promise = self.eventLoop.makePromise(of: [ReturnedType].self)
+        
+        accessQueue.async {
+            let items = self.getExecuteItems(partitionKeys: partitionKeys, additionalWhereClause: additionalWhereClause)
+               
+            let returnedItems: [ReturnedType]
+            do {
+                returnedItems = try items.map { item in
+                    return try self.convertToQueryableType(input: item)
+                }
+            } catch {
+                promise.fail(error)
+                return
+            }
+            
+            promise.succeed(returnedItems)
+        }
+        
+        return promise.futureResult
+    }
+    
+    func execute<ReturnedType: PolymorphicOperationReturnType>(
+            partitionKeys: [String],
+            attributes: [String]?,
+            additionalWhereClause: String?,
+            nextToken: String?) -> EventLoopFuture<([ReturnedType], String?)> {
+        let promise = self.eventLoop.makePromise(of: ([ReturnedType], String?).self)
+        
+        accessQueue.async {
+            let items = self.getExecuteItems(partitionKeys: partitionKeys, additionalWhereClause: additionalWhereClause)
+               
+            let returnedItems: [ReturnedType]
+            do {
+                returnedItems = try items.map { item in
+                    return try self.convertToQueryableType(input: item)
+                }
+            } catch {
+                promise.fail(error)
+                return
+            }
+            
+            promise.succeed((returnedItems, nil))
+        }
+        
+        return promise.futureResult
+    }
+    
+    func monomorphicExecute<AttributesType, ItemType>(
+            partitionKeys: [String],
+            attributes: [String]?,
+            additionalWhereClause: String?)
+    -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> {
+        let promise = self.eventLoop.makePromise(of: [TypedDatabaseItem<AttributesType, ItemType>].self)
+        
+        accessQueue.async {
+            let items = self.getExecuteItems(partitionKeys: partitionKeys, additionalWhereClause: additionalWhereClause)
+               
+            let returnedItems: [TypedDatabaseItem<AttributesType, ItemType>]
+            do {
+                returnedItems = try items.map { item in
+                    guard let typedItem = item as? TypedDatabaseItem<AttributesType, ItemType> else {
+                        let foundType = type(of: item)
+                        let description = "Expected to decode \(TypedDatabaseItem<AttributesType, ItemType>.self). Instead found \(foundType)."
+                        let context = DecodingError.Context(codingPath: [], debugDescription: description)
+                        let error = DecodingError.typeMismatch(TypedDatabaseItem<AttributesType, ItemType>.self, context)
+                        
+                        throw error
+                    }
+                    
+                    return typedItem
+                }
+            } catch {
+                promise.fail(error)
+                return
+            }
+            
+            promise.succeed(returnedItems)
+        }
+        
+        return promise.futureResult
+    }
+    
+    func monomorphicExecute<AttributesType, ItemType>(
+            partitionKeys: [String],
+            attributes: [String]?,
+            additionalWhereClause: String?,
+            nextToken: String?)
+    -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> {
+        let promise = self.eventLoop.makePromise(of: ([TypedDatabaseItem<AttributesType, ItemType>], String?).self)
+        
+        accessQueue.async {
+            let items = self.getExecuteItems(partitionKeys: partitionKeys, additionalWhereClause: additionalWhereClause)
+               
+            let returnedItems: [TypedDatabaseItem<AttributesType, ItemType>]
+            do {
+                returnedItems = try items.map { item in
+                    guard let typedItem = item as? TypedDatabaseItem<AttributesType, ItemType> else {
+                        let foundType = type(of: item)
+                        let description = "Expected to decode \(TypedDatabaseItem<AttributesType, ItemType>.self). Instead found \(foundType)."
+                        let context = DecodingError.Context(codingPath: [], debugDescription: description)
+                        let error = DecodingError.typeMismatch(TypedDatabaseItem<AttributesType, ItemType>.self, context)
+                        
+                        throw error
+                    }
+                    
+                    return typedItem
+                }
+            } catch {
+                promise.fail(error)
+                return
+            }
+            
+            promise.succeed((returnedItems, nil))
+        }
+        
+        return promise.futureResult
+    }
+    
+    func getExecuteItems(partitionKeys: [String],
+                         additionalWhereClause: String?) -> [PolymorphicOperationReturnTypeConvertable] {
+        var items: [PolymorphicOperationReturnTypeConvertable] = []
+        partitionKeys.forEach { partitionKey in
+            guard let partition = self.store[partitionKey] else {
+                // no such partition, continue
+                return
+            }
+            
+            partition.forEach { (sortKey, databaseItem) in
+                // if there is an additional where clause
+                if let additionalWhereClause = additionalWhereClause {
+                    // there must be an executeItemFilter
+                    if let executeItemFilter = self.executeItemFilter {
+                        if executeItemFilter(partitionKey, sortKey, additionalWhereClause, databaseItem) {
+                            // add if the filter says yes
+                            items.append(databaseItem)
+                        }
+                    } else {
+                        fatalError("An executeItemFilter must be provided when an excute call includes an additionalWhereClause")
+                    }
+                } else {
+                    // otherwise just add the item
+                    items.append(databaseItem)
+                }
+            }
+        }
+        
+        return items
+    }
+}

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -148,11 +148,53 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
                                               exclusiveStartKey: exclusiveStartKey)
     }
     
+    public func execute<ReturnedType: PolymorphicOperationReturnType>(
+            partitionKeys: [String],
+            attributes: [String]?,
+            additionalWhereClause: String?) -> EventLoopFuture<[ReturnedType]> {
+        // simply delegate to the wrapped implementation
+        return wrappedDynamoDBTable.execute(partitionKeys: partitionKeys,
+                                            attributes: attributes,
+                                            additionalWhereClause: additionalWhereClause)
+    }
+    
+    public func execute<ReturnedType: PolymorphicOperationReturnType>(
+            partitionKeys: [String],
+            attributes: [String]?,
+            additionalWhereClause: String?, nextToken: String?) -> EventLoopFuture<([ReturnedType], String?)> {
+        // simply delegate to the wrapped implementation
+        return wrappedDynamoDBTable.execute(partitionKeys: partitionKeys,
+                                            attributes: attributes,
+                                            additionalWhereClause: additionalWhereClause,
+                                            nextToken: nextToken)
+    }
+    
     public func monomorphicGetItems<AttributesType, ItemType>(
         forKeys keys: [CompositePrimaryKey<AttributesType>])
     -> EventLoopFuture<[CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>]> {
         // simply delegate to the wrapped implementation
         return wrappedDynamoDBTable.monomorphicGetItems(forKeys: keys)
+    }
+    
+    public func monomorphicExecute<AttributesType, ItemType>(
+            partitionKeys: [String],
+            attributes: [String]?,
+            additionalWhereClause: String?) -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> {
+        // simply delegate to the wrapped implementation
+        return wrappedDynamoDBTable.monomorphicExecute(partitionKeys: partitionKeys,
+                                                       attributes: attributes,
+                                                       additionalWhereClause: additionalWhereClause)
+    }
+    
+    public func monomorphicExecute<AttributesType, ItemType>(
+            partitionKeys: [String],
+            attributes: [String]?,
+            additionalWhereClause: String?, nextToken: String?) -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> {
+        // simply delegate to the wrapped implementation
+        return wrappedDynamoDBTable.monomorphicExecute(partitionKeys: partitionKeys,
+                                                       attributes: attributes,
+                                                       additionalWhereClause: additionalWhereClause,
+                                                       nextToken: nextToken)
     }
     
     public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -150,21 +150,21 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
     
     public func execute<ReturnedType: PolymorphicOperationReturnType>(
             partitionKeys: [String],
-            attributes: [String]?,
+            attributesFilter: [String]?,
             additionalWhereClause: String?) -> EventLoopFuture<[ReturnedType]> {
         // simply delegate to the wrapped implementation
         return wrappedDynamoDBTable.execute(partitionKeys: partitionKeys,
-                                            attributes: attributes,
+                                            attributesFilter: attributesFilter,
                                             additionalWhereClause: additionalWhereClause)
     }
     
     public func execute<ReturnedType: PolymorphicOperationReturnType>(
             partitionKeys: [String],
-            attributes: [String]?,
+            attributesFilter: [String]?,
             additionalWhereClause: String?, nextToken: String?) -> EventLoopFuture<([ReturnedType], String?)> {
         // simply delegate to the wrapped implementation
         return wrappedDynamoDBTable.execute(partitionKeys: partitionKeys,
-                                            attributes: attributes,
+                                            attributesFilter: attributesFilter,
                                             additionalWhereClause: additionalWhereClause,
                                             nextToken: nextToken)
     }
@@ -178,21 +178,21 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
     
     public func monomorphicExecute<AttributesType, ItemType>(
             partitionKeys: [String],
-            attributes: [String]?,
+            attributesFilter: [String]?,
             additionalWhereClause: String?) -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> {
         // simply delegate to the wrapped implementation
         return wrappedDynamoDBTable.monomorphicExecute(partitionKeys: partitionKeys,
-                                                       attributes: attributes,
+                                                       attributesFilter: attributesFilter,
                                                        additionalWhereClause: additionalWhereClause)
     }
     
     public func monomorphicExecute<AttributesType, ItemType>(
             partitionKeys: [String],
-            attributes: [String]?,
+            attributesFilter: [String]?,
             additionalWhereClause: String?, nextToken: String?) -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> {
         // simply delegate to the wrapped implementation
         return wrappedDynamoDBTable.monomorphicExecute(partitionKeys: partitionKeys,
-                                                       attributes: attributes,
+                                                       attributesFilter: attributesFilter,
                                                        additionalWhereClause: additionalWhereClause,
                                                        nextToken: nextToken)
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add execute APIs for cross-partition statements based on the ExecuteStatement DynamoDb API.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
