### PR TITLE
Use strong consistency for query operation

### DIFF
--- a/Sources/SmokeDynamoDB/QueryInput+forSortKeyCondition.swift
+++ b/Sources/SmokeDynamoDB/QueryInput+forSortKeyCondition.swift
@@ -80,7 +80,8 @@ extension QueryInput {
             inputExclusiveStartKey = nil
         }
 
-        return DynamoDBModel.QueryInput(exclusiveStartKey: inputExclusiveStartKey,
+        return DynamoDBModel.QueryInput(consistentRead: true,
+                                        exclusiveStartKey: inputExclusiveStartKey,
                                         expressionAttributeNames: expressionAttributeNames,
                                         expressionAttributeValues: expressionAttributeValues,
                                         indexName: primaryKeyType.indexName,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use strong consistency for query operation, otherwise it would get stale data from DynamoDB.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
