### PR TITLE
Provide the ability to use different event loops with the same InMemory* data store

### DIFF
--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -43,7 +43,11 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
     internal let storeWrapper: InMemoryDynamoDBCompositePrimaryKeyTableStore
     
     public var store: [String: [String: PolymorphicOperationReturnTypeConvertable]] {
-        return storeWrapper.store
+        do {
+            return try storeWrapper.getStore(eventLoop: self.eventLoop).wait()
+        } catch {
+            fatalError("Unable to retrieve InMemoryDynamoDBCompositePrimaryKeyTable store.")
+        }
     }
     
     public init(eventLoop: EventLoop,

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore+execute.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore+execute.swift
@@ -12,7 +12,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  InMemoryDynamoDBCompositePrimaryKeyTable+execute.swift
+//  InMemoryDynamoDBCompositePrimaryKeyTableStore+execute.swift
 //  SmokeDynamoDB
 //
 
@@ -21,13 +21,14 @@ import SmokeHTTPClient
 import DynamoDBModel
 import NIO
 
-public extension InMemoryDynamoDBCompositePrimaryKeyTable {
+extension InMemoryDynamoDBCompositePrimaryKeyTableStore {
     
     func execute<ReturnedType: PolymorphicOperationReturnType>(
             partitionKeys: [String],
             attributesFilter: [String]?,
-            additionalWhereClause: String?) -> EventLoopFuture<[ReturnedType]> {
-        let promise = self.eventLoop.makePromise(of: [ReturnedType].self)
+            additionalWhereClause: String?,
+            eventLoop: EventLoop) -> EventLoopFuture<[ReturnedType]> {
+        let promise = eventLoop.makePromise(of: [ReturnedType].self)
         
         accessQueue.async {
             let items = self.getExecuteItems(partitionKeys: partitionKeys, additionalWhereClause: additionalWhereClause)
@@ -52,8 +53,9 @@ public extension InMemoryDynamoDBCompositePrimaryKeyTable {
             partitionKeys: [String],
             attributesFilter: [String]?,
             additionalWhereClause: String?,
-            nextToken: String?) -> EventLoopFuture<([ReturnedType], String?)> {
-        let promise = self.eventLoop.makePromise(of: ([ReturnedType], String?).self)
+            nextToken: String?,
+            eventLoop: EventLoop) -> EventLoopFuture<([ReturnedType], String?)> {
+        let promise = eventLoop.makePromise(of: ([ReturnedType], String?).self)
         
         accessQueue.async {
             let items = self.getExecuteItems(partitionKeys: partitionKeys, additionalWhereClause: additionalWhereClause)
@@ -77,9 +79,10 @@ public extension InMemoryDynamoDBCompositePrimaryKeyTable {
     func monomorphicExecute<AttributesType, ItemType>(
             partitionKeys: [String],
             attributesFilter: [String]?,
-            additionalWhereClause: String?)
+            additionalWhereClause: String?,
+            eventLoop: EventLoop)
     -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> {
-        let promise = self.eventLoop.makePromise(of: [TypedDatabaseItem<AttributesType, ItemType>].self)
+        let promise = eventLoop.makePromise(of: [TypedDatabaseItem<AttributesType, ItemType>].self)
         
         accessQueue.async {
             let items = self.getExecuteItems(partitionKeys: partitionKeys, additionalWhereClause: additionalWhereClause)
@@ -113,9 +116,10 @@ public extension InMemoryDynamoDBCompositePrimaryKeyTable {
             partitionKeys: [String],
             attributesFilter: [String]?,
             additionalWhereClause: String?,
-            nextToken: String?)
+            nextToken: String?,
+            eventLoop: EventLoop)
     -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> {
-        let promise = self.eventLoop.makePromise(of: ([TypedDatabaseItem<AttributesType, ItemType>], String?).self)
+        let promise = eventLoop.makePromise(of: ([TypedDatabaseItem<AttributesType, ItemType>], String?).self)
         
         accessQueue.async {
             let items = self.getExecuteItems(partitionKeys: partitionKeys, additionalWhereClause: additionalWhereClause)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -127,8 +127,8 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
                     }
                 } else {
                     let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: newItem.compositePrimaryKey.partitionKey,
-                                                                  sortKey: newItem.compositePrimaryKey.sortKey,
-                                                                  message: "Existing item does not exist.")
+                                                                          sortKey: newItem.compositePrimaryKey.sortKey,
+                                                                          message: "Existing item does not exist.")
                     promise.fail(error)
                     return
                 }
@@ -361,7 +361,7 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         if let provider = queryableTypeProviders[storedRowTypeName] {
             return try provider.getReturnType(input: input)
         } else {
-            // throw an exception, we don't what this type is
+            // throw an exception, we don't know what this type is
             throw SmokeDynamoDBError.unexpectedType(provided: storedRowTypeName)
         }
     }

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -1,0 +1,417 @@
+// swiftlint:disable cyclomatic_complexity
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeHTTPClient
+import DynamoDBModel
+import NIO
+
+internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
+
+    public var store: [String: [String: PolymorphicOperationReturnTypeConvertable]] = [:]
+    internal let accessQueue = DispatchQueue(
+        label: "com.amazon.SmokeDynamoDB.InMemoryDynamoDBCompositePrimaryKeyTable.accessQueue",
+        target: DispatchQueue.global())
+    
+    internal let executeItemFilter: ExecuteItemFilterType?
+
+    public init(executeItemFilter: ExecuteItemFilterType? = nil) {
+        self.executeItemFilter = executeItemFilter
+    }
+
+    public func insertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
+                                                     eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        let promise = eventLoop.makePromise(of: Void.self)
+        
+        accessQueue.async {
+            let partition = self.store[item.compositePrimaryKey.partitionKey]
+
+            // if there is already a partition
+            var updatedPartition: [String: PolymorphicOperationReturnTypeConvertable]
+            if let partition = partition {
+                updatedPartition = partition
+
+                // if the row already exists
+                if partition[item.compositePrimaryKey.sortKey] != nil {
+                    let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: item.compositePrimaryKey.partitionKey,
+                                                                          sortKey: item.compositePrimaryKey.sortKey,
+                                                                          message: "Row already exists.")
+                    
+                    promise.fail(error)
+                    return
+                }
+
+                updatedPartition[item.compositePrimaryKey.sortKey] = item
+            } else {
+                updatedPartition = [item.compositePrimaryKey.sortKey: item]
+            }
+
+            self.store[item.compositePrimaryKey.partitionKey] = updatedPartition
+            promise.succeed(())
+        }
+        
+        return promise.futureResult
+    }
+
+    public func clobberItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
+                                                      eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        let promise = eventLoop.makePromise(of: Void.self)
+        
+        accessQueue.async {
+            let partition = self.store[item.compositePrimaryKey.partitionKey]
+
+            // if there is already a partition
+            var updatedPartition: [String: PolymorphicOperationReturnTypeConvertable]
+            if let partition = partition {
+                updatedPartition = partition
+
+                updatedPartition[item.compositePrimaryKey.sortKey] = item
+            } else {
+                updatedPartition = [item.compositePrimaryKey.sortKey: item]
+            }
+
+            self.store[item.compositePrimaryKey.partitionKey] = updatedPartition
+            promise.succeed(())
+        }
+        
+        return promise.futureResult
+    }
+
+    public func updateItem<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                     existingItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                     eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        let promise = eventLoop.makePromise(of: Void.self)
+        
+        accessQueue.async {
+            let partition = self.store[newItem.compositePrimaryKey.partitionKey]
+
+            // if there is already a partition
+            var updatedPartition: [String: PolymorphicOperationReturnTypeConvertable]
+            if let partition = partition {
+                updatedPartition = partition
+
+                // if the row already exists
+                if let actuallyExistingItem = partition[newItem.compositePrimaryKey.sortKey] {
+                    if existingItem.rowStatus.rowVersion != actuallyExistingItem.rowStatus.rowVersion ||
+                        existingItem.createDate.iso8601 != actuallyExistingItem.createDate.iso8601 {
+                        let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: newItem.compositePrimaryKey.partitionKey,
+                                                                              sortKey: newItem.compositePrimaryKey.sortKey,
+                                                                              message: "Trying to overwrite incorrect version.")
+                        promise.fail(error)
+                        return
+                    }
+                } else {
+                    let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: newItem.compositePrimaryKey.partitionKey,
+                                                                  sortKey: newItem.compositePrimaryKey.sortKey,
+                                                                  message: "Existing item does not exist.")
+                    promise.fail(error)
+                    return
+                }
+
+                updatedPartition[newItem.compositePrimaryKey.sortKey] = newItem
+            } else {
+                let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: newItem.compositePrimaryKey.partitionKey,
+                                                                      sortKey: newItem.compositePrimaryKey.sortKey,
+                                                                      message: "Existing item does not exist.")
+                promise.fail(error)
+                return
+            }
+
+            self.store[newItem.compositePrimaryKey.partitionKey] = updatedPartition
+            promise.succeed(())
+        }
+        
+        return promise.futureResult
+    }
+
+    public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>,
+                                                  eventLoop: EventLoop)
+        -> EventLoopFuture<TypedDatabaseItem<AttributesType, ItemType>?> {
+        let promise = eventLoop.makePromise(of: TypedDatabaseItem<AttributesType, ItemType>?.self)
+        
+        accessQueue.async {
+            if let partition = self.store[key.partitionKey] {
+
+                guard let value = partition[key.sortKey] else {
+                    promise.succeed(nil)
+                    return
+                }
+
+                guard let item = value as? TypedDatabaseItem<AttributesType, ItemType> else {
+                    let foundType = type(of: value)
+                    let description = "Expected to decode \(TypedDatabaseItem<AttributesType, ItemType>.self). Instead found \(foundType)."
+                    let context = DecodingError.Context(codingPath: [], debugDescription: description)
+                    let error = DecodingError.typeMismatch(TypedDatabaseItem<AttributesType, ItemType>.self, context)
+                    
+                    promise.fail(error)
+                    return
+                }
+
+                promise.succeed(item)
+                return
+            }
+
+            promise.succeed(nil)
+        }
+        
+        return promise.futureResult
+    }
+    
+    public func getItems<ReturnedType: PolymorphicOperationReturnType & BatchCapableReturnType>(
+        forKeys keys: [CompositePrimaryKey<ReturnedType.AttributesType>],
+        eventLoop: EventLoop)
+    -> EventLoopFuture<[CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType]> {
+        let promise = eventLoop.makePromise(of: [CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType].self)
+        
+        accessQueue.async {
+            var map: [CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType] = [:]
+            
+            keys.forEach { key in
+                if let partition = self.store[key.partitionKey] {
+
+                    guard let value = partition[key.sortKey] else {
+                        return
+                    }
+                    
+                    let itemAsReturnedType: ReturnedType
+                        
+                    do {
+                        itemAsReturnedType = try self.convertToQueryableType(input: value)
+                    } catch {
+                        promise.fail(error)
+                        return
+                    }
+                    
+                    map[key] = itemAsReturnedType
+                }
+            }
+            
+            promise.succeed(map)
+        }
+        
+        return promise.futureResult
+    }
+
+    public func deleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>,
+                                           eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        let promise = eventLoop.makePromise(of: Void.self)
+        
+        accessQueue.async {
+            self.store[key.partitionKey]?[key.sortKey] = nil
+            promise.succeed(())
+        }
+        
+        return promise.futureResult
+    }
+    
+    public func deleteItem<AttributesType, ItemType>(existingItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                     eventLoop: EventLoop) -> EventLoopFuture<Void>
+            where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
+        let promise = eventLoop.makePromise(of: Void.self)
+        
+        accessQueue.async {
+            let partition = self.store[existingItem.compositePrimaryKey.partitionKey]
+
+            // if there is already a partition
+            var updatedPartition: [String: PolymorphicOperationReturnTypeConvertable]
+            if let partition = partition {
+                updatedPartition = partition
+
+                // if the row already exists
+                if let actuallyExistingItem = partition[existingItem.compositePrimaryKey.sortKey] {
+                    if existingItem.rowStatus.rowVersion != actuallyExistingItem.rowStatus.rowVersion ||
+                    existingItem.createDate.iso8601 != actuallyExistingItem.createDate.iso8601 {
+                        let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: existingItem.compositePrimaryKey.partitionKey,
+                                                                              sortKey: existingItem.compositePrimaryKey.sortKey,
+                                                                              message: "Trying to delete incorrect version.")
+                        
+                        promise.fail(error)
+                        return
+                    }
+                } else {
+                    let error =  SmokeDynamoDBError.conditionalCheckFailed(partitionKey: existingItem.compositePrimaryKey.partitionKey,
+                                                                           sortKey: existingItem.compositePrimaryKey.sortKey,
+                                                                           message: "Existing item does not exist.")
+                    
+                    promise.fail(error)
+                    return
+                }
+
+                updatedPartition[existingItem.compositePrimaryKey.sortKey] = nil
+            } else {
+                let error =  SmokeDynamoDBError.conditionalCheckFailed(partitionKey: existingItem.compositePrimaryKey.partitionKey,
+                                                                       sortKey: existingItem.compositePrimaryKey.sortKey,
+                                                                       message: "Existing item does not exist.")
+                
+                promise.fail(error)
+                return
+            }
+
+            self.store[existingItem.compositePrimaryKey.partitionKey] = updatedPartition
+            promise.succeed(())
+        }
+        
+        return promise.futureResult
+    }
+
+    public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                                    sortKeyCondition: AttributeCondition?,
+                                                                    eventLoop: EventLoop)
+        -> EventLoopFuture<[ReturnedType]> {
+        let promise = eventLoop.makePromise(of: [ReturnedType].self)
+        
+        accessQueue.async {
+            var items: [ReturnedType] = []
+
+            if let partition = self.store[partitionKey] {
+                let sortedPartition = partition.sorted(by: { (left, right) -> Bool in
+                    return left.key < right.key
+                })
+                
+                sortKeyIteration: for (sortKey, value) in sortedPartition {
+
+                    if let currentSortKeyCondition = sortKeyCondition {
+                        switch currentSortKeyCondition {
+                        case .equals(let value):
+                            if !(value == sortKey) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .lessThan(let value):
+                            if !(sortKey < value) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .lessThanOrEqual(let value):
+                            if !(sortKey <= value) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .greaterThan(let value):
+                            if !(sortKey > value) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .greaterThanOrEqual(let value):
+                            if !(sortKey >= value) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .between(let value1, let value2):
+                            if !(sortKey > value1 && sortKey < value2) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        case .beginsWith(let value):
+                            if !(sortKey.hasPrefix(value)) {
+                                // don't include this in the results
+                                continue sortKeyIteration
+                            }
+                        }
+                    }
+
+                    do {
+                        items.append(try self.convertToQueryableType(input: value))
+                    } catch {
+                        promise.fail(error)
+                        return
+                    }
+                }
+            }
+
+            promise.succeed(items)
+        }
+        
+        return promise.futureResult
+    }
+    
+    internal func convertToQueryableType<ReturnedType: PolymorphicOperationReturnType>(input: PolymorphicOperationReturnTypeConvertable) throws -> ReturnedType {
+        let storedRowTypeName = input.rowTypeIdentifier
+        
+        var queryableTypeProviders: [String: PolymorphicOperationReturnOption<ReturnedType.AttributesType, ReturnedType>] = [:]
+        ReturnedType.types.forEach { (type, provider) in
+            queryableTypeProviders[getTypeRowIdentifier(type: type)] = provider
+        }
+
+        if let provider = queryableTypeProviders[storedRowTypeName] {
+            return try provider.getReturnType(input: input)
+        } else {
+            // throw an exception, we don't what this type is
+            throw SmokeDynamoDBError.unexpectedType(provided: storedRowTypeName)
+        }
+    }
+    
+    public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                                    sortKeyCondition: AttributeCondition?,
+                                                                    limit: Int?,
+                                                                    exclusiveStartKey: String?,
+                                                                    eventLoop: EventLoop)
+            -> EventLoopFuture<([ReturnedType], String?)> {
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     limit: limit,
+                     scanIndexForward: true,
+                     exclusiveStartKey: exclusiveStartKey,
+                     eventLoop: eventLoop)
+    }
+
+    public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                                    sortKeyCondition: AttributeCondition?,
+                                                                    limit: Int?,
+                                                                    scanIndexForward: Bool,
+                                                                    exclusiveStartKey: String?,
+                                                                    eventLoop: EventLoop)
+            -> EventLoopFuture<([ReturnedType], String?)> {
+        // get all the results
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     eventLoop: eventLoop)
+            .map { (rawItems: [ReturnedType]) in
+                let items: [ReturnedType]
+                if !scanIndexForward {
+                    items = rawItems.reversed()
+                } else {
+                    items = rawItems
+                }
+
+                let startIndex: Int
+                // if there is an exclusiveStartKey
+                if let exclusiveStartKey = exclusiveStartKey {
+                    guard let storedStartIndex = Int(exclusiveStartKey) else {
+                        fatalError("Unexpectedly encoded exclusiveStartKey '\(exclusiveStartKey)'")
+                    }
+
+                    startIndex = storedStartIndex
+                } else {
+                    startIndex = 0
+                }
+
+                let endIndex: Int
+                let lastEvaluatedKey: String?
+                if let limit = limit, startIndex + limit < items.count {
+                    endIndex = startIndex + limit
+                    lastEvaluatedKey = String(endIndex)
+                } else {
+                    endIndex = items.count
+                    lastEvaluatedKey = nil
+                }
+
+                return (Array(items[startIndex..<endIndex]), lastEvaluatedKey)
+            }
+    }
+}

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -23,19 +23,29 @@ import NIO
 
 internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
 
