### PR TITLE
Provide async provider variants for conditionalUpdate* APIs

### DIFF
--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
@@ -87,4 +87,50 @@ public extension DynamoDBCompositePrimaryKeyTable {
             }
         }
     }
+    
+    func conditionallyUpdateItem<AttributesType, ItemType: Codable>(
+            forKey key: CompositePrimaryKey<AttributesType>,
+            withRetries retries: Int = 10,
+            updatedPayloadProvider: @escaping (ItemType) -> EventLoopFuture<ItemType>) -> EventLoopFuture<Void> {
+        guard retries > 0 else {
+            let error = SmokeDynamoDBError.concurrencyError(partitionKey: key.partitionKey,
+                                                            sortKey: key.sortKey,
+                                                            message: "Unable to complete request to update versioned item in specified number of attempts")
+            
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            promise.fail(error)
+            return promise.futureResult
+        }
+        
+        return getItem(forKey: key).flatMap { (databaseItemOptional: TypedDatabaseItem<AttributesType, ItemType>?) in
+            guard let databaseItem = databaseItemOptional else {
+                let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: key.partitionKey,
+                                                                    sortKey: key.sortKey,
+                                                                    message: "Item not present in database.")
+                
+                let promise = self.eventLoop.makePromise(of: Void.self)
+                promise.fail(error)
+                return promise.futureResult
+            }
+            
+            let updatedPayloadFuture = updatedPayloadProvider(databaseItem.rowValue)
+            
+            return updatedPayloadFuture.flatMap { updatedPayload in
+                let updatedDatabaseItem = databaseItem.createUpdatedItem(withValue: updatedPayload)
+                
+                return self.updateItem(newItem: updatedDatabaseItem, existingItem: databaseItem).flatMapError { error in
+                    if case SmokeDynamoDBError.conditionalCheckFailed = error {
+                        // try again
+                        return self.conditionallyUpdateItem(forKey: key, withRetries: retries - 1,
+                                                            updatedPayloadProvider: updatedPayloadProvider)
+                    } else {
+                        // propagate the error as its not an error causing a retry
+                        let promise = self.eventLoop.makePromise(of: Void.self)
+                        promise.fail(error)
+                        return promise.futureResult
+                    }
+                }
+            }
+        }
+    }
 }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
@@ -79,7 +79,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                     return self.conditionallyUpdateItem(forKey: key, withRetries: retries - 1,
                                                         updatedPayloadProvider: updatedPayloadProvider)
                 } else {
-                    // propagate the error as its not an error causing a retry
+                    // propagate the error as it's not an error causing a retry
                     let promise = self.eventLoop.makePromise(of: Void.self)
                     promise.fail(error)
                     return promise.futureResult
@@ -105,8 +105,8 @@ public extension DynamoDBCompositePrimaryKeyTable {
         return getItem(forKey: key).flatMap { (databaseItemOptional: TypedDatabaseItem<AttributesType, ItemType>?) in
             guard let databaseItem = databaseItemOptional else {
                 let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: key.partitionKey,
-                                                                    sortKey: key.sortKey,
-                                                                    message: "Item not present in database.")
+                                                                      sortKey: key.sortKey,
+                                                                      message: "Item not present in database.")
                 
                 let promise = self.eventLoop.makePromise(of: Void.self)
                 promise.fail(error)
@@ -124,7 +124,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                         return self.conditionallyUpdateItem(forKey: key, withRetries: retries - 1,
                                                             updatedPayloadProvider: updatedPayloadProvider)
                     } else {
-                        // propagate the error as its not an error causing a retry
+                        // propagate the error as it's not an error causing a retry
                         let promise = self.eventLoop.makePromise(of: Void.self)
                         promise.fail(error)
                         return promise.futureResult

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTableHistoricalItemExtensions.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTableHistoricalItemExtensions.swift
@@ -78,7 +78,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                                     historicalItemProvider: historicalItemProvider,
                                                     withRetries: retries - 1)
             } else {
-                // propagate the error as its not an error causing a retry
+                // propagate the error as it's not an error causing a retry
                 let promise = self.eventLoop.makePromise(of: Void.self)
                 promise.fail(error)
                 return promise.futureResult
@@ -231,7 +231,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                                                 primaryItemProvider: primaryItemProvider,
                                                                 historicalItemProvider: historicalItemProvider, withRetries: retries - 1)
             } else {
-                // propagate the error as its not an error causing a retry
+                // propagate the error as it's not an error causing a retry
                 let promise = self.eventLoop.makePromise(of: TypedDatabaseItem<AttributesType, ItemType>.self)
                 promise.fail(error)
                 return promise.futureResult
@@ -254,7 +254,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                                                 primaryItemProvider: primaryItemProvider,
                                                                 historicalItemProvider: historicalItemProvider, withRetries: retries - 1)
             } else {
-                // propagate the error as its not an error causing a retry
+                // propagate the error as it's not an error causing a retry
                 let promise = self.eventLoop.makePromise(of: TypedDatabaseItem<AttributesType, ItemType>.self)
                 promise.fail(error)
                 return promise.futureResult

--- a/Tests/SmokeDynamoDBTests/DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests.swift
+++ b/Tests/SmokeDynamoDBTests/DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests.swift
@@ -42,6 +42,16 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         return TestTypeA(firstly: "firstlyX2", secondly: "secondlyX2")
     }
     
