### PR TITLE
Add deleteItems and monomorphicBulkWrite APIs

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+deleteItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+deleteItems.swift
@@ -1,0 +1,111 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AWSDynamoDBCompositePrimaryKeyTable+deleteItems.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeAWSCore
+import DynamoDBModel
+import SmokeHTTPClient
+import Logging
+import NIO
+
+// BatchExecuteStatement has a maximum of 25 statements
+private let maximumUpdatesPerExecuteStatement = 25
+
+/// DynamoDBTable conformance updateItems function
+public extension AWSDynamoDBCompositePrimaryKeyTable {
+    private func deleteChunkedItems<AttributesType>(_ keys: [CompositePrimaryKey<AttributesType>])
+    -> EventLoopFuture<Void> {
+        // if there are no keys, there is nothing to update
+        guard keys.count > 0 else {
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            promise.succeed(())
+            return promise.futureResult
+        }
+        
+        let statements: [BatchStatementRequest]
+        do {
+            statements = try keys.map { existingKey -> BatchStatementRequest in
+                let statement = try getDeleteExpression(tableName: self.targetTableName,
+                                                        existingKey: existingKey)
+                
+                return BatchStatementRequest(consistentRead: true, statement: statement)
+            }
+        } catch {
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            promise.fail(error)
+            return promise.futureResult
+        }
+        
+        let executeInput = BatchExecuteStatementInput(statements: statements)
+        
+        return dynamodb.batchExecuteStatement(input: executeInput).map { _ in
+            
+        }
+    }
+    
+    private func deleteChunkedItems<ItemType: DatabaseItem>(_ existingItems: [ItemType])
+    -> EventLoopFuture<Void> {
+        // if there are no items, there is nothing to update
+        guard existingItems.count > 0 else {
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            promise.succeed(())
+            return promise.futureResult
+        }
+        
+        let statements: [BatchStatementRequest]
+        do {
+            statements = try existingItems.map { existingItem -> BatchStatementRequest in
+                let statement = try getDeleteExpression(tableName: self.targetTableName,
+                                                        existingItem: existingItem)
+                
+                return BatchStatementRequest(consistentRead: true, statement: statement)
+            }
+        } catch {
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            promise.fail(error)
+            return promise.futureResult
+        }
+        
+        let executeInput = BatchExecuteStatementInput(statements: statements)
+        
+        return dynamodb.batchExecuteStatement(input: executeInput).map { _ in
+            
+        }
+    }
+    
+    func deleteItems<AttributesType>(forKeys keys: [CompositePrimaryKey<AttributesType>]) -> EventLoopFuture<Void> {
+        // BatchExecuteStatement has a maximum of 25 statements
+        // This function handles pagination internally.
+        let chunkedKeys = keys.chunked(by: maximumUpdatesPerExecuteStatement)
+        let futures = chunkedKeys.map { chunk -> EventLoopFuture<Void> in
+            return deleteChunkedItems(chunk)
+        }
+        
+        return EventLoopFuture.andAllComplete(futures, on: self.eventLoop)
+    }
+    
+    func deleteItems<ItemType: DatabaseItem>(existingItems: [ItemType]) -> EventLoopFuture<Void> {
+        // BatchExecuteStatement has a maximum of 25 statements
+        // This function handles pagination internally.
+        let chunkedItems = existingItems.chunked(by: maximumUpdatesPerExecuteStatement)
+        let futures = chunkedItems.map { chunk -> EventLoopFuture<Void> in
+            return deleteChunkedItems(chunk)
+        }
+        
+        return EventLoopFuture.andAllComplete(futures, on: self.eventLoop)
+    }
+}

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+deleteItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+deleteItems.swift
@@ -52,8 +52,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         
         let executeInput = BatchExecuteStatementInput(statements: statements)
         
-        return dynamodb.batchExecuteStatement(input: executeInput).map { _ in
-            
+        return dynamodb.batchExecuteStatement(input: executeInput).flatMapThrowing { response in
+            try self.throwOnBatchExecuteStatementErrors(response: response)
         }
     }
     
@@ -82,8 +82,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         
         let executeInput = BatchExecuteStatementInput(statements: statements)
         
-        return dynamodb.batchExecuteStatement(input: executeInput).map { _ in
-            
+        return dynamodb.batchExecuteStatement(input: executeInput).flatMapThrowing { response in
+            try self.throwOnBatchExecuteStatementErrors(response: response)
         }
     }
     

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+deleteItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+deleteItems.swift
@@ -95,7 +95,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             return deleteChunkedItems(chunk)
         }
         
-        return EventLoopFuture.andAllComplete(futures, on: self.eventLoop)
+        return EventLoopFuture.andAllSucceed(futures, on: self.eventLoop)
     }
     
     func deleteItems<ItemType: DatabaseItem>(existingItems: [ItemType]) -> EventLoopFuture<Void> {
@@ -106,6 +106,6 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             return deleteChunkedItems(chunk)
         }
         
-        return EventLoopFuture.andAllComplete(futures, on: self.eventLoop)
+        return EventLoopFuture.andAllSucceed(futures, on: self.eventLoop)
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
@@ -1,0 +1,74 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeAWSCore
+import DynamoDBModel
+import SmokeHTTPClient
+import Logging
+import NIO
+
+// BatchExecuteStatement has a maximum of 25 statements
+private let maximumUpdatesPerExecuteStatement = 25
+
+/// DynamoDBTable conformance updateItems function
+public extension AWSDynamoDBCompositePrimaryKeyTable {
+    private func updateChunkedItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
+                                                                         existing: TypedDatabaseItem<AttributesType, ItemType>)])
+    -> EventLoopFuture<Void> {
+        // if there are no items, there is nothing to update
+        guard items.count > 0 else {
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            promise.succeed(())
+            return promise.futureResult
+        }
+        
+        let statements: [BatchStatementRequest]
+        do {
+            statements = try items.map { (new, existing) -> BatchStatementRequest in
+                let statement = try getUpdateExpression(tableName: self.targetTableName,
+                                                        newItem: new,
+                                                        existingItem: existing)
+                
+                return BatchStatementRequest(consistentRead: true, statement: statement)
+            }
+        } catch {
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            promise.fail(error)
+            return promise.futureResult
+        }
+        
+        let executeInput = BatchExecuteStatementInput(statements: statements)
+        
+        return dynamodb.batchExecuteStatement(input: executeInput).map { _ in
+            
+        }
+    }
+    
+    func updateItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
+                                                          existing: TypedDatabaseItem<AttributesType, ItemType>)])
+    -> EventLoopFuture<Void> {
+        // BatchExecuteStatement has a maximum of 25 statements
+        // This function handles pagination internally.
+        let chunkedItems = items.chunked(by: maximumUpdatesPerExecuteStatement)
+        let futures = chunkedItems.map { chunk -> EventLoopFuture<Void> in
+            return updateChunkedItems(chunk)
+        }
+        
+        return EventLoopFuture.andAllComplete(futures, on: self.eventLoop)
+    }
+}

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
@@ -105,7 +105,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         throw SmokeDynamoDBError.batchErrorsReturned(errorCount: errorCount, messageMap: errorMap)
     }
     