-    public var store: [String: [String: PolymorphicOperationReturnTypeConvertable]] = [:]
+    internal var store: [String: [String: PolymorphicOperationReturnTypeConvertable]] = [:]
     internal let accessQueue = DispatchQueue(
         label: "com.amazon.SmokeDynamoDB.InMemoryDynamoDBCompositePrimaryKeyTable.accessQueue",
         target: DispatchQueue.global())
     
     internal let executeItemFilter: ExecuteItemFilterType?
 
-    public init(executeItemFilter: ExecuteItemFilterType? = nil) {
+    init(executeItemFilter: ExecuteItemFilterType? = nil) {
         self.executeItemFilter = executeItemFilter
     }
+    
+    func getStore(eventLoop: EventLoop) -> EventLoopFuture<[String: [String: PolymorphicOperationReturnTypeConvertable]]> {
+        let promise = eventLoop.makePromise(of: [String: [String: PolymorphicOperationReturnTypeConvertable]].self)
+        
+        accessQueue.async {
+            promise.succeed(self.store)
+        }
+        
+        return promise.futureResult
+    }
 
-    public func insertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
-                                                     eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    func insertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
+                                              eventLoop: EventLoop) -> EventLoopFuture<Void> {
         let promise = eventLoop.makePromise(of: Void.self)
         
         accessQueue.async {
@@ -68,8 +78,8 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         return promise.futureResult
     }
 
-    public func clobberItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
-                                                      eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    func clobberItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
+                                               eventLoop: EventLoop) -> EventLoopFuture<Void> {
         let promise = eventLoop.makePromise(of: Void.self)
         
         accessQueue.async {
@@ -92,9 +102,9 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         return promise.futureResult
     }
 
-    public func updateItem<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
-                                                     existingItem: TypedDatabaseItem<AttributesType, ItemType>,
-                                                     eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    func updateItem<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                              existingItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                              eventLoop: EventLoop) -> EventLoopFuture<Void> {
         let promise = eventLoop.makePromise(of: Void.self)
         
         accessQueue.async {
@@ -139,8 +149,8 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         return promise.futureResult
     }
 
-    public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>,
-                                                  eventLoop: EventLoop)
+    func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>,
+                                           eventLoop: EventLoop)
         -> EventLoopFuture<TypedDatabaseItem<AttributesType, ItemType>?> {
         let promise = eventLoop.makePromise(of: TypedDatabaseItem<AttributesType, ItemType>?.self)
         
@@ -172,7 +182,7 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         return promise.futureResult
     }
     