+    func getUpdatedPayloadProviderAsync(on eventLoop: EventLoop) -> ((TestTypeA) -> EventLoopFuture<TestTypeA>) {
+        func provider(item: TestTypeA) -> EventLoopFuture<TestTypeA> {
+            let promise = eventLoop.makePromise(of: TestTypeA.self)
+            promise.succeed(TestTypeA(firstly: "firstlyX2", secondly: "secondlyX2"))
+            return promise.futureResult
+        }
+        
+        return provider
+    }
+    
     func testUpdateItemConditionallyAtKey() {
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
@@ -59,6 +69,32 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         XCTAssertEqual(databaseItem.rowValue.secondly, retrievedItem.rowValue.secondly)
         
         XCTAssertNoThrow(try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: updatedPayloadProvider).wait())
+        
+        let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual("sortId", secondRetrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual("firstlyX2", secondRetrievedItem.rowValue.firstly)
+        XCTAssertEqual("secondlyX2", secondRetrievedItem.rowValue.secondly)
+    }
+    
+    func testUpdateItemConditionallyAtKeyWithAsyncProvider() {
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
+        
+        let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
+                                                     sortKey: "sortId")
+        let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
+        
+        XCTAssertNoThrow(try table.insertItem(databaseItem).wait())
+        
+        let retrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual(databaseItem.compositePrimaryKey.sortKey, retrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual(databaseItem.rowValue.firstly, retrievedItem.rowValue.firstly)
+        XCTAssertEqual(databaseItem.rowValue.secondly, retrievedItem.rowValue.secondly)
+        
+        let asyncUpdatedPayloadProvider = getUpdatedPayloadProviderAsync(on: self.eventLoop)
+        XCTAssertNoThrow(try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: asyncUpdatedPayloadProvider).wait())
         
         let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
         
@@ -95,6 +131,35 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         XCTAssertEqual("secondlyX2", secondRetrievedItem.rowValue.secondly)
     }
     