-    func bulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
+    func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
     -> EventLoopFuture<Void> {
         // BatchExecuteStatement has a maximum of 25 statements
         // This function handles pagination internally.

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
@@ -109,6 +109,6 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             return updateChunkedItems(chunk)
         }
         
-        return EventLoopFuture.andAllComplete(futures, on: self.eventLoop)
+        return EventLoopFuture.andAllSucceed(futures, on: self.eventLoop)
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -123,24 +123,10 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
         let conditionExpression = "#rowversion = :versionnumber AND #createdate = :creationdate"
 
         return DynamoDBModel.PutItemInput(conditionExpression: conditionExpression,
-                                                      expressionAttributeNames: expressionAttributeNames,
-                                                      expressionAttributeValues: expressionAttributeValues,
-                                                      item: attributes,
-                                                      tableName: targetTableName)
-    }
-
-    internal func getAttributes<AttributesType, ItemType>(forItem item: TypedDatabaseItem<AttributesType, ItemType>) throws
-        -> [String: DynamoDBModel.AttributeValue] {
-            let attributeValue = try DynamoDBEncoder().encode(item)
-
-            let attributes: [String: DynamoDBModel.AttributeValue]
-            if let itemAttributes = attributeValue.M {
-                attributes = itemAttributes
-            } else {
-                throw SmokeDynamoDBError.unexpectedResponse(reason: "Expected a map.")
-            }
-
-            return attributes
+                                          expressionAttributeNames: expressionAttributeNames,
+                                          expressionAttributeValues: expressionAttributeValues,
+                                          item: attributes,
+                                          tableName: targetTableName)
     }
 
     internal func getInputForGetItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>) throws -> DynamoDBModel.GetItemInput {

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
@@ -104,6 +104,10 @@ extension DynamoDBCompositePrimaryKeyTable {
             + "AND \(AttributesType.sortKeyAttributeName)='\(existingKey.sortKey)'"
     }
     
+    /*
+     Function to return the differences between two items. This is used to them create an UPDATE
+     query that just specifies the values that are changing.
+     */
     func diffItems<AttributesType, ItemType>(
                 newItem: TypedDatabaseItem<AttributesType, ItemType>,
                 existingItem: TypedDatabaseItem<AttributesType, ItemType>) throws -> [AttributeDifference] {

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
@@ -74,10 +74,10 @@ extension DynamoDBCompositePrimaryKeyTable {
         
         let combinedElements = elements.joined(separator: " ")
         
-        return "UPDATE \(tableName) \(combinedElements) "
+        return "UPDATE \"\(tableName)\" \(combinedElements) "
             + "WHERE \(AttributesType.partitionKeyAttributeName)='\(newItem.compositePrimaryKey.partitionKey)' "
             + "AND \(AttributesType.sortKeyAttributeName)='\(newItem.compositePrimaryKey.sortKey)' "
-            + "AND \(RowStatus.CodingKeys.rowVersion.rawValue)='\(existingItem.rowStatus.rowVersion)'"
+            + "AND \(RowStatus.CodingKeys.rowVersion.rawValue)=\(existingItem.rowStatus.rowVersion)"
     }
     
     func getInsertExpression<AttributesType, ItemType>(tableName: String,
@@ -86,20 +86,20 @@ extension DynamoDBCompositePrimaryKeyTable {
         let flattenedAttribute = try getFlattenedMapAttribute(attribute: newAttributes)
         
         // according to https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.insert.html
-        return "INSERT INTO \(tableName) value \(flattenedAttribute) "
+        return "INSERT INTO \"\(tableName)\" value \(flattenedAttribute)"
     }
     
     func getDeleteExpression<ItemType: DatabaseItem>(tableName: String,
                                                      existingItem: ItemType) throws -> String {
-        return "DELETE FROM \(tableName) "
+        return "DELETE FROM \"\(tableName)\" "
             + "WHERE \(ItemType.AttributesType.partitionKeyAttributeName)='\(existingItem.compositePrimaryKey.partitionKey)' "
             + "AND \(ItemType.AttributesType.sortKeyAttributeName)='\(existingItem.compositePrimaryKey.sortKey)' "
-            + "AND \(RowStatus.CodingKeys.rowVersion.rawValue)='\(existingItem.rowStatus.rowVersion)'"
+            + "AND \(RowStatus.CodingKeys.rowVersion.rawValue)=\(existingItem.rowStatus.rowVersion)"
     }
     
     func getDeleteExpression<AttributesType>(tableName: String,
                                              existingKey: CompositePrimaryKey<AttributesType>) throws -> String {
-        return "DELETE FROM \(tableName) "
+        return "DELETE FROM \"\(tableName)\" "
             + "WHERE \(AttributesType.partitionKeyAttributeName)='\(existingKey.partitionKey)' "
             + "AND \(AttributesType.sortKeyAttributeName)='\(existingKey.sortKey)'"
     }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
@@ -1,0 +1,274 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeHTTPClient
+import Logging
+import DynamoDBModel
+import NIO
+
+internal enum AttributeDifference: Equatable {
+    case update(path: String, value: String)
+    case remove(path: String)
+    case listAppend(path: String, value: String)
+    
+    var path: String {
+        switch self {
+        case .update(path: let path, value: _):
+            return path
+        case .remove(path: let path):
+            return path
+        case .listAppend(path: let path, value: _):
+            return path
+        }
+    }
+}
+
+extension DynamoDBCompositePrimaryKeyTable {
+    
+    func getAttributes<AttributesType, ItemType>(forItem item: TypedDatabaseItem<AttributesType, ItemType>) throws
+        -> [String: DynamoDBModel.AttributeValue] {
+            let attributeValue = try DynamoDBEncoder().encode(item)
+
+            let attributes: [String: DynamoDBModel.AttributeValue]
+            if let itemAttributes = attributeValue.M {
+                attributes = itemAttributes
+            } else {
+                throw SmokeDynamoDBError.unexpectedResponse(reason: "Expected a map.")
+            }
+
+            return attributes
+    }
+    
+    func getUpdateExpression<AttributesType, ItemType>(tableName: String,
+                                                       newItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                       existingItem: TypedDatabaseItem<AttributesType, ItemType>) throws -> String {
+        let attributeDifferences = try diffItems(newItem: newItem,
+                                                 existingItem: existingItem)
+        
+        // according to https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html
+        let elements = attributeDifferences.map { attributeDifference -> String in
+            switch attributeDifference {
+            case .update(path: let path, value: let value):
+                return "SET \(path)=\(value)"
+            case .remove(path: let path):
+                return "REMOVE \(path)"
+            case .listAppend(path: let path, value: let value):
+                return "SET \(path)=list_append(\(path),\(value)"
+            }
+        }
+        
+        let combinedElements = elements.joined(separator: " ")
+        
+        return "UPDATE \(tableName) \(combinedElements) "
+            + "WHERE \(AttributesType.partitionKeyAttributeName)='\(newItem.compositePrimaryKey.partitionKey)' "
+            + "AND \(AttributesType.sortKeyAttributeName)='\(newItem.compositePrimaryKey.sortKey)' "
+            + "AND \(RowStatus.CodingKeys.rowVersion.rawValue)='\(existingItem.rowStatus.rowVersion)'"
+    }
+    
+    func getDeleteExpression<ItemType: DatabaseItem>(tableName: String,
+                                                     existingItem: ItemType) throws -> String {
+        return "DELETE FROM \(tableName) "
+            + "WHERE \(ItemType.AttributesType.partitionKeyAttributeName)='\(existingItem.compositePrimaryKey.partitionKey)' "
+            + "AND \(ItemType.AttributesType.sortKeyAttributeName)='\(existingItem.compositePrimaryKey.sortKey)' "
+            + "AND \(RowStatus.CodingKeys.rowVersion.rawValue)='\(existingItem.rowStatus.rowVersion)'"
+    }
+    
+    func getDeleteExpression<AttributesType>(tableName: String,
+                                             existingKey: CompositePrimaryKey<AttributesType>) throws -> String {
+        return "DELETE FROM \(tableName) "
+            + "WHERE \(AttributesType.partitionKeyAttributeName)='\(existingKey.partitionKey)' "
+            + "AND \(AttributesType.sortKeyAttributeName)='\(existingKey.sortKey)'"
+    }
+    
+    func diffItems<AttributesType, ItemType>(
+                newItem: TypedDatabaseItem<AttributesType, ItemType>,
+                existingItem: TypedDatabaseItem<AttributesType, ItemType>) throws -> [AttributeDifference] {
+        let newAttributes = try getAttributes(forItem: newItem)
+        let existingAttributes = try getAttributes(forItem: existingItem)
+        
+        return try diffMapAttribute(path: nil, newAttribute: newAttributes, existingAttribute: existingAttributes)
+    }
+    
+    private func diffAttribute(path: String,
+                               newAttribute: DynamoDBModel.AttributeValue,
+                               existingAttribute: DynamoDBModel.AttributeValue) throws -> [AttributeDifference] {
+        if newAttribute.B != nil || existingAttribute.B != nil {
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Binary types.")
+        } else if let newTypedAttribute = newAttribute.BOOL, let existingTypedAttribute = existingAttribute.BOOL {
+            if newTypedAttribute != existingTypedAttribute {
+                return [.update(path: path, value: String(newTypedAttribute))]
+            }
+        } else if newAttribute.BS != nil || existingAttribute.BS != nil {
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Binary Set types.")
+        } else if let newTypedAttribute = newAttribute.L, let existingTypedAttribute = existingAttribute.L {
+            return try diffListAttribute(path: path, newAttribute: newTypedAttribute, existingAttribute: existingTypedAttribute)
+        } else if let newTypedAttribute = newAttribute.M, let existingTypedAttribute = existingAttribute.M {
+            return try diffMapAttribute(path: path, newAttribute: newTypedAttribute, existingAttribute: existingTypedAttribute)
+        } else if let newTypedAttribute = newAttribute.N, let existingTypedAttribute = existingAttribute.N {
+            if newTypedAttribute != existingTypedAttribute {
+                return [.update(path: path, value: String(newTypedAttribute))]
+            }
+        } else if newAttribute.NS != nil || existingAttribute.NS  != nil {
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Number Set types.")
+        } else if newAttribute.NULL != nil && existingAttribute.NULL != nil {
+            // always equal
+            return []
+        } else if let newTypedAttribute = newAttribute.S, let existingTypedAttribute = existingAttribute.S {
+            if newTypedAttribute != existingTypedAttribute {
+                return [.update(path: path, value: "'\(newTypedAttribute)'")]
+            }
+        } else if newAttribute.SS != nil || existingAttribute.SS  != nil {
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande String Set types.")
+        } else {
+            // new value is a different type and could be replaced
+            return try updateAttribute(newPath: path, attribute: newAttribute)
+        }
+        
+        // no change
+        return []
+    }
+    
+    private func diffListAttribute(path: String,
+                                   newAttribute: [DynamoDBModel.AttributeValue],
+                                   existingAttribute: [DynamoDBModel.AttributeValue]) throws -> [AttributeDifference] {
+        let maxIndex = max(newAttribute.count, existingAttribute.count)
+        var haveAppendedAdditionalValues = false
+        
+        return try (0..<maxIndex).flatMap { index -> [AttributeDifference] in
+            let newPath = "\(path)[\(index)]"
+            
+            // if both new and existing attributes are present
+            if index < newAttribute.count && index < existingAttribute.count {
+                return try diffAttribute(path: newPath, newAttribute: newAttribute[index], existingAttribute: existingAttribute[index])
+            } else if index < existingAttribute.count {
+                return [.remove(path: newPath)]
+            } else if index < newAttribute.count {
+                let additionalAttributes = Array(newAttribute[index...])
+                let newValue = try getFlattenedListAttribute(attribute: additionalAttributes)
+                
+                if !haveAppendedAdditionalValues {
+                    haveAppendedAdditionalValues = true
+                    
+                    return [.listAppend(path: path, value: newValue)]
+                } else {
+                    // values have already been appended to the list
+                    return []
+                }
+            }
+            
+            return []
+        }
+    }
+    
+    private func diffMapAttribute(path: String?,
+                                  newAttribute: [String: DynamoDBModel.AttributeValue],
+                                  existingAttribute: [String: DynamoDBModel.AttributeValue]) throws -> [AttributeDifference] {
+        var combinedMap: [String: (new: DynamoDBModel.AttributeValue?, existing: DynamoDBModel.AttributeValue?)] = [:]
+        
+        newAttribute.forEach { (key, attribute) in
+            var existingEntry = combinedMap[key] ?? (nil, nil)
+            existingEntry.new = attribute
+            combinedMap[key] = existingEntry
+        }
+        
+        existingAttribute.forEach { (key, attribute) in
+            var existingEntry = combinedMap[key] ?? (nil, nil)
+            existingEntry.existing = attribute
+            combinedMap[key] = existingEntry
+        }
+        
+        return try combinedMap.flatMap { (key, attribute) -> [AttributeDifference] in
+            let newPath = combinePath(basePath: path, newComponent: key)
+            
+            // if both new and existing attributes are present
+            if let new = attribute.new, let existing = attribute.existing {
+                return try diffAttribute(path: newPath, newAttribute: new, existingAttribute: existing)
+            } else if attribute.existing != nil {
+                return [.remove(path: newPath)]
+            } else if let new = attribute.new {
+                return try updateAttribute(newPath: newPath, attribute: new)
+            } else {
+                return []
+            }
+        }
+    }
+    
+    private func combinePath(basePath: String?, newComponent: String) -> String {
+        if let basePath = basePath {
+            return "\(basePath).\(newComponent)"
+        } else {
+            return newComponent
+        }
+    }
+    
+    private func updateAttribute(newPath: String, attribute: DynamoDBModel.AttributeValue) throws -> [AttributeDifference] {
+        if let newValue = try getFlattenedAttribute(attribute: attribute) {
+            return [.update(path: newPath, value: newValue)]
+        } else {
+            return [.remove(path: newPath)]
+        }
+    }
+    
+    private func getFlattenedAttribute(attribute: DynamoDBModel.AttributeValue) throws -> String? {
+        if attribute.B != nil {
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Binary types.")
+        } else if let typedAttribute = attribute.BOOL {
+            return String(typedAttribute)
+        } else if attribute.BS != nil {
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Binary Set types.")
+        } else if let typedAttribute = attribute.L {
+            return try getFlattenedListAttribute(attribute: typedAttribute)
+        } else if let typedAttribute = attribute.M {
+            return try getFlattenedMapAttribute(attribute: typedAttribute)
+        } else if let typedAttribute = attribute.N {
+            return String(typedAttribute)
+        } else if attribute.NS != nil {
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Number Set types.")
+        } else if attribute.NULL != nil {
+            return nil
+        } else if let typedAttribute = attribute.S {
+            return "'\(typedAttribute)'"
+        } else if attribute.SS != nil {
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande String Set types.")
+        }
+        
+        return nil
+    }
+    
+    private func getFlattenedListAttribute(attribute: [DynamoDBModel.AttributeValue]) throws -> String {
+        let elements: [String] = try attribute.compactMap { nestedAttribute in
+            return try getFlattenedAttribute(attribute: nestedAttribute)
+        }
+        
+        let joinedElements = elements.joined(separator: ", ")
+        return "[\(joinedElements)]"
+    }
+    
+    private func getFlattenedMapAttribute(attribute: [String: DynamoDBModel.AttributeValue]) throws -> String {
+        let elements: [String] = try attribute.compactMap { (key, nestedAttribute) in
+            guard let flattenedNestedAttribute = try getFlattenedAttribute(attribute: nestedAttribute) else {
+                return nil
+            }
+            
+            return "'\(key)': \(flattenedNestedAttribute)"
+        }
+        
+        let joinedElements = elements.joined(separator: ", ")
+        return "{\(joinedElements)}"
+    }
+}

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
@@ -64,11 +64,11 @@ extension DynamoDBCompositePrimaryKeyTable {
         let elements = attributeDifferences.map { attributeDifference -> String in
             switch attributeDifference {
             case .update(path: let path, value: let value):
-                return "SET \(path)=\(value)"
+                return "SET \"\(path)\"=\(value)"
             case .remove(path: let path):
-                return "REMOVE \(path)"
+                return "REMOVE \"\(path)\""
             case .listAppend(path: let path, value: let value):
-                return "SET \(path)=list_append(\(path),\(value)"
+                return "SET \"\(path)\"=list_append(\(path),\(value)"
             }
         }
         

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
@@ -105,7 +105,7 @@ extension DynamoDBCompositePrimaryKeyTable {
     }
     
     /*
-     Function to return the differences between two items. This is used to them create an UPDATE
+     Function to return the differences between two items. This is used to then create an UPDATE
      query that just specifies the values that are changing.
      */
     func diffItems<AttributesType, ItemType>(
@@ -121,13 +121,13 @@ extension DynamoDBCompositePrimaryKeyTable {
                                newAttribute: DynamoDBModel.AttributeValue,
                                existingAttribute: DynamoDBModel.AttributeValue) throws -> [AttributeDifference] {
         if newAttribute.B != nil || existingAttribute.B != nil {
-            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Binary types.")
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to handle Binary types.")
         } else if let newTypedAttribute = newAttribute.BOOL, let existingTypedAttribute = existingAttribute.BOOL {
             if newTypedAttribute != existingTypedAttribute {
                 return [.update(path: path, value: String(newTypedAttribute))]
             }
         } else if newAttribute.BS != nil || existingAttribute.BS != nil {
-            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Binary Set types.")
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to handle Binary Set types.")
         } else if let newTypedAttribute = newAttribute.L, let existingTypedAttribute = existingAttribute.L {
             return try diffListAttribute(path: path, newAttribute: newTypedAttribute, existingAttribute: existingTypedAttribute)
         } else if let newTypedAttribute = newAttribute.M, let existingTypedAttribute = existingAttribute.M {
@@ -137,7 +137,7 @@ extension DynamoDBCompositePrimaryKeyTable {
                 return [.update(path: path, value: String(newTypedAttribute))]
             }
         } else if newAttribute.NS != nil || existingAttribute.NS  != nil {
-            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Number Set types.")
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to handle Number Set types.")
         } else if newAttribute.NULL != nil && existingAttribute.NULL != nil {
             // always equal
             return []
@@ -146,7 +146,7 @@ extension DynamoDBCompositePrimaryKeyTable {
                 return [.update(path: path, value: "'\(newTypedAttribute)'")]
             }
         } else if newAttribute.SS != nil || existingAttribute.SS  != nil {
-            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande String Set types.")
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to handle String Set types.")
         } else {
             // new value is a different type and could be replaced
             return try updateAttribute(newPath: path, attribute: newAttribute)
@@ -239,11 +239,11 @@ extension DynamoDBCompositePrimaryKeyTable {
     
     func getFlattenedAttribute(attribute: DynamoDBModel.AttributeValue) throws -> String? {
         if attribute.B != nil {
-            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Binary types.")
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to handle Binary types.")
         } else if let typedAttribute = attribute.BOOL {
             return String(typedAttribute)
         } else if attribute.BS != nil {
-            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Binary Set types.")
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to handle Binary Set types.")
         } else if let typedAttribute = attribute.L {
             return try getFlattenedListAttribute(attribute: typedAttribute)
         } else if let typedAttribute = attribute.M {
@@ -251,13 +251,13 @@ extension DynamoDBCompositePrimaryKeyTable {
         } else if let typedAttribute = attribute.N {
             return String(typedAttribute)
         } else if attribute.NS != nil {
-            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande Number Set types.")
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to handle Number Set types.")
         } else if attribute.NULL != nil {
             return nil
         } else if let typedAttribute = attribute.S {
             return "'\(typedAttribute)'"
         } else if attribute.SS != nil {
-            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to hande String Set types.")
+            throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to handle String Set types.")
         }
         
         return nil

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -69,6 +69,13 @@ public enum AttributeCondition {
     case beginsWith(String)
 }
 
+public enum WriteEntry<AttributesType: PrimaryKeyAttributes, ItemType: Codable> {
+    case update(new: TypedDatabaseItem<AttributesType, ItemType>, existing: TypedDatabaseItem<AttributesType, ItemType>)
+    case insert(new: TypedDatabaseItem<AttributesType, ItemType>)
+    case deleteAtKey(key: CompositePrimaryKey<AttributesType>)
+    case deleteItem(existing: TypedDatabaseItem<AttributesType, ItemType>)
+}
+
 public protocol DynamoDBCompositePrimaryKeyTable {
     var eventLoop: EventLoop { get }
 
@@ -92,11 +99,9 @@ public protocol DynamoDBCompositePrimaryKeyTable {
                                               existingItem: TypedDatabaseItem<AttributesType, ItemType>) -> EventLoopFuture<Void>
     
     /**
-     * Update item requires having gotten an item from the database previously and will not update
-     * if the item at the specified key is not the existing item provided.
+     * Provides the ability to bulk write database rows
      */
-    func updateOrInsertItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
-                                                       existing: TypedDatabaseItem<AttributesType, ItemType>?)]) -> EventLoopFuture<Void>
+    func bulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<Void>
 
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -76,6 +76,8 @@ public enum WriteEntry<AttributesType: PrimaryKeyAttributes, ItemType: Codable> 
     case deleteItem(existing: TypedDatabaseItem<AttributesType, ItemType>)
 }
 
+public typealias StandardWriteEntry<ItemType: Codable> = WriteEntry<StandardPrimaryKeyAttributes, ItemType>
+
 public protocol DynamoDBCompositePrimaryKeyTable {
     var eventLoop: EventLoop { get }
 

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -88,7 +88,14 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      * if the item at the specified key is not the existing item provided.
      */
     func updateItem<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
-                                                  existingItem: TypedDatabaseItem<AttributesType, ItemType>) -> EventLoopFuture<Void>
+                                              existingItem: TypedDatabaseItem<AttributesType, ItemType>) -> EventLoopFuture<Void>
+    
+    /**
+     * Update item requires having gotten an item from the database previously and will not update
+     * if the item at the specified key is not the existing item provided.
+     */
+    func updateItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
+                                                          existing: TypedDatabaseItem<AttributesType, ItemType>)]) -> EventLoopFuture<Void>
 
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.
@@ -114,6 +121,19 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      * if the item at the specified key is not the existing item provided.
      */
     func deleteItem<AttributesType, ItemType>(existingItem: TypedDatabaseItem<AttributesType, ItemType>) -> EventLoopFuture<Void>
+    
+    /**
+     * Removes items from the database table. Is an idempotent operation; running it multiple times
+     * on the same item or attribute does not result in an error response.
+     */
+    func deleteItems<AttributesType>(forKeys keys: [CompositePrimaryKey<AttributesType>]) -> EventLoopFuture<Void>
+    
+    /**
+     * Removes items from the database table. Is an idempotent operation; running it multiple times
+     * on the same item or attribute does not result in an error response. This operation will not modify the table
+     * if the item at the specified key is not the existing item provided.
+     */
+    func deleteItems<ItemType: DatabaseItem>(existingItems: [ItemType]) -> EventLoopFuture<Void>
 
     /**
      * Queries a partition in the database table and optionally a sort key condition. If the

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -94,8 +94,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      * Update item requires having gotten an item from the database previously and will not update
      * if the item at the specified key is not the existing item provided.
      */
-    func updateItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
-                                                          existing: TypedDatabaseItem<AttributesType, ItemType>)]) -> EventLoopFuture<Void>
+    func updateOrInsertItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
+                                                       existing: TypedDatabaseItem<AttributesType, ItemType>?)]) -> EventLoopFuture<Void>
 
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -37,6 +37,7 @@ public enum SmokeDynamoDBError: Error {
     case multipleUnexpectedErrors(cause: [Swift.Error])
     case batchAPIExceededRetries(retryCount: Int)
     case validationError(reason: String)
+    case batchErrorsReturned(errorCount: Int, messageMap: [String: Int])
 }
 
 public typealias SmokeDynamoDBErrorResult<SuccessPayload> = Result<SuccessPayload, SmokeDynamoDBError>

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -103,7 +103,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
     /**
      * Provides the ability to bulk write database rows
      */