-    public func getItems<ReturnedType: PolymorphicOperationReturnType & BatchCapableReturnType>(
+    func getItems<ReturnedType: PolymorphicOperationReturnType & BatchCapableReturnType>(
         forKeys keys: [CompositePrimaryKey<ReturnedType.AttributesType>],
         eventLoop: EventLoop)
     -> EventLoopFuture<[CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType]> {
@@ -207,8 +217,8 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         return promise.futureResult
     }
 
-    public func deleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>,
-                                           eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    func deleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>,
+                                    eventLoop: EventLoop) -> EventLoopFuture<Void> {
         let promise = eventLoop.makePromise(of: Void.self)
         
         accessQueue.async {
@@ -219,8 +229,8 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         return promise.futureResult
     }
     
-    public func deleteItem<AttributesType, ItemType>(existingItem: TypedDatabaseItem<AttributesType, ItemType>,
-                                                     eventLoop: EventLoop) -> EventLoopFuture<Void>
+    func deleteItem<AttributesType, ItemType>(existingItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                              eventLoop: EventLoop) -> EventLoopFuture<Void>
             where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         let promise = eventLoop.makePromise(of: Void.self)
         
@@ -269,9 +279,9 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         return promise.futureResult
     }
 
-    public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
-                                                                    sortKeyCondition: AttributeCondition?,
-                                                                    eventLoop: EventLoop)
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             eventLoop: EventLoop)
         -> EventLoopFuture<[ReturnedType]> {
         let promise = eventLoop.makePromise(of: [ReturnedType].self)
         
@@ -356,11 +366,11 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         }
     }
     