+    func testUpdateItemConditionallyAtKeyWithAcceptableConcurrencyWithAsyncProvider() {
+        let wrappedTable = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
+        let table = SimulateConcurrencyDynamoDBCompositePrimaryKeyTable(wrappedDynamoDBTable: wrappedTable, eventLoop: eventLoop,
+                                                     simulateConcurrencyModifications: 5,
+                                                     simulateOnInsertItem: false)
+        
+        let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
+                                                     sortKey: "sortId")
+        let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
+        
+        XCTAssertNoThrow(try table.insertItem(databaseItem).wait())
+        
+        let retrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual(databaseItem.compositePrimaryKey.sortKey, retrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual(databaseItem.rowValue.firstly, retrievedItem.rowValue.firstly)
+        XCTAssertEqual(databaseItem.rowValue.secondly, retrievedItem.rowValue.secondly)
+        
+        let asyncUpdatedPayloadProvider = getUpdatedPayloadProviderAsync(on: self.eventLoop)
+        XCTAssertNoThrow(try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: asyncUpdatedPayloadProvider).wait())
+        
+        let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual("sortId", secondRetrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual("firstlyX2", secondRetrievedItem.rowValue.firstly)
+        XCTAssertEqual("secondlyX2", secondRetrievedItem.rowValue.secondly)
+    }
+    
     func testUpdateItemConditionallyAtKeyWithUnacceptableConcurrency() {
         let wrappedTable = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         let table = SimulateConcurrencyDynamoDBCompositePrimaryKeyTable(wrappedDynamoDBTable: wrappedTable, eventLoop: eventLoop,
@@ -116,6 +181,44 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         
         do {
             try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: updatedPayloadProvider).wait()
+            
+            XCTFail("Expected concurrency error not thrown.")
+        } catch SmokeDynamoDBError.concurrencyError {
+            // expected error thrown
+        } catch {
+            XCTFail("Unexpected error thrown: \(error).")
+        }
+        
+        let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual("sortId", secondRetrievedItem.compositePrimaryKey.sortKey)
+        // Check the item hasn't been updated
+        XCTAssertEqual("firstly", secondRetrievedItem.rowValue.firstly)
+        XCTAssertEqual("secondly", secondRetrievedItem.rowValue.secondly)
+    }
+    
+    func testUpdateItemConditionallyAtKeyWithUnacceptableConcurrencyWithAsyncProvider() {
+        let wrappedTable = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
+        let table = SimulateConcurrencyDynamoDBCompositePrimaryKeyTable(wrappedDynamoDBTable: wrappedTable, eventLoop: eventLoop,
+                                                     simulateConcurrencyModifications: 100,
+                                                     simulateOnInsertItem: false)
+        
+        let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
+                                                     sortKey: "sortId")
+        let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
+        
+        XCTAssertNoThrow(try table.insertItem(databaseItem).wait())
+        
+        let retrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual(databaseItem.compositePrimaryKey.sortKey, retrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual(databaseItem.rowValue.firstly, retrievedItem.rowValue.firstly)
+        XCTAssertEqual(databaseItem.rowValue.secondly, retrievedItem.rowValue.secondly)
+        
+        let asyncUpdatedPayloadProvider = getUpdatedPayloadProviderAsync(on: self.eventLoop)
+        do {
+            try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: asyncUpdatedPayloadProvider).wait()
             
             XCTFail("Expected concurrency error not thrown.")
         } catch SmokeDynamoDBError.concurrencyError {
@@ -185,6 +288,58 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         XCTAssertEqual("secondly", secondRetrievedItem.rowValue.secondly)
     }
     