-    func bulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<Void>
+    func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<Void>
 
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -79,6 +79,11 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
                                                      existingItem: TypedDatabaseItem<AttributesType, ItemType>) -> EventLoopFuture<Void> {
         return storeWrapper.updateItem(newItem: newItem, existingItem: existingItem, eventLoop: self.eventLoop)
     }
+    
+    public func updateItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
+                                                          existing: TypedDatabaseItem<AttributesType, ItemType>)]) -> EventLoopFuture<Void> {
+        return storeWrapper.updateItems(items, eventLoop: self.eventLoop)
+    }
 
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>)
     -> EventLoopFuture<TypedDatabaseItem<AttributesType, ItemType>?> {
@@ -93,6 +98,14 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
 
     public func deleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>) -> EventLoopFuture<Void> {
         return storeWrapper.deleteItem(forKey: key, eventLoop: self.eventLoop)
+    }
+    
+    public func deleteItems<AttributesType>(forKeys keys: [CompositePrimaryKey<AttributesType>]) -> EventLoopFuture<Void> {
+        return storeWrapper.deleteItems(forKeys: keys, eventLoop: self.eventLoop)
+    }
+    
+    public func deleteItems<ItemType: DatabaseItem>(existingItems: [ItemType]) -> EventLoopFuture<Void> {
+        return storeWrapper.deleteItems(existingItems: existingItems, eventLoop: self.eventLoop)
     }
     
     public func deleteItem<AttributesType, ItemType>(existingItem: TypedDatabaseItem<AttributesType, ItemType>) -> EventLoopFuture<Void>

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -80,9 +80,10 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
         return storeWrapper.updateItem(newItem: newItem, existingItem: existingItem, eventLoop: self.eventLoop)
     }
     