-    public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
-                                                                    sortKeyCondition: AttributeCondition?,
-                                                                    limit: Int?,
-                                                                    exclusiveStartKey: String?,
-                                                                    eventLoop: EventLoop)
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             limit: Int?,
+                                                             exclusiveStartKey: String?,
+                                                             eventLoop: EventLoop)
             -> EventLoopFuture<([ReturnedType], String?)> {
         return query(forPartitionKey: partitionKey,
                      sortKeyCondition: sortKeyCondition,
@@ -370,12 +380,12 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
                      eventLoop: eventLoop)
     }
 
-    public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
-                                                                    sortKeyCondition: AttributeCondition?,
-                                                                    limit: Int?,
-                                                                    scanIndexForward: Bool,
-                                                                    exclusiveStartKey: String?,
-                                                                    eventLoop: EventLoop)
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             limit: Int?,
+                                                             scanIndexForward: Bool,
+                                                             exclusiveStartKey: String?,
+                                                             eventLoop: EventLoop)
             -> EventLoopFuture<([ReturnedType], String?)> {
         // get all the results
         return query(forPartitionKey: partitionKey,

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
@@ -27,7 +27,11 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
     internal let keysWrapper: InMemoryDynamoDBCompositePrimaryKeysProjectionStore
     
     public var keys: [Any] {
-        return keysWrapper.keys
+        do {
+            return try keysWrapper.getKeys(eventLoop: self.eventLoop).wait()
+        } catch {
+            fatalError("Unable to retrieve InMemoryDynamoDBCompositePrimaryKeysProjection keys.")
+        }
     }
 
     public init(keys: [Any] = [], eventLoop: EventLoop) {

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
@@ -1,0 +1,164 @@
+// swiftlint:disable cyclomatic_complexity
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeHTTPClient
+import DynamoDBModel
+import NIO
+
+public class InMemoryDynamoDBCompositePrimaryKeysProjectionStore {
+    public var keys: [Any] = []
+    private let accessQueue = DispatchQueue(
+        label: "com.amazon.SmokeDynamoDB.InMemoryDynamoDBCompositePrimaryKeysProjection.accessQueue",
+        target: DispatchQueue.global())
+
+    public init(keys: [Any] = []) {
+        self.keys = keys
+    }
+
+    public func query<AttributesType>(forPartitionKey partitionKey: String,
+                                      sortKeyCondition: AttributeCondition?,
+                                      eventLoop: EventLoop)
+            -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]> {
+        let promise = eventLoop.makePromise(of: [CompositePrimaryKey<AttributesType>].self)
+        
+        accessQueue.async {
+            var items: [CompositePrimaryKey<AttributesType>] = []
+                
+            let sortedKeys = self.keys.compactMap { $0 as? CompositePrimaryKey<AttributesType> }.sorted(by: { (left, right) -> Bool in
+                return left.sortKey < right.sortKey
+            })
+                
+            sortKeyIteration: for key in sortedKeys {
+                if key.partitionKey != partitionKey {
+                    // don't include this in the results
+                    continue sortKeyIteration
+                }
+                
+                let sortKey = key.sortKey
+
+                if let currentSortKeyCondition = sortKeyCondition {
+                    switch currentSortKeyCondition {
+                    case .equals(let value):
+                        if !(value == sortKey) {
+                            // don't include this in the results
+                            continue sortKeyIteration
+                        }
+                    case .lessThan(let value):
+                        if !(sortKey < value) {
+                            // don't include this in the results
+                            continue sortKeyIteration
+                        }
+                    case .lessThanOrEqual(let value):
+                        if !(sortKey <= value) {
+                            // don't include this in the results
+                            continue sortKeyIteration
+                        }
+                    case .greaterThan(let value):
+                        if !(sortKey > value) {
+                            // don't include this in the results
+                            continue sortKeyIteration
+                        }
+                    case .greaterThanOrEqual(let value):
+                        if !(sortKey >= value) {
+                            // don't include this in the results
+                            continue sortKeyIteration
+                        }
+                    case .between(let value1, let value2):
+                        if !(sortKey > value1 && sortKey < value2) {
+                            // don't include this in the results
+                            continue sortKeyIteration
+                        }
+                    case .beginsWith(let value):
+                        if !(sortKey.hasPrefix(value)) {
+                            // don't include this in the results
+                            continue sortKeyIteration
+                        }
+                    }
+                }
+
+                items.append(key)
+            }
+
+            promise.succeed(items)
+        }
+        
+        return promise.futureResult
+    }
+    
+    public func query<AttributesType>(forPartitionKey partitionKey: String,
+                                          sortKeyCondition: AttributeCondition?,
+                                          limit: Int?,
+                                          exclusiveStartKey: String?,
+                                          eventLoop: EventLoop)
+            -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
+            where AttributesType: PrimaryKeyAttributes {
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     limit: limit,
+                     scanIndexForward: true,
+                     exclusiveStartKey: exclusiveStartKey,
+                     eventLoop: eventLoop)
+    }
+
+    public func query<AttributesType>(forPartitionKey partitionKey: String,
+                                      sortKeyCondition: AttributeCondition?,
+                                      limit: Int?,
+                                      scanIndexForward: Bool,
+                                      exclusiveStartKey: String?,
+                                      eventLoop: EventLoop)
+            -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
+            where AttributesType: PrimaryKeyAttributes {
+        // get all the results
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     eventLoop: eventLoop)
+            .map { (rawItems: [CompositePrimaryKey<AttributesType>]) in
+                let items: [CompositePrimaryKey<AttributesType>]
+                if !scanIndexForward {
+                    items = rawItems.reversed()
+                } else {
+                    items = rawItems
+                }
+
+                let startIndex: Int
+                // if there is an exclusiveStartKey
+                if let exclusiveStartKey = exclusiveStartKey {
+                    guard let storedStartIndex = Int(exclusiveStartKey) else {
+                        fatalError("Unexpectedly encoded exclusiveStartKey '\(exclusiveStartKey)'")
+                    }
+
+                    startIndex = storedStartIndex
+                } else {
+                    startIndex = 0
+                }
+
+                let endIndex: Int
+                let lastEvaluatedKey: String?
+                if let limit = limit, startIndex + limit < items.count {
+                    endIndex = startIndex + limit
+                    lastEvaluatedKey = String(endIndex)
+                } else {
+                    endIndex = items.count
+                    lastEvaluatedKey = nil
+                }
+
+                return (Array(items[startIndex..<endIndex]), lastEvaluatedKey)
+            }
+    }
+}

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
@@ -30,6 +30,16 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjectionStore {
     public init(keys: [Any] = []) {
         self.keys = keys
     }
+    
+    func getKeys(eventLoop: EventLoop) -> EventLoopFuture<[Any]> {
+        let promise = eventLoop.makePromise(of: [Any].self)
+        
+        accessQueue.async {
+            promise.succeed(self.keys)
+        }
+        
+        return promise.futureResult
+    }
 
     public func query<AttributesType>(forPartitionKey partitionKey: String,
                                       sortKeyCondition: AttributeCondition?,

--- a/Sources/SmokeDynamoDB/PolymorphicOperationReturnType.swift
+++ b/Sources/SmokeDynamoDB/PolymorphicOperationReturnType.swift
@@ -88,7 +88,7 @@ internal struct ReturnTypeDecodable<ReturnType: PolymorphicOperationReturnType>:
         if let provider = queryableTypeProviders[storedRowTypeName] {
             self.decodedValue = try provider.getReturnType(from: decoder)
         } else {
-            // throw an exception, we don't what this type is
+            // throw an exception, we don't know what this type is
             throw SmokeDynamoDBError.unexpectedType(provided: storedRowTypeName)
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Provides the ability to use the same InMemory* data store across different thread loops. This changes creates an internal data store class which is provided the event loop from the wrapping type.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