+    func testUpdateItemConditionallyAtKeyWithFailingUpdateWithAsyncProvider() {
+        let wrappedTable = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
+        let table = SimulateConcurrencyDynamoDBCompositePrimaryKeyTable(wrappedDynamoDBTable: wrappedTable, eventLoop: eventLoop,
+                                                     simulateConcurrencyModifications: 100,
+                                                     simulateOnInsertItem: false)
+        
+        let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
+                                                     sortKey: "sortId")
+        let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
+        
+        XCTAssertNoThrow(try table.insertItem(databaseItem).wait())
+        
+        let retrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual(databaseItem.compositePrimaryKey.sortKey, retrievedItem.compositePrimaryKey.sortKey)
+        XCTAssertEqual(databaseItem.rowValue.firstly, retrievedItem.rowValue.firstly)
+        XCTAssertEqual(databaseItem.rowValue.secondly, retrievedItem.rowValue.secondly)
+        
+        var passCount = 0
+        
+        func failingUpdatedPayloadProvider(item: TestTypeA) -> EventLoopFuture<TestTypeA> {
+            let promise = eventLoop.makePromise(of: TestTypeA.self)
+            if passCount < 5 {
+                passCount += 1
+                promise.succeed(TestTypeA(firstly: "firstlyX2", secondly: "secondlyX2"))
+            } else {
+                // fail before the retry limit with a custom error
+                promise.fail(TestError.everythingIsWrong)
+            }
+            
+            return promise.futureResult
+        }
+        
+        do {
+            try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: failingUpdatedPayloadProvider).wait()
+            
+            XCTFail("Expected everythingIsWrong error not thrown.")
+        } catch TestError.everythingIsWrong {
+            // expected error thrown
+        } catch {
+            XCTFail("Unexpected error thrown: \(error).")
+        }
+        
+        let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA> = try! table.getItem(forKey: key).wait()!
+        
+        XCTAssertEqual("sortId", secondRetrievedItem.compositePrimaryKey.sortKey)
+        // Check the item hasn't been updated
+        XCTAssertEqual("firstly", secondRetrievedItem.rowValue.firstly)
+        XCTAssertEqual("secondly", secondRetrievedItem.rowValue.secondly)
+    }
+    
     func testUpdateItemConditionallyAtKeyWithUnknownItem() {
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
@@ -206,11 +361,42 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         XCTAssertNil(secondRetrievedItem)
     }
     
+    func testUpdateItemConditionallyAtKeyWithUnknownItemWithAsyncProvider() {
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
+        
+        let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
+                                                     sortKey: "sortId")
+        
+        let asyncUpdatedPayloadProvider = getUpdatedPayloadProviderAsync(on: self.eventLoop)
+        do {
+            try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: asyncUpdatedPayloadProvider).wait()
+            
+            XCTFail("Expected concurrency error not thrown.")
+        } catch SmokeDynamoDBError.conditionalCheckFailed {
+            // expected error thrown
+        } catch {
+            XCTFail("Unexpected error thrown: \(error).")
+        }
+        
+        let secondRetrievedItem: StandardTypedDatabaseItem<TestTypeA>? = try! table.getItem(forKey: key).wait()
+        
+        XCTAssertNil(secondRetrievedItem)
+    }
+    
     static var allTests = [
         ("testUpdateItemConditionallyAtKey", testUpdateItemConditionallyAtKey),
+        ("testUpdateItemConditionallyAtKeyWithAsyncProvider", testUpdateItemConditionallyAtKeyWithAsyncProvider),
         ("testUpdateItemConditionallyAtKeyWithAcceptableConcurrency", testUpdateItemConditionallyAtKeyWithAcceptableConcurrency),
+        ("testUpdateItemConditionallyAtKeyWithAcceptableConcurrencyWithAsyncProvider",
+            testUpdateItemConditionallyAtKeyWithAcceptableConcurrencyWithAsyncProvider),
         ("testUpdateItemConditionallyAtKeyWithUnacceptableConcurrency", testUpdateItemConditionallyAtKeyWithUnacceptableConcurrency),
+        ("testUpdateItemConditionallyAtKeyWithUnacceptableConcurrencyWithAsyncProvider",
+            testUpdateItemConditionallyAtKeyWithUnacceptableConcurrencyWithAsyncProvider),
         ("testUpdateItemConditionallyAtKeyWithFailingUpdate", testUpdateItemConditionallyAtKeyWithFailingUpdate),
+        ("testUpdateItemConditionallyAtKeyWithFailingUpdateWithAsyncProvider",
+            testUpdateItemConditionallyAtKeyWithFailingUpdateWithAsyncProvider),
         ("testUpdateItemConditionallyAtKeyWithUnknownItem", testUpdateItemConditionallyAtKeyWithUnknownItem),
+        ("testUpdateItemConditionallyAtKeyWithUnknownItemWithAsyncProvider",
+            testUpdateItemConditionallyAtKeyWithUnknownItemWithAsyncProvider),
     ]
 }