-    public func updateItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
-                                                          existing: TypedDatabaseItem<AttributesType, ItemType>)]) -> EventLoopFuture<Void> {
-        return storeWrapper.updateItems(items, eventLoop: self.eventLoop)
+    public func updateOrInsertItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
+                                                                         existing: TypedDatabaseItem<AttributesType, ItemType>?)])
+    -> EventLoopFuture<Void> {
+        return storeWrapper.updateOrInsertItems(items, eventLoop: self.eventLoop)
     }
 
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -80,9 +80,9 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
         return storeWrapper.updateItem(newItem: newItem, existingItem: existingItem, eventLoop: self.eventLoop)
     }
     
-    public func bulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
+    public func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
     -> EventLoopFuture<Void> {
-        return storeWrapper.bulkWrite(entries, eventLoop: self.eventLoop)
+        return storeWrapper.monomorphicBulkWrite(entries, eventLoop: self.eventLoop)
     }
 
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -80,10 +80,9 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
         return storeWrapper.updateItem(newItem: newItem, existingItem: existingItem, eventLoop: self.eventLoop)
     }
     
-    public func updateOrInsertItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
-                                                                         existing: TypedDatabaseItem<AttributesType, ItemType>?)])
+    public func bulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
     -> EventLoopFuture<Void> {
-        return storeWrapper.updateOrInsertItems(items, eventLoop: self.eventLoop)
+        return storeWrapper.bulkWrite(entries, eventLoop: self.eventLoop)
     }
 
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -160,7 +160,7 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
             }
         }
         
