### PR TITLE
Add parameter consistentRead into argument of query operation

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
@@ -147,23 +147,27 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
     
     func query<ReturnedType: PolymorphicOperationReturnType>(
             forPartitionKey partitionKey: String,
-            sortKeyCondition: AttributeCondition?) -> EventLoopFuture<[ReturnedType]> {
+            sortKeyCondition: AttributeCondition?,
+            consistentRead: Bool?) -> EventLoopFuture<[ReturnedType]> {
         return partialQuery(forPartitionKey: partitionKey,
                             sortKeyCondition: sortKeyCondition,
-                            exclusiveStartKey: nil)
+                            exclusiveStartKey: nil,
+                            consistentRead: consistentRead)
     }
     
     // function to return a future with the results of a query call and all future paginated calls
     private func partialQuery<ReturnedType: PolymorphicOperationReturnType>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            exclusiveStartKey: String?) -> EventLoopFuture<[ReturnedType]> {
+            exclusiveStartKey: String?,
+            consistentRead: Bool?) -> EventLoopFuture<[ReturnedType]> {
         let queryFuture: EventLoopFuture<([ReturnedType], String?)> =
             query(forPartitionKey: partitionKey,
                   sortKeyCondition: sortKeyCondition,
                   limit: nil,
                   scanIndexForward: true,
-                  exclusiveStartKey: exclusiveStartKey)
+                  exclusiveStartKey: exclusiveStartKey,
+                  consistentRead: consistentRead)
         
         return queryFuture.flatMap { paginatedItems in
             // if there are more items
@@ -171,7 +175,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                 // returns a future with all the results from all later paginated calls
                 return self.partialQuery(forPartitionKey: partitionKey,
                                          sortKeyCondition: sortKeyCondition,
-                                         exclusiveStartKey: lastEvaluatedKey)
+                                         exclusiveStartKey: lastEvaluatedKey,
+                                         consistentRead: consistentRead)
                     .map { partialResult in
                         // return the results from 'this' call and all later paginated calls
                         return paginatedItems.0 + partialResult
@@ -188,25 +193,29 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
     func query<ReturnedType: PolymorphicOperationReturnType>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            limit: Int?, exclusiveStartKey: String?) -> EventLoopFuture<([ReturnedType], String?)> {
+            limit: Int?, exclusiveStartKey: String?,
+            consistentRead: Bool?) -> EventLoopFuture<([ReturnedType], String?)> {
         return query(forPartitionKey: partitionKey,
                      sortKeyCondition: sortKeyCondition,
                      limit: limit,
                      scanIndexForward: true,
-                     exclusiveStartKey: exclusiveStartKey)
+                     exclusiveStartKey: exclusiveStartKey,
+                     consistentRead: consistentRead)
     }
     
     func query<ReturnedType: PolymorphicOperationReturnType>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            limit: Int?, scanIndexForward: Bool, exclusiveStartKey: String?)
+            limit: Int?, scanIndexForward: Bool, exclusiveStartKey: String?,
+            consistentRead: Bool?)
             -> EventLoopFuture<([ReturnedType], String?)> {
         let queryInput: DynamoDBModel.QueryInput
         do {
             queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(forPartitionKey: partitionKey, targetTableName: targetTableName,
                                                                           primaryKeyType: ReturnedType.AttributesType.self,
                                                                           sortKeyCondition: sortKeyCondition, limit: limit,
-                                                                          scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
+                                                                          scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                                                                          consistentRead: consistentRead)
         } catch {
             let promise = self.eventLoop.makePromise(of: ([ReturnedType], String?).self)
             promise.fail(error)
@@ -284,25 +293,29 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
     
     func monomorphicQuery<AttributesType, ItemType>(
             forPartitionKey partitionKey: String,
-            sortKeyCondition: AttributeCondition?) -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
+            sortKeyCondition: AttributeCondition?,
+            consistentRead: Bool?) -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
             where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         return monomorphicPartialQuery(forPartitionKey: partitionKey,
                                        sortKeyCondition: sortKeyCondition,
-                                       exclusiveStartKey: nil)
+                                       exclusiveStartKey: nil,
+                                       consistentRead: consistentRead)
     }
     
     // function to return a future with the results of a query call and all future paginated calls
     private func monomorphicPartialQuery<AttributesType, ItemType>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            exclusiveStartKey: String?) -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