--- a/Tests/SmokeDynamoDBTests/DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests.swift
+++ b/Tests/SmokeDynamoDBTests/DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests.swift
@@ -56,7 +56,7 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                     sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -81,7 +81,7 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                     sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -110,7 +110,7 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
                                                      simulateOnInsertItem: false)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                     sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -138,7 +138,7 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
                                                      simulateOnInsertItem: false)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                     sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -167,7 +167,7 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
                                                      simulateOnInsertItem: false)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                     sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -204,7 +204,7 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
                                                      simulateOnInsertItem: false)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                     sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -246,7 +246,7 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
                                                      simulateOnInsertItem: false)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                     sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -295,7 +295,7 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
                                                      simulateOnInsertItem: false)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                     sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -344,7 +344,7 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                     sortKey: "sortId")
+                                              sortKey: "sortId")
         
         do {
             try table.conditionallyUpdateItem(forKey: key, updatedPayloadProvider: updatedPayloadProvider).wait()
@@ -365,7 +365,7 @@ class DynamoDBCompositePrimaryKeyTableUpdateItemConditionallyAtKeyTests: XCTestC
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                     sortKey: "sortId")
+                                              sortKey: "sortId")
         
         let asyncUpdatedPayloadProvider = getUpdatedPayloadProviderAsync(on: self.eventLoop)
         do {

--- a/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
@@ -54,7 +54,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                        sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -81,7 +81,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                        sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -101,7 +101,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                        sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let updatedPayload = TestTypeA(firstly: "firstlyX2", secondly: "secondlyX2")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
@@ -125,7 +125,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         // add to the database a lot of items - a number that isn't a multiple of the pagination page size
         for index in 0..<1376 {
             let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                        sortKey: "sortId_\(index)")
+                                                  sortKey: "sortId_\(index)")
             let payload = TestTypeA(firstly: "firstly_\(index)", secondly: "secondly_\(index)")
             let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
             
@@ -184,7 +184,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         // add to the database a lot of items - a number that isn't a multiple of the pagination page size
         for index in 0..<1376 {
             let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                        sortKey: "sortId_\(index)")
+                                                  sortKey: "sortId_\(index)")
             let payload = TestTypeA(firstly: "firstly_\(index)", secondly: "secondly_\(index)")
             let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
             
@@ -244,7 +244,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         // add to the database a lot of items - a number that isn't a multiple of the pagination page size
         for index in 0..<1376 {
             let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                        sortKey: "sortId_\(index)")
+                                                  sortKey: "sortId_\(index)")
             let payload = TestTypeA(firstly: "firstly_\(index)", secondly: "secondly_\(index)")
             let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
             
@@ -276,7 +276,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         // add to the database a lot of items - a number that isn't a multiple of the pagination page size
         for index in 0..<1376 {
             let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                        sortKey: "sortId_\(index)")
+                                                  sortKey: "sortId_\(index)")
             let payload = TestTypeA(firstly: "firstly_\(index)", secondly: "secondly_\(index)")
             let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
             
@@ -304,7 +304,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                        sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -323,7 +323,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                        sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         
@@ -342,7 +342,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                        sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let updatedPayload = TestTypeA(firstly: "firstlyX2", secondly: "secondlyX2")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
@@ -370,7 +370,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop)
         
         let key = StandardCompositePrimaryKey(partitionKey: "partitionId",
-                                                        sortKey: "sortId")
+                                              sortKey: "sortId")
         let payload = TestTypeA(firstly: "firstly", secondly: "secondly")
         let databaseItem = StandardTypedDatabaseItem.newItem(withKey: key, andValue: payload)
         


### PR DESCRIPTION
…ure returning providers.

*Issue #, if available:*

*Description of changes:* Provide variants for conditionalUpdate* APIs that accept EventLoopFuture returning providers. Allows the update provider to make additional async calls to determine if the update should proceed.

**Note**: When async/await lands, the conditionalUpdate* APIs will just be able to take an async function as the provider and Swift will handle the conversion between a sync function and an async function. Until we are fully migrated to async/await, we will need to provide distinct APIs for the two use cases


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