-        return EventLoopFuture.andAllComplete(futures, on: eventLoop)
+        return EventLoopFuture.andAllSucceed(futures, on: eventLoop)
     }
 
     func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>,
@@ -298,7 +298,7 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
             return deleteItem(forKey: key, eventLoop: eventLoop)
         }
         
-        return EventLoopFuture.andAllComplete(futures, on: eventLoop)
+        return EventLoopFuture.andAllSucceed(futures, on: eventLoop)
     }
     
     func deleteItems<ItemType: DatabaseItem>(existingItems: [ItemType],
@@ -307,7 +307,7 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
             return deleteItem(existingItem: existingItem, eventLoop: eventLoop)
         }
         
-        return EventLoopFuture.andAllComplete(futures, on: eventLoop)
+        return EventLoopFuture.andAllSucceed(futures, on: eventLoop)
     }
 
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -149,7 +149,7 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         return promise.futureResult
     }
     
-    public func bulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>],
+    public func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>],
                                                     eventLoop: EventLoop) -> EventLoopFuture<Void> {
         let futures = entries.map { entry -> EventLoopFuture<Void> in
             switch entry {

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -77,7 +77,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
             }
         }
         
-        return EventLoopFuture.andAllComplete(futures, on: self.eventLoop)
+        return EventLoopFuture.andAllSucceed(futures, on: self.eventLoop)
     }
     
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>)
@@ -112,7 +112,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
                 return self.gsiLogic.onDeleteItem(forKey: key, gsiDataStore: self.gsiDataStore)
             }
             
