### PR TITLE
Add missing right parentheses to list append statement

### DIFF
--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
@@ -68,7 +68,7 @@ extension DynamoDBCompositePrimaryKeyTable {
             case .remove(path: let path):
                 return "REMOVE \"\(path)\""
             case .listAppend(path: let path, value: let value):
-                return "SET \"\(path)\"=list_append(\(path),\(value)"
+                return "SET \"\(path)\"=list_append(\(path),\(value))"
             }
         }
         

--- a/Tests/SmokeDynamoDBTests/TypedDatabaseItem+RowWithItemVersionProtocolTests.swift
+++ b/Tests/SmokeDynamoDBTests/TypedDatabaseItem+RowWithItemVersionProtocolTests.swift
@@ -364,7 +364,7 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
                                                        existingItem: databaseItemA)
         XCTAssertEqual(expression, "UPDATE \"TableName\" "
                                  + "SET \"theList[1]\"='eigthly' "
-                                 + "SET \"theList\"=list_append(theList,['ninthly', 'tenthly'] "
+                                 + "SET \"theList\"=list_append(theList,['ninthly', 'tenthly']) "
                                  + "WHERE PK='partitionKey' AND SK='sortKey' "
                                  + "AND RowVersion=1")
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add missing right parentheses to list append statement
Reference - https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