+            exclusiveStartKey: String?,
+            consistentRead: Bool?) -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
             where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         let queryFuture: EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> =
             monomorphicQuery(forPartitionKey: partitionKey,
                              sortKeyCondition: sortKeyCondition,
                              limit: nil,
                              scanIndexForward: true,
-                             exclusiveStartKey: nil)
+                             exclusiveStartKey: nil,
+                             consistentRead: consistentRead)
         
         return queryFuture.flatMap { paginatedItems in
             // if there are more items
@@ -310,7 +323,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                 // returns a future with all the results from all later paginated calls
                 return self.monomorphicPartialQuery(forPartitionKey: partitionKey,
                                                     sortKeyCondition: sortKeyCondition,
-                                                    exclusiveStartKey: lastEvaluatedKey)
+                                                    exclusiveStartKey: lastEvaluatedKey,
+                                                    consistentRead: consistentRead)
                     .map { partialResult in
                         // return the results from 'this' call and all later paginated calls
                         return paginatedItems.0 + partialResult
@@ -329,7 +343,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             sortKeyCondition: AttributeCondition?,
             limit: Int?,
             scanIndexForward: Bool,
-            exclusiveStartKey: String?) -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
+            exclusiveStartKey: String?,
+            consistentRead: Bool?) -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
             where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         let queryInput: DynamoDBModel.QueryInput
         do {
@@ -337,7 +352,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                 forPartitionKey: partitionKey, targetTableName: targetTableName,
                 primaryKeyType: AttributesType.self,
                 sortKeyCondition: sortKeyCondition, limit: limit,
-                scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
+                scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                consistentRead: consistentRead)
         } catch {
             let promise = self.eventLoop.makePromise(of: ([TypedDatabaseItem<AttributesType, ItemType>], String?).self)
             promise.fail(error)

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
@@ -1,0 +1,85 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeHTTPClient
+import DynamoDBModel
+import NIO
+
+public extension DynamoDBCompositePrimaryKeyTable {
+
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             consistentRead: Bool? = nil)
+    -> EventLoopFuture<[ReturnedType]> {
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     consistentRead: consistentRead)
+    }
+
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             limit: Int?,
+                                                             exclusiveStartKey: String?,
+                                                             consistentRead: Bool? = nil)
+    -> EventLoopFuture<([ReturnedType], String?)> {
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     limit: limit,
+                     exclusiveStartKey: exclusiveStartKey,
+                     consistentRead: consistentRead)
+    }
+
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             limit: Int?,
+                                                             scanIndexForward: Bool,
+                                                             exclusiveStartKey: String?,
+                                                             consistentRead: Bool? = nil)
+    -> EventLoopFuture<([ReturnedType], String?)> {
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     limit: limit,
+                     scanIndexForward: scanIndexForward,
+                     exclusiveStartKey: exclusiveStartKey,
+                     consistentRead: consistentRead)
+    }
+
+    func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                    sortKeyCondition: AttributeCondition?,
+                                                    consistentRead: Bool? = nil)
+    -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> {
+        return monomorphicQuery(forPartitionKey: partitionKey,
+                                sortKeyCondition: sortKeyCondition,
+                                consistentRead: consistentRead)
+    }
+
+    func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                    sortKeyCondition: AttributeCondition?,
+                                                    limit: Int?,
+                                                    scanIndexForward: Bool,
+                                                    exclusiveStartKey: String?,
+                                                    consistentRead: Bool? = nil)
+    -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> {
+        return monomorphicQuery(forPartitionKey: partitionKey,
+                                sortKeyCondition: sortKeyCondition,
+                                limit: limit,
+                                scanIndexForward: scanIndexForward,
+                                exclusiveStartKey: exclusiveStartKey,
+                                consistentRead: consistentRead)
+    }
+}

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -150,7 +150,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
        the query.
      */
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
-                                                             sortKeyCondition: AttributeCondition?)
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             consistentRead: Bool?)
         -> EventLoopFuture<[ReturnedType]>
 
     /**
@@ -161,7 +162,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                              sortKeyCondition: AttributeCondition?,
                                                              limit: Int?,
-                                                             exclusiveStartKey: String?)
+                                                             exclusiveStartKey: String?,
+                                                             consistentRead: Bool?)
         -> EventLoopFuture<([ReturnedType], String?)>
     
     /**
@@ -173,7 +175,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
                                                              sortKeyCondition: AttributeCondition?,
                                                              limit: Int?,
                                                              scanIndexForward: Bool,
-                                                             exclusiveStartKey: String?)
+                                                             exclusiveStartKey: String?,
+                                                             consistentRead: Bool?)
         -> EventLoopFuture<([ReturnedType], String?)>
     
     /**
@@ -216,7 +219,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
        the query.
      */
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
-                                                    sortKeyCondition: AttributeCondition?)
+                                                    sortKeyCondition: AttributeCondition?,
+                                                    consistentRead: Bool?)
         -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
     
     /**
@@ -228,7 +232,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
                                                         sortKeyCondition: AttributeCondition?,
                                                         limit: Int?,
                                                         scanIndexForward: Bool,
-                                                        exclusiveStartKey: String?)
+                                                        exclusiveStartKey: String?,
+                                                        consistentRead: Bool?)
         -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
     
     /**

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection+consistentReadQuery.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection+consistentReadQuery.swift
@@ -1,0 +1,61 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  DynamoDBCompositePrimaryKeysProjection+consistentReadQuery.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeHTTPClient
+import DynamoDBModel
+import NIO
+
+public extension DynamoDBCompositePrimaryKeysProjection {
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                               sortKeyCondition: AttributeCondition?,
+                               consistentRead: Bool? = nil)
+    -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]> {
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     consistentRead: consistentRead)
+    }
+    
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                               sortKeyCondition: AttributeCondition?,
+                               limit: Int?,
+                               exclusiveStartKey: String?,
+                               consistentRead: Bool? = nil)
+    -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)> {
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     limit: limit,
+                     exclusiveStartKey: exclusiveStartKey,
+                     consistentRead: consistentRead)
+        
+    }
+    
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                               sortKeyCondition: AttributeCondition?,
+                               limit: Int?,
+                               scanIndexForward: Bool,
+                               exclusiveStartKey: String?,
+                               consistentRead: Bool? = nil)
+    -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)> {
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     limit: limit,
+                     scanIndexForward: scanIndexForward,
+                     exclusiveStartKey: exclusiveStartKey,
+                     consistentRead: consistentRead)
+    }
+}

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
@@ -34,7 +34,8 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
        the query.
      */
     func query<AttributesType>(forPartitionKey partitionKey: String,
-                               sortKeyCondition: AttributeCondition?)
+                               sortKeyCondition: AttributeCondition?,
+                               consistentRead: Bool?)
         -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]>
 
     /**
@@ -45,13 +46,15 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
     func query<AttributesType>(forPartitionKey partitionKey: String,
                                sortKeyCondition: AttributeCondition?,
                                limit: Int?,
-                               exclusiveStartKey: String?)
+                               exclusiveStartKey: String?,
+                               consistentRead: Bool?)
         -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
     
     func query<AttributesType>(forPartitionKey partitionKey: String,
-                                   sortKeyCondition: AttributeCondition?,
-                                   limit: Int?,
-                                   scanIndexForward: Bool,
-                                   exclusiveStartKey: String?)
+                               sortKeyCondition: AttributeCondition?,
+                               limit: Int?,
+                               scanIndexForward: Bool,
+                               exclusiveStartKey: String?,
+                               consistentRead: Bool?)
         -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
 }

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -114,7 +114,8 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
     }
 
     public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
-                                                                    sortKeyCondition: AttributeCondition?)
+                                                                    sortKeyCondition: AttributeCondition?,
+                                                                    consistentRead: Bool?)
     -> EventLoopFuture<[ReturnedType]> {
         return storeWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition, eventLoop: self.eventLoop)
     }
@@ -122,7 +123,8 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
     public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                                     sortKeyCondition: AttributeCondition?,
                                                                     limit: Int?,
-                                                                    exclusiveStartKey: String?)
+                                                                    exclusiveStartKey: String?,
+                                                                    consistentRead: Bool?)
     -> EventLoopFuture<([ReturnedType], String?)> {
         return storeWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
                                   limit: limit, exclusiveStartKey: exclusiveStartKey, eventLoop: self.eventLoop)
@@ -132,7 +134,8 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
                                                                     sortKeyCondition: AttributeCondition?,
                                                                     limit: Int?,
                                                                     scanIndexForward: Bool,
-                                                                    exclusiveStartKey: String?)
+                                                                    exclusiveStartKey: String?,
+                                                                    consistentRead: Bool?)
     -> EventLoopFuture<([ReturnedType], String?)> {
         return storeWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
                                   limit: limit, scanIndexForward: scanIndexForward,
@@ -182,7 +185,8 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
     }
     
     public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
-                                                    sortKeyCondition: AttributeCondition?)
+                                                           sortKeyCondition: AttributeCondition?,
+                                                           consistentRead: Bool?)
     -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
     where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         return storeWrapper.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
@@ -194,7 +198,8 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
             sortKeyCondition: AttributeCondition?,
             limit: Int?,
             scanIndexForward: Bool,
-            exclusiveStartKey: String?)
+            exclusiveStartKey: String?,
+            consistentRead: Bool?)
     -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
     where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         return storeWrapper.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -131,7 +131,9 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         }
     }
     
-    public func query<ReturnedType>(forPartitionKey partitionKey: String, sortKeyCondition: AttributeCondition?)
+    public func query<ReturnedType>(forPartitionKey partitionKey: String,
+                                    sortKeyCondition: AttributeCondition?,
+                                    consistentRead: Bool? = nil)
     -> EventLoopFuture<[ReturnedType]> where ReturnedType : PolymorphicOperationReturnType {
         // if this is querying an index
         if let indexName = ReturnedType.AttributesType.indexName {
@@ -143,15 +145,19 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
             }
             
             // query on the index
-            return self.gsiDataStore.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition)
+            return self.gsiDataStore.query(forPartitionKey: partitionKey,
+                                           sortKeyCondition: sortKeyCondition,
+                                           consistentRead: consistentRead)
         }
         
         // query on the main table
-        return self.primaryTable.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition)
+        return self.primaryTable.query(forPartitionKey: partitionKey,
+                                       sortKeyCondition: sortKeyCondition,
+                                       consistentRead: consistentRead)
     }
     
     public func query<ReturnedType>(forPartitionKey partitionKey: String, sortKeyCondition: AttributeCondition?,
-                                    limit: Int?, exclusiveStartKey: String?)
+                                    limit: Int?, exclusiveStartKey: String?, consistentRead: Bool? = nil)
     -> EventLoopFuture<([ReturnedType], String?)> where ReturnedType : PolymorphicOperationReturnType {
         // if this is querying an index
         if let indexName = ReturnedType.AttributesType.indexName {
@@ -164,18 +170,19 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
             
             // query on the index
             return self.gsiDataStore.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                           limit: limit, exclusiveStartKey: exclusiveStartKey)
+                                           limit: limit, exclusiveStartKey: exclusiveStartKey, consistentRead: consistentRead)
         }
         
         // query on the main table
         return self.primaryTable.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                       limit: limit, exclusiveStartKey: exclusiveStartKey)
+                                       limit: limit, exclusiveStartKey: exclusiveStartKey, consistentRead: consistentRead)
     }
     
     public func query<ReturnedType>(forPartitionKey partitionKey: String,
                                     sortKeyCondition: AttributeCondition?,
                                     limit: Int?, scanIndexForward: Bool,
-                                    exclusiveStartKey: String?)
+                                    exclusiveStartKey: String?,
+                                    consistentRead: Bool? = nil)
     -> EventLoopFuture<([ReturnedType], String?)> where ReturnedType : PolymorphicOperationReturnType {
         // if this is querying an index
         if let indexName = ReturnedType.AttributesType.indexName {
@@ -188,12 +195,14 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
             
             // query on the index
             return self.gsiDataStore.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                           limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
+                                           limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                                           consistentRead: consistentRead)
         }
         
         // query on the main table
         return self.primaryTable.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                       limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
+                                       limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                                       consistentRead: consistentRead)
     }
     
     public func execute<ReturnedType>(partitionKeys: [String], attributesFilter: [String]?, additionalWhereClause: String?)
@@ -244,7 +253,9 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         return self.primaryTable.monomorphicGetItems(forKeys: keys)
     }
     
-    public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String, sortKeyCondition: AttributeCondition?)
+    public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                           sortKeyCondition: AttributeCondition?,
+                                                           consistentRead: Bool? = nil)
     -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> where AttributesType : PrimaryKeyAttributes, ItemType : Decodable,
                                                                             ItemType : Encodable {
         // if this is querying an index
@@ -257,15 +268,20 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
             }
             
             // query on the index
-            return self.gsiDataStore.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition)
+            return self.gsiDataStore.monomorphicQuery(forPartitionKey: partitionKey,
+                                                      sortKeyCondition: sortKeyCondition,
+                                                      consistentRead: consistentRead)
         }
         
         // query on the main table
-        return self.primaryTable.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition)
+        return self.primaryTable.monomorphicQuery(forPartitionKey: partitionKey,
+                                                  sortKeyCondition: sortKeyCondition,
+                                                  consistentRead: consistentRead)
     }
     
     public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String, sortKeyCondition: AttributeCondition?,
-                                                           limit: Int?, scanIndexForward: Bool, exclusiveStartKey: String?)
+                                                           limit: Int?, scanIndexForward: Bool, exclusiveStartKey: String?,
+                                                           consistentRead: Bool? = nil)
     -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> where AttributesType : PrimaryKeyAttributes,
                                                                                        ItemType : Decodable, ItemType : Encodable {
         // if this is querying an index
@@ -279,12 +295,14 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
             
             // query on the index
             return self.gsiDataStore.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                                      limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
+                                                      limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                                                      consistentRead: consistentRead)
         }
         
         // query on the main table
         return self.primaryTable.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                                  limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
+                                                  limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                                                  consistentRead: consistentRead)
     }
     
     public func monomorphicExecute<AttributesType, ItemType>(partitionKeys: [String], attributesFilter: [String]?, additionalWhereClause: String?)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
@@ -51,31 +51,36 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
     }
 
     public func query<AttributesType>(forPartitionKey partitionKey: String,
-                                      sortKeyCondition: AttributeCondition?)
+                                      sortKeyCondition: AttributeCondition?,
+                                      consistentRead: Bool?)
             -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]> {
         return keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                 eventLoop: self.eventLoop)
+                                 consistentRead: consistentRead, eventLoop: self.eventLoop)
     }
     
     public func query<AttributesType>(forPartitionKey partitionKey: String,
-                                          sortKeyCondition: AttributeCondition?,
-                                          limit: Int?,
-                                          exclusiveStartKey: String?)
+                                      sortKeyCondition: AttributeCondition?,
+                                      limit: Int?,
+                                      exclusiveStartKey: String?,
+                                      consistentRead: Bool?)
             -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
             where AttributesType: PrimaryKeyAttributes {
         return keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                 limit: limit, exclusiveStartKey: exclusiveStartKey, eventLoop: self.eventLoop)
+                                 limit: limit, exclusiveStartKey: exclusiveStartKey,
+                                 consistentRead: consistentRead, eventLoop: self.eventLoop)
     }
 
     public func query<AttributesType>(forPartitionKey partitionKey: String,
                                       sortKeyCondition: AttributeCondition?,
                                       limit: Int?,
                                       scanIndexForward: Bool,
-                                      exclusiveStartKey: String?)
+                                      exclusiveStartKey: String?,
+                                      consistentRead: Bool?)
     -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
     where AttributesType: PrimaryKeyAttributes {
         return keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
                                  limit: limit, scanIndexForward: scanIndexForward,
-                                 exclusiveStartKey: exclusiveStartKey, eventLoop: self.eventLoop)
+                                 exclusiveStartKey: exclusiveStartKey, consistentRead: consistentRead,
+                                 eventLoop: self.eventLoop)
     }
 }

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
@@ -43,6 +43,7 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjectionStore {
 
     public func query<AttributesType>(forPartitionKey partitionKey: String,
                                       sortKeyCondition: AttributeCondition?,
+                                      consistentRead: Bool? = nil,
                                       eventLoop: EventLoop)
             -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]> {
         let promise = eventLoop.makePromise(of: [CompositePrimaryKey<AttributesType>].self)
@@ -112,10 +113,11 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjectionStore {
     }
     
     public func query<AttributesType>(forPartitionKey partitionKey: String,
-                                          sortKeyCondition: AttributeCondition?,
-                                          limit: Int?,
-                                          exclusiveStartKey: String?,
-                                          eventLoop: EventLoop)
+                                      sortKeyCondition: AttributeCondition?,
+                                      limit: Int?,
+                                      exclusiveStartKey: String?,
+                                      consistentRead: Bool? = nil,
+                                      eventLoop: EventLoop)
             -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
             where AttributesType: PrimaryKeyAttributes {
         return query(forPartitionKey: partitionKey,
@@ -123,6 +125,7 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjectionStore {
                      limit: limit,
                      scanIndexForward: true,
                      exclusiveStartKey: exclusiveStartKey,
+                     consistentRead: consistentRead,
                      eventLoop: eventLoop)
     }
 
@@ -131,12 +134,14 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjectionStore {
                                       limit: Int?,
                                       scanIndexForward: Bool,
                                       exclusiveStartKey: String?,
+                                      consistentRead: Bool? = nil,
                                       eventLoop: EventLoop)
             -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
             where AttributesType: PrimaryKeyAttributes {
         // get all the results
         return query(forPartitionKey: partitionKey,
                      sortKeyCondition: sortKeyCondition,
+                     consistentRead: consistentRead,
                      eventLoop: eventLoop)
             .map { (rawItems: [CompositePrimaryKey<AttributesType>]) in
                 let items: [CompositePrimaryKey<AttributesType>]

--- a/Sources/SmokeDynamoDB/QueryInput+forSortKeyCondition.swift
+++ b/Sources/SmokeDynamoDB/QueryInput+forSortKeyCondition.swift
@@ -25,7 +25,8 @@ extension QueryInput {
                                                                  sortKeyCondition: AttributeCondition?,
                                                                  limit: Int?,
                                                                  scanIndexForward: Bool,
-                                                                 exclusiveStartKey: String?) throws
+                                                                 exclusiveStartKey: String?,
+                                                                 consistentRead: Bool?) throws
         -> DynamoDBModel.QueryInput where AttributesType: PrimaryKeyAttributes {
         let expressionAttributeValues: [String: DynamoDBModel.AttributeValue]
         let expressionAttributeNames: [String: String]
@@ -80,7 +81,7 @@ extension QueryInput {
             inputExclusiveStartKey = nil
         }
 
-        return DynamoDBModel.QueryInput(consistentRead: true,
+        return DynamoDBModel.QueryInput(consistentRead: consistentRead,
                                         exclusiveStartKey: inputExclusiveStartKey,
                                         expressionAttributeNames: expressionAttributeNames,
                                         expressionAttributeValues: expressionAttributeValues,

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -141,37 +141,43 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
     }
     
     public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
-                                                                    sortKeyCondition: AttributeCondition?)
+                                                                    sortKeyCondition: AttributeCondition?,
+                                                                    consistentRead: Bool? = nil)
             -> EventLoopFuture<[ReturnedType]> {
         // simply delegate to the wrapped implementation
         return wrappedDynamoDBTable.query(forPartitionKey: partitionKey,
-                                          sortKeyCondition: sortKeyCondition)
+                                          sortKeyCondition: sortKeyCondition,
+                                          consistentRead: consistentRead)
     }
     
     public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                                     sortKeyCondition: AttributeCondition?,
                                                                     limit: Int?,
-                                                                    exclusiveStartKey: String?)
+                                                                    exclusiveStartKey: String?,
+                                                                    consistentRead: Bool? = nil)
         -> EventLoopFuture<([ReturnedType], String?)> {
             // simply delegate to the wrapped implementation
             return wrappedDynamoDBTable.query(forPartitionKey: partitionKey,
                                               sortKeyCondition: sortKeyCondition,
                                               limit: limit,
-                                              exclusiveStartKey: exclusiveStartKey)
+                                              exclusiveStartKey: exclusiveStartKey,
+                                              consistentRead: consistentRead)
     }
     
     public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                                     sortKeyCondition: AttributeCondition?,
                                                                     limit: Int?,
                                                                     scanIndexForward: Bool,
-                                                                    exclusiveStartKey: String?)
+                                                                    exclusiveStartKey: String?,
+                                                                    consistentRead: Bool? = nil)
         -> EventLoopFuture<([ReturnedType], String?)> {
             // simply delegate to the wrapped implementation
             return wrappedDynamoDBTable.query(forPartitionKey: partitionKey,
                                               sortKeyCondition: sortKeyCondition,
                                               limit: limit,
                                               scanIndexForward: scanIndexForward,
-                                              exclusiveStartKey: exclusiveStartKey)
+                                              exclusiveStartKey: exclusiveStartKey,
+                                              consistentRead: consistentRead)
     }
     
     public func execute<ReturnedType: PolymorphicOperationReturnType>(
@@ -224,19 +230,22 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
     }
     
     public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
-                                                           sortKeyCondition: AttributeCondition?)
+                                                           sortKeyCondition: AttributeCondition?,
+                                                           consistentRead: Bool? = nil)
     -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
     where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         // simply delegate to the wrapped implementation
         return wrappedDynamoDBTable.monomorphicQuery(forPartitionKey: partitionKey,
-                                                     sortKeyCondition: sortKeyCondition)
+                                                     sortKeyCondition: sortKeyCondition,
+                                                     consistentRead: consistentRead)
     }
     
     public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
                                                            sortKeyCondition: AttributeCondition?,
                                                            limit: Int?,
                                                            scanIndexForward: Bool,
-                                                           exclusiveStartKey: String?)
+                                                           exclusiveStartKey: String?,
+                                                           consistentRead: Bool? = nil)
     -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
     where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         // simply delegate to the wrapped implementation
@@ -244,6 +253,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
                                                      sortKeyCondition: sortKeyCondition,
                                                      limit: limit,
                                                      scanIndexForward: scanIndexForward,
-                                                     exclusiveStartKey: exclusiveStartKey)
+                                                     exclusiveStartKey: exclusiveStartKey,
+                                                     consistentRead: consistentRead)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add parameter consistentRead into argument of query operation.  Use eventual consistency by default and can set strong consistency via set consistentRead to true.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