-            return EventLoopFuture.andAllComplete(futures, on: eventLoop)
+            return EventLoopFuture.andAllSucceed(futures, on: eventLoop)
         }
     }
     
@@ -123,7 +123,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
                 return self.gsiLogic.onDeleteItem(forKey: existingItem.compositePrimaryKey, gsiDataStore: self.gsiDataStore)
             }
             
-            return EventLoopFuture.andAllComplete(futures, on: eventLoop)
+            return EventLoopFuture.andAllSucceed(futures, on: eventLoop)
         }
     }
     

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -66,7 +66,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         }
     }
     
-    public func bulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
+    public func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
     -> EventLoopFuture<Void> {
         let futures = entries.map { entry -> EventLoopFuture<Void> in
             switch entry {

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -66,14 +66,18 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         }
     }
     
-    public func updateOrInsertItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
-                                                                         existing: TypedDatabaseItem<AttributesType, ItemType>?)])
+    public func bulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
     -> EventLoopFuture<Void> {
-        let futures = items.map { (new, existing) -> EventLoopFuture<Void> in
-            if let existing = existing {
+        let futures = entries.map { entry -> EventLoopFuture<Void> in
+            switch entry {
+            case .update(new: let new, existing: let existing):
                 return updateItem(newItem: new, existingItem: existing)
-            } else {
+            case .insert(new: let new):
                 return insertItem(new)
+            case .deleteAtKey(key: let key):
+                return deleteItem(forKey: key)
+            case .deleteItem(existing: let existing):
+                return deleteItem(existingItem: existing)
             }
         }
         

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -116,7 +116,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
                 return self.gsiLogic.onDeleteItem(forKey: key, gsiDataStore: self.gsiDataStore)
             }
             
-            return EventLoopFuture.andAllSucceed(futures, on: eventLoop)
+            return EventLoopFuture.andAllSucceed(futures, on: self.eventLoop)
         }
     }
     
@@ -127,7 +127,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
                 return self.gsiLogic.onDeleteItem(forKey: existingItem.compositePrimaryKey, gsiDataStore: self.gsiDataStore)
             }
             
-            return EventLoopFuture.andAllSucceed(futures, on: eventLoop)
+            return EventLoopFuture.andAllSucceed(futures, on: self.eventLoop)
         }
     }
     

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -66,10 +66,15 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         }
     }
     
-    public func updateItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
-                                                          existing: TypedDatabaseItem<AttributesType, ItemType>)]) -> EventLoopFuture<Void> {
-        let futures = items.map { (new, existing) in
-            return updateItem(newItem: new, existingItem: existing)
+    public func updateOrInsertItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
+                                                                         existing: TypedDatabaseItem<AttributesType, ItemType>?)])
+    -> EventLoopFuture<Void> {
+        let futures = items.map { (new, existing) -> EventLoopFuture<Void> in
+            if let existing = existing {
+                return updateItem(newItem: new, existingItem: existing)
+            } else {
+                return insertItem(new)
+            }
         }
         
         return EventLoopFuture.andAllComplete(futures, on: self.eventLoop)

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -91,6 +91,15 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         return wrappedDynamoDBTable.updateItem(newItem: newItem, existingItem: existingItem)
     }
     
+    public func updateItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
+                                                          existing: TypedDatabaseItem<AttributesType, ItemType>)]) -> EventLoopFuture<Void> {
+        let futures = items.map { (new, existing) in
+            return updateItem(newItem: new, existingItem: existing)
+        }
+        
+        return EventLoopFuture.andAllComplete(futures, on: self.eventLoop)
+    }
+    
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>)
             -> EventLoopFuture<TypedDatabaseItem<AttributesType, ItemType>?> {
         // simply delegate to the wrapped implementation
@@ -112,6 +121,14 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
     public func deleteItem<AttributesType, ItemType>(existingItem: TypedDatabaseItem<AttributesType, ItemType>) -> EventLoopFuture<Void>
             where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         return wrappedDynamoDBTable.deleteItem(existingItem: existingItem)
+    }
+    
+    public func deleteItems<AttributesType>(forKeys keys: [CompositePrimaryKey<AttributesType>]) -> EventLoopFuture<Void> {
+        return wrappedDynamoDBTable.deleteItems(forKeys: keys)
+    }
+    
+    public func deleteItems<ItemType: DatabaseItem>(existingItems: [ItemType]) -> EventLoopFuture<Void> {
+        return wrappedDynamoDBTable.deleteItems(existingItems: existingItems)
     }
     
     public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -91,7 +91,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         return wrappedDynamoDBTable.updateItem(newItem: newItem, existingItem: existingItem)
     }
     
-    public func bulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
+    public func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
     -> EventLoopFuture<Void> {
         let futures = entries.map { entry -> EventLoopFuture<Void> in
             switch entry {

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -102,7 +102,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
             }
         }
         
-        return EventLoopFuture.andAllComplete(futures, on: self.eventLoop)
+        return EventLoopFuture.andAllSucceed(futures, on: self.eventLoop)
     }
     
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>)

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -91,10 +91,15 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         return wrappedDynamoDBTable.updateItem(newItem: newItem, existingItem: existingItem)
     }
     
