### PR TITLE
Add parameter consistentRead into argument of query operation

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionAsync.swift
@@ -77,6 +77,7 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
                      limit: limit,
                      scanIndexForward: true,
                      exclusiveStartKey: exclusiveStartKey)
+        
     }
     
     func query<AttributesType>(
@@ -91,7 +92,8 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
             queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(forPartitionKey: partitionKey, targetTableName: targetTableName,
                                                                           primaryKeyType: AttributesType.self,
                                                                           sortKeyCondition: sortKeyCondition, limit: limit,
-                                                                          scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
+                                                                          scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                                                                          consistentRead: false)
         } catch {
             let promise = self.eventLoop.makePromise(of: ([CompositePrimaryKey<AttributesType>], String?).self)
             promise.fail(error)

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
@@ -1,0 +1,80 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
+//  SmokeDynamoDB
+//
+
+import Foundation
+import SmokeHTTPClient
+import DynamoDBModel
+import NIO
+
+public extension DynamoDBCompositePrimaryKeyTable {
+
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?)
+    -> EventLoopFuture<[ReturnedType]> {
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     consistentRead: true)
+    }
+
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             limit: Int?,
+                                                             exclusiveStartKey: String?)
+    -> EventLoopFuture<([ReturnedType], String?)> {
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     limit: limit,
+                     exclusiveStartKey: exclusiveStartKey,
+                     consistentRead: true)
+    }
+
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             limit: Int?,
+                                                             scanIndexForward: Bool,
+                                                             exclusiveStartKey: String?)
+    -> EventLoopFuture<([ReturnedType], String?)> {
+        return query(forPartitionKey: partitionKey,
+                     sortKeyCondition: sortKeyCondition,
+                     limit: limit,
+                     scanIndexForward: scanIndexForward,
+                     exclusiveStartKey: exclusiveStartKey,
+                     consistentRead: true)
+    }
+
+    func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                    sortKeyCondition: AttributeCondition?)
+    -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> {
+        return monomorphicQuery(forPartitionKey: partitionKey,
+                                sortKeyCondition: sortKeyCondition,
+                                consistentRead: true)
+    }
+
+    func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                    sortKeyCondition: AttributeCondition?,
+                                                    limit: Int?,
+                                                    scanIndexForward: Bool,
+                                                    exclusiveStartKey: String?)
+    -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> {
+        return monomorphicQuery(forPartitionKey: partitionKey,
+                                sortKeyCondition: sortKeyCondition,
+                                limit: limit,
+                                scanIndexForward: scanIndexForward,
+                                exclusiveStartKey: exclusiveStartKey,
+                                consistentRead: true)
+    }
+}

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -150,7 +150,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
        the query.
      */
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
-                                                             sortKeyCondition: AttributeCondition?)
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             consistentRead: Bool)
         -> EventLoopFuture<[ReturnedType]>
 
     /**
@@ -161,7 +162,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                              sortKeyCondition: AttributeCondition?,
                                                              limit: Int?,
-                                                             exclusiveStartKey: String?)
+                                                             exclusiveStartKey: String?,
+                                                             consistentRead: Bool)
         -> EventLoopFuture<([ReturnedType], String?)>
     
     /**
@@ -173,7 +175,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
                                                              sortKeyCondition: AttributeCondition?,
                                                              limit: Int?,
                                                              scanIndexForward: Bool,
-                                                             exclusiveStartKey: String?)
+                                                             exclusiveStartKey: String?,
+                                                             consistentRead: Bool)
         -> EventLoopFuture<([ReturnedType], String?)>
     
     /**
@@ -216,7 +219,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
        the query.
      */
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
-                                                    sortKeyCondition: AttributeCondition?)
+                                                    sortKeyCondition: AttributeCondition?,
+                                                    consistentRead: Bool)
         -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
     
     /**
@@ -228,7 +232,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
                                                         sortKeyCondition: AttributeCondition?,
                                                         limit: Int?,
                                                         scanIndexForward: Bool,
-                                                        exclusiveStartKey: String?)
+                                                        exclusiveStartKey: String?,
+                                                        consistentRead: Bool)
         -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
     
     /**

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
@@ -49,9 +49,9 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
         -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
     
     func query<AttributesType>(forPartitionKey partitionKey: String,
-                                   sortKeyCondition: AttributeCondition?,
-                                   limit: Int?,
-                                   scanIndexForward: Bool,
-                                   exclusiveStartKey: String?)
+                               sortKeyCondition: AttributeCondition?,
+                               limit: Int?,
+                               scanIndexForward: Bool,
+                               exclusiveStartKey: String?)
         -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
 }

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -114,7 +114,8 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
     }
 
     public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
-                                                                    sortKeyCondition: AttributeCondition?)
+                                                                    sortKeyCondition: AttributeCondition?,
+                                                                    consistentRead: Bool)
     -> EventLoopFuture<[ReturnedType]> {
         return storeWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition, eventLoop: self.eventLoop)
     }
@@ -122,7 +123,8 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
     public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                                     sortKeyCondition: AttributeCondition?,
                                                                     limit: Int?,
-                                                                    exclusiveStartKey: String?)
+                                                                    exclusiveStartKey: String?,
+                                                                    consistentRead: Bool)
     -> EventLoopFuture<([ReturnedType], String?)> {
         return storeWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
                                   limit: limit, exclusiveStartKey: exclusiveStartKey, eventLoop: self.eventLoop)
@@ -132,7 +134,8 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
                                                                     sortKeyCondition: AttributeCondition?,
                                                                     limit: Int?,
                                                                     scanIndexForward: Bool,
-                                                                    exclusiveStartKey: String?)
+                                                                    exclusiveStartKey: String?,
+                                                                    consistentRead: Bool)
     -> EventLoopFuture<([ReturnedType], String?)> {
         return storeWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
                                   limit: limit, scanIndexForward: scanIndexForward,
@@ -182,7 +185,8 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
     }
     
     public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
-                                                    sortKeyCondition: AttributeCondition?)
+                                                           sortKeyCondition: AttributeCondition?,
+                                                           consistentRead: Bool)
     -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
     where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         return storeWrapper.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
@@ -194,7 +198,8 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
             sortKeyCondition: AttributeCondition?,
             limit: Int?,
             scanIndexForward: Bool,
-            exclusiveStartKey: String?)
+            exclusiveStartKey: String?,
+            consistentRead: Bool)
     -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
     where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         return storeWrapper.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -131,7 +131,9 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         }
     }
     
-    public func query<ReturnedType>(forPartitionKey partitionKey: String, sortKeyCondition: AttributeCondition?)
+    public func query<ReturnedType>(forPartitionKey partitionKey: String,
+                                    sortKeyCondition: AttributeCondition?,
+                                    consistentRead: Bool)
     -> EventLoopFuture<[ReturnedType]> where ReturnedType : PolymorphicOperationReturnType {
         // if this is querying an index
         if let indexName = ReturnedType.AttributesType.indexName {
@@ -143,15 +145,19 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
             }
             
             // query on the index
-            return self.gsiDataStore.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition)
+            return self.gsiDataStore.query(forPartitionKey: partitionKey,
+                                           sortKeyCondition: sortKeyCondition,
+                                           consistentRead: consistentRead)
         }
         
         // query on the main table
-        return self.primaryTable.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition)
+        return self.primaryTable.query(forPartitionKey: partitionKey,
+                                       sortKeyCondition: sortKeyCondition,
+                                       consistentRead: consistentRead)
     }
     
     public func query<ReturnedType>(forPartitionKey partitionKey: String, sortKeyCondition: AttributeCondition?,
-                                    limit: Int?, exclusiveStartKey: String?)
+                                    limit: Int?, exclusiveStartKey: String?, consistentRead: Bool)
     -> EventLoopFuture<([ReturnedType], String?)> where ReturnedType : PolymorphicOperationReturnType {
         // if this is querying an index
         if let indexName = ReturnedType.AttributesType.indexName {
@@ -164,18 +170,19 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
             
             // query on the index
             return self.gsiDataStore.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                           limit: limit, exclusiveStartKey: exclusiveStartKey)
+                                           limit: limit, exclusiveStartKey: exclusiveStartKey, consistentRead: consistentRead)
         }
         
         // query on the main table
         return self.primaryTable.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                       limit: limit, exclusiveStartKey: exclusiveStartKey)
+                                       limit: limit, exclusiveStartKey: exclusiveStartKey, consistentRead: consistentRead)
     }
     
     public func query<ReturnedType>(forPartitionKey partitionKey: String,
                                     sortKeyCondition: AttributeCondition?,
                                     limit: Int?, scanIndexForward: Bool,
-                                    exclusiveStartKey: String?)
+                                    exclusiveStartKey: String?,
+                                    consistentRead: Bool)
     -> EventLoopFuture<([ReturnedType], String?)> where ReturnedType : PolymorphicOperationReturnType {
         // if this is querying an index
         if let indexName = ReturnedType.AttributesType.indexName {
@@ -188,12 +195,14 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
             
             // query on the index
             return self.gsiDataStore.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                           limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
+                                           limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                                           consistentRead: consistentRead)
         }
         
         // query on the main table
         return self.primaryTable.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                       limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
+                                       limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                                       consistentRead: consistentRead)
     }
     
     public func execute<ReturnedType>(partitionKeys: [String], attributesFilter: [String]?, additionalWhereClause: String?)
@@ -244,7 +253,9 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         return self.primaryTable.monomorphicGetItems(forKeys: keys)
     }
     
-    public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String, sortKeyCondition: AttributeCondition?)
+    public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                           sortKeyCondition: AttributeCondition?,
+                                                           consistentRead: Bool)
     -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> where AttributesType : PrimaryKeyAttributes, ItemType : Decodable,
                                                                             ItemType : Encodable {
         // if this is querying an index
@@ -257,15 +268,20 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
             }
             
             // query on the index
-            return self.gsiDataStore.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition)
+            return self.gsiDataStore.monomorphicQuery(forPartitionKey: partitionKey,
+                                                      sortKeyCondition: sortKeyCondition,
+                                                      consistentRead: consistentRead)
         }
         
         // query on the main table
-        return self.primaryTable.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition)
+        return self.primaryTable.monomorphicQuery(forPartitionKey: partitionKey,
+                                                  sortKeyCondition: sortKeyCondition,
+                                                  consistentRead: consistentRead)
     }
     
     public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String, sortKeyCondition: AttributeCondition?,
-                                                           limit: Int?, scanIndexForward: Bool, exclusiveStartKey: String?)
+                                                           limit: Int?, scanIndexForward: Bool, exclusiveStartKey: String?,
+                                                           consistentRead: Bool)
     -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)> where AttributesType : PrimaryKeyAttributes,
                                                                                        ItemType : Decodable, ItemType : Encodable {
         // if this is querying an index
@@ -279,12 +295,14 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
             
             // query on the index
             return self.gsiDataStore.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                                      limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
+                                                      limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                                                      consistentRead: consistentRead)
         }
         
         // query on the main table
         return self.primaryTable.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                                  limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey)
+                                                  limit: limit, scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                                                  consistentRead: consistentRead)
     }
     
     public func monomorphicExecute<AttributesType, ItemType>(partitionKeys: [String], attributesFilter: [String]?, additionalWhereClause: String?)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
@@ -52,16 +52,15 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
 
     public func query<AttributesType>(forPartitionKey partitionKey: String,
                                       sortKeyCondition: AttributeCondition?)
-            -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]> {
-        return keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                 eventLoop: self.eventLoop)
+    -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]> {
+        return keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition, eventLoop: self.eventLoop)
     }
     
     public func query<AttributesType>(forPartitionKey partitionKey: String,
-                                          sortKeyCondition: AttributeCondition?,
-                                          limit: Int?,
-                                          exclusiveStartKey: String?)
-            -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
+                                      sortKeyCondition: AttributeCondition?,
+                                      limit: Int?,
+                                      exclusiveStartKey: String?)
+    -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
             where AttributesType: PrimaryKeyAttributes {
         return keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
                                  limit: limit, exclusiveStartKey: exclusiveStartKey, eventLoop: self.eventLoop)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
@@ -112,10 +112,10 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjectionStore {
     }
     
     public func query<AttributesType>(forPartitionKey partitionKey: String,
-                                          sortKeyCondition: AttributeCondition?,
-                                          limit: Int?,
-                                          exclusiveStartKey: String?,
-                                          eventLoop: EventLoop)
+                                      sortKeyCondition: AttributeCondition?,
+                                      limit: Int?,
+                                      exclusiveStartKey: String?,
+                                      eventLoop: EventLoop)
             -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
             where AttributesType: PrimaryKeyAttributes {
         return query(forPartitionKey: partitionKey,

--- a/Sources/SmokeDynamoDB/QueryInput+forSortKeyCondition.swift
+++ b/Sources/SmokeDynamoDB/QueryInput+forSortKeyCondition.swift
@@ -25,7 +25,8 @@ extension QueryInput {
                                                                  sortKeyCondition: AttributeCondition?,
                                                                  limit: Int?,
                                                                  scanIndexForward: Bool,
-                                                                 exclusiveStartKey: String?) throws
+                                                                 exclusiveStartKey: String?,
+                                                                 consistentRead: Bool?) throws
         -> DynamoDBModel.QueryInput where AttributesType: PrimaryKeyAttributes {
         let expressionAttributeValues: [String: DynamoDBModel.AttributeValue]
         let expressionAttributeNames: [String: String]
@@ -80,7 +81,7 @@ extension QueryInput {
             inputExclusiveStartKey = nil
         }
 
-        return DynamoDBModel.QueryInput(consistentRead: true,
+        return DynamoDBModel.QueryInput(consistentRead: consistentRead,
                                         exclusiveStartKey: inputExclusiveStartKey,
                                         expressionAttributeNames: expressionAttributeNames,
                                         expressionAttributeValues: expressionAttributeValues,

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -141,37 +141,43 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
     }
     
     public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
-                                                                    sortKeyCondition: AttributeCondition?)
-            -> EventLoopFuture<[ReturnedType]> {
+                                                                    sortKeyCondition: AttributeCondition?,
+                                                                    consistentRead: Bool)
+    -> EventLoopFuture<[ReturnedType]> {
         // simply delegate to the wrapped implementation
         return wrappedDynamoDBTable.query(forPartitionKey: partitionKey,
-                                          sortKeyCondition: sortKeyCondition)
+                                          sortKeyCondition: sortKeyCondition,
+                                          consistentRead: consistentRead)
     }
     
     public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                                     sortKeyCondition: AttributeCondition?,
                                                                     limit: Int?,
-                                                                    exclusiveStartKey: String?)
-        -> EventLoopFuture<([ReturnedType], String?)> {
-            // simply delegate to the wrapped implementation
-            return wrappedDynamoDBTable.query(forPartitionKey: partitionKey,
-                                              sortKeyCondition: sortKeyCondition,
-                                              limit: limit,
-                                              exclusiveStartKey: exclusiveStartKey)
+                                                                    exclusiveStartKey: String?,
+                                                                    consistentRead: Bool)
+    -> EventLoopFuture<([ReturnedType], String?)> {
+        // simply delegate to the wrapped implementation
+        return wrappedDynamoDBTable.query(forPartitionKey: partitionKey,
+                                          sortKeyCondition: sortKeyCondition,
+                                          limit: limit,
+                                          exclusiveStartKey: exclusiveStartKey,
+                                          consistentRead: consistentRead)
     }
     
     public func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                                     sortKeyCondition: AttributeCondition?,
                                                                     limit: Int?,
                                                                     scanIndexForward: Bool,
-                                                                    exclusiveStartKey: String?)
-        -> EventLoopFuture<([ReturnedType], String?)> {
-            // simply delegate to the wrapped implementation
-            return wrappedDynamoDBTable.query(forPartitionKey: partitionKey,
-                                              sortKeyCondition: sortKeyCondition,
-                                              limit: limit,
-                                              scanIndexForward: scanIndexForward,
-                                              exclusiveStartKey: exclusiveStartKey)
+                                                                    exclusiveStartKey: String?,
+                                                                    consistentRead: Bool)
+    -> EventLoopFuture<([ReturnedType], String?)> {
+        // simply delegate to the wrapped implementation
+        return wrappedDynamoDBTable.query(forPartitionKey: partitionKey,
+                                          sortKeyCondition: sortKeyCondition,
+                                          limit: limit,
+                                          scanIndexForward: scanIndexForward,
+                                          exclusiveStartKey: exclusiveStartKey,
+                                          consistentRead: consistentRead)
     }
     
     public func execute<ReturnedType: PolymorphicOperationReturnType>(
@@ -224,19 +230,22 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
     }
     
     public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
-                                                           sortKeyCondition: AttributeCondition?)
+                                                           sortKeyCondition: AttributeCondition?,
+                                                           consistentRead: Bool)
     -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]>
     where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         // simply delegate to the wrapped implementation
         return wrappedDynamoDBTable.monomorphicQuery(forPartitionKey: partitionKey,
-                                                     sortKeyCondition: sortKeyCondition)
+                                                     sortKeyCondition: sortKeyCondition,
+                                                     consistentRead: consistentRead)
     }
     
     public func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
                                                            sortKeyCondition: AttributeCondition?,
                                                            limit: Int?,
                                                            scanIndexForward: Bool,
-                                                           exclusiveStartKey: String?)
+                                                           exclusiveStartKey: String?,
+                                                           consistentRead: Bool)
     -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
     where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         // simply delegate to the wrapped implementation
@@ -244,6 +253,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
                                                      sortKeyCondition: sortKeyCondition,
                                                      limit: limit,
                                                      scanIndexForward: scanIndexForward,
-                                                     exclusiveStartKey: exclusiveStartKey)
+                                                     exclusiveStartKey: exclusiveStartKey,
+                                                     consistentRead: consistentRead)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
Add parameter consistentRead into argument of query operation for non GSI query operation. Create function variant that use strong consistency by default.

Also, Set eventual consistency for GSI query operation as DynamoDB not support strong consistency for GSI. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