-    public func updateItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
-                                                          existing: TypedDatabaseItem<AttributesType, ItemType>)]) -> EventLoopFuture<Void> {
-        let futures = items.map { (new, existing) in
-            return updateItem(newItem: new, existingItem: existing)
+    public func updateOrInsertItems<AttributesType, ItemType>(_ items: [(new: TypedDatabaseItem<AttributesType, ItemType>,
+                                                                         existing: TypedDatabaseItem<AttributesType, ItemType>?)])
+    -> EventLoopFuture<Void> {
+        let futures = items.map { (new, existing) -> EventLoopFuture<Void> in
+            if let existing = existing {
+                return updateItem(newItem: new, existingItem: existing)
+            } else {
+                return insertItem(new)
+            }
         }
         
         return EventLoopFuture.andAllComplete(futures, on: self.eventLoop)

--- a/Sources/SmokeDynamoDB/TypedDatabaseItem.swift
+++ b/Sources/SmokeDynamoDB/TypedDatabaseItem.swift
@@ -32,7 +32,19 @@ public struct RowStatus: Codable {
     }
 }
 
-public struct TypedDatabaseItem<AttributesType: PrimaryKeyAttributes, RowType: Codable>: Codable {
+public protocol DatabaseItem {
+    associatedtype AttributesType: PrimaryKeyAttributes
+    
+    var compositePrimaryKey: CompositePrimaryKey<AttributesType> { get }
+    var createDate: Date { get }
+    var rowStatus: RowStatus { get }
+}
+
+public protocol StandardDatabaseItem: DatabaseItem where AttributesType == StandardPrimaryKeyAttributes {
+    
+}
+
+public struct TypedDatabaseItem<AttributesType: PrimaryKeyAttributes, RowType: Codable>: DatabaseItem, Codable {
     public let compositePrimaryKey: CompositePrimaryKey<AttributesType>
     public let createDate: Date
     public let rowStatus: RowStatus

--- a/Tests/SmokeDynamoDBTests/TestConfiguration.swift
+++ b/Tests/SmokeDynamoDBTests/TestConfiguration.swift
@@ -30,6 +30,20 @@ struct TestTypeB: Codable, Equatable, CustomRowTypeIdentifier {
     let fourthly: String
 }
 
+struct TestTypeC: Codable {
+    let theString: String?
+    let theNumber: Int?
+    let theStruct: TestTypeA?
+    let theList: [String]?
+    
+    init(theString: String?, theNumber: Int?, theStruct: TestTypeA?, theList: [String]?) {
+        self.theString = theString
+        self.theNumber = theNumber
+        self.theStruct = theStruct
+        self.theList = theList
+    }
+}
+
 enum TestQueryableTypes: PolymorphicOperationReturnType {
     typealias AttributesType = StandardPrimaryKeyAttributes
     

--- a/Tests/SmokeDynamoDBTests/TypedDatabaseItem+RowWithItemVersionProtocolTests.swift
+++ b/Tests/SmokeDynamoDBTests/TypedDatabaseItem+RowWithItemVersionProtocolTests.swift
@@ -19,11 +19,30 @@ import Foundation
 
 import XCTest
 @testable import SmokeDynamoDB
+import NIO
 
 private let ORIGINAL_PAYLOAD = "Payload"
 private let UPDATED_PAYLOAD = "Updated"
 
 class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
+    var eventLoopGroup: EventLoopGroup?
+    var eventLoop: EventLoop!
+    
+    override func setUp() {
+        super.setUp()
+        
+        let newEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        eventLoop = newEventLoopGroup.next()
+        eventLoopGroup = newEventLoopGroup
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        
+        try? eventLoopGroup?.syncShutdownGracefully()
+        eventLoop = nil
+    }
+
 
     func testCreateUpdatedRowWithItemVersion() throws {
         let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
@@ -76,12 +95,391 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
             XCTFail("Unexpected error thrown: '\(error)'.")
         }
     }
-
+    
+    func testStringFieldDifference() throws {
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "eigthly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        XCTAssertEqual(pathMap["theString"], .update(path: "theString", value: "'eigthly'"))
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testNumberFieldDifference() throws {
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "firstly", theNumber: 12, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        XCTAssertEqual(pathMap["theNumber"], .update(path: "theNumber", value: "12"))
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testStructFieldDifference() throws {
+        let theStructA = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let theStructB = TestTypeA(firstly: "eigthly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStructA, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStructB, theList: ["thirdly", "fourthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        XCTAssertEqual(pathMap["theStruct.firstly"], .update(path: "theStruct.firstly", value: "'eigthly'"))
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testListFieldDifference() throws {
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "eigthly", "ninthly", "tenthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        XCTAssertEqual(pathMap["theList[1]"], .update(path: "theList[1]", value: "'eigthly'"))
+        XCTAssertEqual(pathMap["theList"], .listAppend(path: "theList", value: "['ninthly', 'tenthly']"))
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testStringFieldAddition() throws {
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: nil, theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "eigthly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        XCTAssertEqual(pathMap["theString"], .update(path: "theString", value: "'eigthly'"))
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testNumberFieldAddition() throws {
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: nil, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "firstly", theNumber: 12, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        XCTAssertEqual(pathMap["theNumber"], .update(path: "theNumber", value: "12"))
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testStructFieldAddition() throws {
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: nil, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        guard case .update(_, let value) = pathMap["theStruct"] else {
+            XCTFail()
+            return
+        }
+        
+        let valueMatches = (value == "{'firstly': 'firstly', 'secondly': 'secondly'}") ||
+            (value == "{'secondly': 'secondly', 'firstly': 'firstly'}")
+        
+        XCTAssertTrue(valueMatches)
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testListFieldAddition() throws {
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: nil)
+        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "eigthly", "ninthly", "tenthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        XCTAssertEqual(pathMap["theList"], .update(path: "theList", value: "['thirdly', 'eigthly', 'ninthly', 'tenthly']"))
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testStringFieldRemoval() throws {
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: nil, theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        XCTAssertEqual(pathMap["theString"], .remove(path: "theString"))
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testNumberFieldRemoval() throws {
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "firstly", theNumber: nil, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        XCTAssertEqual(pathMap["theNumber"], .remove(path: "theNumber"))
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testStructFieldRemoval() throws {
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: nil, theList: ["thirdly", "fourthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        XCTAssertEqual(pathMap["theStruct"], .remove(path: "theStruct"))
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testListFieldRemoval() throws {
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: nil)
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let differences = try table.diffItems(newItem: databaseItemB,
+                                              existingItem: databaseItemA)
+        let pathMap = differences.pathMap
+        
+        XCTAssertEqual(pathMap["theList"], .remove(path: "theList"))
+        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+    }
+    
+    func testListFieldDifferenceExpression() throws {
+        let tableName = "TableName"
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "eigthly", "ninthly", "tenthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let expression = try table.getUpdateExpression(tableName: tableName,
+                                                       newItem: databaseItemB,
+                                                       existingItem: databaseItemA)
+        XCTAssertEqual(expression, "UPDATE TableName "
+                                 + "SET theList[1]='eigthly' "
+                                 + "SET theList=list_append(theList,['ninthly', 'tenthly'] "
+                                 + "WHERE PK='partitionKey' AND SK='sortKey' "
+                                 + "AND RowVersion='1'")
+    }
+    
+    func testListFieldAdditionExpression() throws {
+        let tableName = "TableName"
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: nil)
+        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "eigthly", "ninthly", "tenthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let expression = try table.getUpdateExpression(tableName: tableName,
+                                                       newItem: databaseItemB,
+                                                       existingItem: databaseItemA)
+        XCTAssertEqual(expression, "UPDATE TableName "
+                                 + "SET theList=['thirdly', 'eigthly', 'ninthly', 'tenthly'] "
+                                 + "WHERE PK='partitionKey' AND SK='sortKey' "
+                                 + "AND RowVersion='1'")
+    }
+    
+    func testListFieldRemovalExpression() throws {
+        let tableName = "TableName"
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: nil)
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        let databaseItemB = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadB)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let expression = try table.getUpdateExpression(tableName: tableName,
+                                                       newItem: databaseItemB,
+                                                       existingItem: databaseItemA)
+        XCTAssertEqual(expression, "UPDATE TableName "
+                                 + "REMOVE theList "
+                                 + "WHERE PK='partitionKey' AND SK='sortKey' "
+                                 + "AND RowVersion='1'")
+    }
+    
+    func testDeleteItemExpression() throws {
+        let tableName = "TableName"
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let expression = try table.getDeleteExpression(tableName: tableName,
+                                                       existingItem: databaseItemA)
+        XCTAssertEqual(expression, "DELETE FROM TableName "
+                                 + "WHERE PK='partitionKey' AND SK='sortKey' "
+                                 + "AND RowVersion='1'")
+    }
+    
+    func testDeleteKeyExpression() throws {
+        let tableName = "TableName"
+        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
+        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
+                                                                 sortKey: "sortKey")
+        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
+        
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: self.eventLoop)
+        
+        let expression = try table.getDeleteExpression(tableName: tableName,
+                                                       existingItem: databaseItemA)
+        XCTAssertEqual(expression, "DELETE FROM TableName "
+                                 + "WHERE PK='partitionKey' AND SK='sortKey' "
+                                 + "AND RowVersion='1'")
+    }
+    
     static var allTests = [
         ("testCreateUpdatedRowWithItemVersion", testCreateUpdatedRowWithItemVersion),
         ("testCreateUpdatedRowWithItemVersionWithCorrectConditionalVersion",
          testCreateUpdatedRowWithItemVersionWithCorrectConditionalVersion),
         ("testCreateUpdatedRowWithItemVersionWithIncorrectConditionalVersion",
-         testCreateUpdatedRowWithItemVersionWithIncorrectConditionalVersion)
+         testCreateUpdatedRowWithItemVersionWithIncorrectConditionalVersion),
+        ("testStringFieldDifference", testStringFieldDifference),
+        ("testNumberFieldDifference", testNumberFieldDifference),
+        ("testStructFieldDifference", testStructFieldDifference),
+        ("testListFieldDifference", testListFieldDifference),
+        ("testStringFieldAddition", testStringFieldAddition),
+        ("testNumberFieldAddition", testNumberFieldAddition),
+        ("testStructFieldAddition", testStructFieldAddition),
+        ("testListFieldAddition", testListFieldAddition),
+        ("testStringFieldRemoval", testStringFieldRemoval),
+        ("testNumberFieldRemoval", testNumberFieldRemoval),
+        ("testStructFieldRemoval", testStructFieldRemoval),
+        ("testListFieldRemoval", testListFieldRemoval),
+        ("testListFieldDifferenceExpression", testListFieldDifferenceExpression),
+        ("testListFieldAdditionExpression", testListFieldAdditionExpression),
+        ("testDeleteItemExpression", testDeleteItemExpression),
     ]
+}
+
+extension Array where Element == AttributeDifference {
+    var pathMap: [String: AttributeDifference] {
+        var newPathMap: [String: AttributeDifference] = [:]
+        self.forEach { attributeDifference in
+            newPathMap[attributeDifference.path] = attributeDifference
+        }
+        
+        return newPathMap
+    }
 }

--- a/Tests/SmokeDynamoDBTests/TypedDatabaseItem+RowWithItemVersionProtocolTests.swift
+++ b/Tests/SmokeDynamoDBTests/TypedDatabaseItem+RowWithItemVersionProtocolTests.swift
@@ -362,11 +362,11 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
         let expression = try table.getUpdateExpression(tableName: tableName,
                                                        newItem: databaseItemB,
                                                        existingItem: databaseItemA)
-        XCTAssertEqual(expression, "UPDATE TableName "
+        XCTAssertEqual(expression, "UPDATE \"TableName\" "
                                  + "SET theList[1]='eigthly' "
                                  + "SET theList=list_append(theList,['ninthly', 'tenthly'] "
                                  + "WHERE PK='partitionKey' AND SK='sortKey' "
-                                 + "AND RowVersion='1'")
+                                 + "AND RowVersion=1")
     }
     
     func testListFieldAdditionExpression() throws {
@@ -385,10 +385,10 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
         let expression = try table.getUpdateExpression(tableName: tableName,
                                                        newItem: databaseItemB,
                                                        existingItem: databaseItemA)
-        XCTAssertEqual(expression, "UPDATE TableName "
+        XCTAssertEqual(expression, "UPDATE \"TableName\" "
                                  + "SET theList=['thirdly', 'eigthly', 'ninthly', 'tenthly'] "
                                  + "WHERE PK='partitionKey' AND SK='sortKey' "
-                                 + "AND RowVersion='1'")
+                                 + "AND RowVersion=1")
     }
     
     func testListFieldRemovalExpression() throws {
@@ -407,10 +407,10 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
         let expression = try table.getUpdateExpression(tableName: tableName,
                                                        newItem: databaseItemB,
                                                        existingItem: databaseItemA)
-        XCTAssertEqual(expression, "UPDATE TableName "
+        XCTAssertEqual(expression, "UPDATE \"TableName\" "
                                  + "REMOVE theList "
                                  + "WHERE PK='partitionKey' AND SK='sortKey' "
-                                 + "AND RowVersion='1'")
+                                 + "AND RowVersion=1")
     }
     
     func testDeleteItemExpression() throws {
@@ -426,9 +426,9 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
         
         let expression = try table.getDeleteExpression(tableName: tableName,
                                                        existingItem: databaseItemA)
-        XCTAssertEqual(expression, "DELETE FROM TableName "
+        XCTAssertEqual(expression, "DELETE FROM \"TableName\" "
                                  + "WHERE PK='partitionKey' AND SK='sortKey' "
-                                 + "AND RowVersion='1'")
+                                 + "AND RowVersion=1")
     }
     
     func testDeleteKeyExpression() throws {
@@ -444,9 +444,9 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
         
         let expression = try table.getDeleteExpression(tableName: tableName,
                                                        existingItem: databaseItemA)
-        XCTAssertEqual(expression, "DELETE FROM TableName "
+        XCTAssertEqual(expression, "DELETE FROM \"TableName\" "
                                  + "WHERE PK='partitionKey' AND SK='sortKey' "
-                                 + "AND RowVersion='1'")
+                                 + "AND RowVersion=1")
     }
     
     static var allTests = [

--- a/Tests/SmokeDynamoDBTests/TypedDatabaseItem+RowWithItemVersionProtocolTests.swift
+++ b/Tests/SmokeDynamoDBTests/TypedDatabaseItem+RowWithItemVersionProtocolTests.swift
@@ -363,8 +363,8 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
                                                        newItem: databaseItemB,
                                                        existingItem: databaseItemA)
         XCTAssertEqual(expression, "UPDATE \"TableName\" "
-                                 + "SET theList[1]='eigthly' "
-                                 + "SET theList=list_append(theList,['ninthly', 'tenthly'] "
+                                 + "SET \"theList[1]\"='eigthly' "
+                                 + "SET \"theList\"=list_append(theList,['ninthly', 'tenthly'] "
                                  + "WHERE PK='partitionKey' AND SK='sortKey' "
                                  + "AND RowVersion=1")
     }
@@ -386,7 +386,7 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
                                                        newItem: databaseItemB,
                                                        existingItem: databaseItemA)
         XCTAssertEqual(expression, "UPDATE \"TableName\" "
-                                 + "SET theList=['thirdly', 'eigthly', 'ninthly', 'tenthly'] "
+                                 + "SET \"theList\"=['thirdly', 'eigthly', 'ninthly', 'tenthly'] "
                                  + "WHERE PK='partitionKey' AND SK='sortKey' "
                                  + "AND RowVersion=1")
     }
@@ -408,7 +408,7 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
                                                        newItem: databaseItemB,
                                                        existingItem: databaseItemA)
         XCTAssertEqual(expression, "UPDATE \"TableName\" "
-                                 + "REMOVE theList "
+                                 + "REMOVE \"theList\" "
                                  + "WHERE PK='partitionKey' AND SK='sortKey' "
                                  + "AND RowVersion=1")
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add deleteItems and monomorphicBulkWrite APIs that uses DynamoDB's batchExecuteStatement.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
