### PR TITLE
Add async/await apis

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.4.3", "5.3.3", "5.2.5"]
+        swift: ["5.4.3", "5.3.3"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "d5bd8d6526fa861adf18be7217bc180e6c13ac0d",
-          "version": "1.6.2"
+          "revision": "1081b0b0541f535ca088acdb56f5ca5598bc6247",
+          "version": "1.6.3"
         }
       },
       {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-dynamodb/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.3|5.4-orange.svg?style=flat" alt="Swift 5.3, 5.4 and 5.5 Tested">
+<img src="https://img.shields.io/badge/swift-5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.3, 5.4 and 5.5 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 18.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-dynamodb/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4-orange.svg?style=flat" alt="Swift 5.2, 5.3, 5.4 and 5.5 Tested">
+<img src="https://img.shields.io/badge/swift-5.3|5.4-orange.svg?style=flat" alt="Swift 5.3, 5.4 and 5.5 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 18.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
@@ -211,7 +211,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             -> EventLoopFuture<([ReturnedType], String?)> {
         let queryInput: DynamoDBModel.QueryInput
         do {
-            queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(forPartitionKey: partitionKey, targetTableName: targetTableName,
+            queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(partitionKey: partitionKey, targetTableName: targetTableName,
                                                                           primaryKeyType: ReturnedType.AttributesType.self,
                                                                           sortKeyCondition: sortKeyCondition, limit: limit,
                                                                           scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
@@ -349,7 +349,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         let queryInput: DynamoDBModel.QueryInput
         do {
             queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(
-                forPartitionKey: partitionKey, targetTableName: targetTableName,
+                partitionKey: partitionKey, targetTableName: targetTableName,
                 primaryKeyType: AttributesType.self,
                 sortKeyCondition: sortKeyCondition, limit: limit,
                 scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionAsync.swift
@@ -89,7 +89,7 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
             where AttributesType: PrimaryKeyAttributes {
         let queryInput: DynamoDBModel.QueryInput
         do {
-            queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(forPartitionKey: partitionKey, targetTableName: targetTableName,
+            queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(partitionKey: partitionKey, targetTableName: targetTableName,
                                                                           primaryKeyType: AttributesType.self,
                                                                           sortKeyCondition: sortKeyCondition, limit: limit,
                                                                           scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyGSILogic.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyGSILogic.swift
@@ -51,4 +51,77 @@ public protocol DynamoDBCompositePrimaryKeyGSILogic {
      */
     func onDeleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>,
                                       gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) -> EventLoopFuture<Void>
+    
+#if compiler(>=5.5) && canImport(_Concurrency)
+    /**
+     * Called when an item is inserted on the main table. Can be used to transform the provided item to the item that would be made available on the GSI.
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func onInsertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
+                                                gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws
+
+    /**
+     * Called when an item is clobbered on the main table. Can be used to transform the provided item to the item that would be made available on the GSI.
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func onClobberItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
+                                                 gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws
+
+    /**
+     * Called when an item is updated on the main table. Can be used to transform the provided item to the item that would be made available on the GSI.
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func onUpdateItem<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                existingItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws
+ 
+    /**
+     * Called when an item is delete on the main table. Can be used to also delete the corresponding item on the GSI.
+
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func onDeleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>,
+                                      gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws
+#endif
 }
+
+// For async/await APIs, simply delegate to the EventLoopFuture implementation until support is dropped for Swift <5.5
+public extension DynamoDBCompositePrimaryKeyGSILogic {
+#if compiler(>=5.5) && canImport(_Concurrency)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func onInsertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
+                                                gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws {
+        try await onInsertItem(item, gsiDataStore: gsiDataStore).get()
+    }
+
+    /**
+     * Called when an item is clobbered on the main table. Can be used to transform the provided item to the item that would be made available on the GSI.
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func onClobberItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
+                                                 gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws {
+        try await onClobberItem(item, gsiDataStore: gsiDataStore).get()
+    }
+
+    /**
+     * Called when an item is updated on the main table. Can be used to transform the provided item to the item that would be made available on the GSI.
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func onUpdateItem<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                existingItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws {
+        try await onUpdateItem(newItem: newItem, existingItem: existingItem, gsiDataStore: gsiDataStore).get()
+    }
+ 
+    /**
+     * Called when an item is delete on the main table. Can be used to also delete the corresponding item on the GSI.
+
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func onDeleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>,
+                                      gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws {
+        try await onDeleteItem(forKey: key, gsiDataStore: gsiDataStore).get()
+    }
+#endif
+}
+

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+clobberVersionedItemWithHistoricalRow.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+clobberVersionedItemWithHistoricalRow.swift
@@ -71,4 +71,38 @@ public extension DynamoDBCompositePrimaryKeyTable {
             return clobberItemWithHistoricalRow(primaryItemProvider: primaryItemProvider,
                                                 historicalItemProvider: historicalItemProvider)
     }
+    
+#if compiler(>=5.5) && canImport(_Concurrency)
+    /**
+     * This operation provide a mechanism for managing mutable database rows
+     * and storing all previous versions of that row in a historical partition.
+     * This operation store the primary item under a "version zero" sort key
+     * with a payload that replicates the current version of the row. This
+     * historical partition contains rows for each version, including the
+     * current version under a sort key for that version.
+     
+     - Parameters:
+        - partitionKey: the partition key to use for the primary (v0) item
+        - historicalKey: the partition key to use for the historical items
+        - item: the payload for the new version of the primary item row
+        - AttributesType: the row identity type
+        - generateSortKey: generator to provide a sort key for a provided
+                           version number.
+     - completion: completion handler providing an error that was thrown or nil
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func clobberVersionedItemWithHistoricalRow<AttributesType: PrimaryKeyAttributes, ItemType: Codable>(
+        forPrimaryKey partitionKey: String,
+        andHistoricalKey historicalKey: String,
+        item: ItemType,
+        primaryKeyType: AttributesType.Type,
+        generateSortKey: @escaping (Int) -> String) async throws {
+            try await clobberVersionedItemWithHistoricalRow(
+                forPrimaryKey: partitionKey,
+                andHistoricalKey: historicalKey,
+                item: item,
+                primaryKeyType: primaryKeyType,
+                generateSortKey: generateSortKey).get()
+    }
+#endif
 }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
@@ -77,4 +77,62 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                 exclusiveStartKey: exclusiveStartKey,
                                 consistentRead: true)
     }
+    
+#if compiler(>=5.5) && canImport(_Concurrency)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?) async throws
+    -> [ReturnedType] {
+        return try await query(forPartitionKey: partitionKey,
+                               sortKeyCondition: sortKeyCondition).get()
+    }
+    
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             limit: Int?,
+                                                             exclusiveStartKey: String?) async throws
+    -> ([ReturnedType], String?) {
+        return try await query(forPartitionKey: partitionKey,
+                               sortKeyCondition: sortKeyCondition,
+                               limit: limit,
+                               exclusiveStartKey: exclusiveStartKey).get()
+    }
+    
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             limit: Int?,
+                                                             scanIndexForward: Bool,
+                                                             exclusiveStartKey: String?) async throws
+    -> ([ReturnedType], String?) {
+        return try await query(forPartitionKey: partitionKey,
+                               sortKeyCondition: sortKeyCondition,
+                               limit: limit,
+                               scanIndexForward: scanIndexForward,
+                               exclusiveStartKey: exclusiveStartKey).get()
+    }
+    
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                    sortKeyCondition: AttributeCondition?) async throws
+    -> [TypedDatabaseItem<AttributesType, ItemType>] {
+        return try await monomorphicQuery(forPartitionKey: partitionKey,
+                                          sortKeyCondition: sortKeyCondition).get()
+    }
+    
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                    sortKeyCondition: AttributeCondition?,
+                                                    limit: Int?,
+                                                    scanIndexForward: Bool,
+                                                    exclusiveStartKey: String?) async throws
+    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+        return try await monomorphicQuery(forPartitionKey: partitionKey,
+                                          sortKeyCondition: sortKeyCondition,
+                                          limit: limit,
+                                          scanIndexForward: scanIndexForward,
+                                          exclusiveStartKey: exclusiveStartKey).get()
+    }
+#endif
 }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTableHistoricalItemExtensions.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTableHistoricalItemExtensions.swift
@@ -165,6 +165,128 @@ public extension DynamoDBCompositePrimaryKeyTable {
         }
     }
     
+#if compiler(>=5.5) && canImport(_Concurrency)
+    /**
+     * Historical items exist across multiple rows. This method provides an interface to record all
+     * rows in a single call.
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func insertItemWithHistoricalRow<AttributesType, ItemType>(primaryItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                               historicalItem: TypedDatabaseItem<AttributesType, ItemType>) async throws {
+        try await insertItem(primaryItem)
+        try await insertItem(historicalItem)
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func updateItemWithHistoricalRow<AttributesType, ItemType>(primaryItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                               existingItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                               historicalItem: TypedDatabaseItem<AttributesType, ItemType>) async throws {
+        try await updateItem(newItem: primaryItem, existingItem: existingItem)
+        try await insertItem(historicalItem)
+    }
+    
+    /**
+     * This operation will attempt to update the primary item, repeatedly calling the
+     * `primaryItemProvider` to retrieve an updated version of the current row (if it
+     * exists) until the appropriate `insert` or  `update` operation succeeds. Once this
+     * operation has succeeded, the `historicalItemProvider` is called to provide
+     * the historical item based on the primary item that was inserted into the
+     * database table. The primary item may not exist in the database table to
+     * begin with.
+     *
+     * Clobbering a historical item requires knowledge of existing rows to accurately record
+     * historical data.
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func clobberItemWithHistoricalRow<AttributesType, ItemType>(
+            primaryItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>?) -> TypedDatabaseItem<AttributesType, ItemType>,
+            historicalItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) -> TypedDatabaseItem<AttributesType, ItemType>,
+            withRetries retries: Int = 10) async throws {
+        try await clobberItemWithHistoricalRow(primaryItemProvider: primaryItemProvider,
+                                               historicalItemProvider: historicalItemProvider,
+                                               withRetries: retries).get()
+    }
+    
+    /**
+      Operations will attempt to update the primary item, repeatedly calling the
+      `primaryItemProvider` to retrieve an updated version of the current row
+      until the appropriate  `update` operation succeeds. The
+      `primaryItemProvider` can thrown an exception to indicate that the current
+      row is unable to be updated. The `historicalItemProvider` is called to
+      provide the historical item based on the primary item that was
+      inserted into the database table.
+
+     - Parameters:
+        - compositePrimaryKey: The composite key for the version to update.
+        - primaryItemProvider: Function to provide the updated item or throw if the current item can't be updated.
+        - historicalItemProvider: Function to provide the historical item for the primary item.
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func conditionallyUpdateItemWithHistoricalRow<AttributesType, ItemType>(
+            compositePrimaryKey: CompositePrimaryKey<AttributesType>,
+            primaryItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) async throws -> TypedDatabaseItem<AttributesType, ItemType>,
+            historicalItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) -> TypedDatabaseItem<AttributesType, ItemType>,
+            withRetries retries: Int = 10) async throws -> TypedDatabaseItem<AttributesType, ItemType> {
+        return try await conditionallyUpdateItemWithHistoricalRowInternal(
+            compositePrimaryKey: compositePrimaryKey,
+            primaryItemProvider: primaryItemProvider,
+            historicalItemProvider: historicalItemProvider,
+            withRetries: retries)
+    }
+    
+    // Explicitly specify an overload with sync updatedPayloadProvider
+    // to avoid the compiler matching a call site with such a provider with the EventLoopFuture-returning overload.
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func conditionallyUpdateItemWithHistoricalRow<AttributesType, ItemType>(
+            compositePrimaryKey: CompositePrimaryKey<AttributesType>,
+            primaryItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) throws -> TypedDatabaseItem<AttributesType, ItemType>,
+            historicalItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) -> TypedDatabaseItem<AttributesType, ItemType>,
+            withRetries retries: Int = 10) async throws -> TypedDatabaseItem<AttributesType, ItemType> {
+        return try await conditionallyUpdateItemWithHistoricalRowInternal(
+            compositePrimaryKey: compositePrimaryKey,
+            primaryItemProvider: primaryItemProvider,
+            historicalItemProvider: historicalItemProvider,
+            withRetries: retries)
+    }
+    
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    private func conditionallyUpdateItemWithHistoricalRowInternal<AttributesType, ItemType>(
+            compositePrimaryKey: CompositePrimaryKey<AttributesType>,
+            primaryItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) async throws -> TypedDatabaseItem<AttributesType, ItemType>,
+            historicalItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) -> TypedDatabaseItem<AttributesType, ItemType>,
+            withRetries retries: Int = 10) async throws -> TypedDatabaseItem<AttributesType, ItemType> {
+        guard retries > 0 else {
+             throw SmokeDynamoDBError.concurrencyError(partitionKey: compositePrimaryKey.partitionKey,
+                                                       sortKey: compositePrimaryKey.sortKey,
+                                                       message: "Unable to complete request to update versioned item in specified number of attempts")
+        }
+        
+        let existingItemOptional: TypedDatabaseItem<AttributesType, ItemType>? = try await getItem(forKey: compositePrimaryKey)
+        
+        guard let existingItem = existingItemOptional else {
+            throw SmokeDynamoDBError.conditionalCheckFailed(partitionKey: compositePrimaryKey.partitionKey,
+                                                            sortKey: compositePrimaryKey.sortKey,
+                                                            message: "Item not present in database.")
+        }
+        
+        let updatedItem = try await primaryItemProvider(existingItem)
+        let historicalItem = historicalItemProvider(updatedItem)
+
+        do {
+            try await updateItemWithHistoricalRow(primaryItem: updatedItem,
+                                                  existingItem: existingItem,
+                                                  historicalItem: historicalItem)
+        } catch SmokeDynamoDBError.conditionalCheckFailed {
+            // try again
+            return try await conditionallyUpdateItemWithHistoricalRow(compositePrimaryKey: compositePrimaryKey,
+                                                                      primaryItemProvider: primaryItemProvider,
+                                                                      historicalItemProvider: historicalItemProvider, withRetries: retries - 1)
+        }
+        
+        return updatedItem
+    }
+#endif
+    
     func conditionallyUpdateItemWithHistoricalRow<AttributesType, ItemType>(
             compositePrimaryKey: CompositePrimaryKey<AttributesType>,
             primaryItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) -> EventLoopFuture<TypedDatabaseItem<AttributesType, ItemType>>,

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
@@ -54,4 +54,76 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
                                scanIndexForward: Bool,
                                exclusiveStartKey: String?)
         -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
+    
+#if compiler(>=5.5) && canImport(_Concurrency)
+    /**
+     * Queries a partition in the database table and optionally a sort key condition. If the
+       partition doesn't exist, this operation will return an empty list as a response. This
+       function will potentially make multiple calls to DynamoDB to retrieve all results for
+       the query.
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                               sortKeyCondition: AttributeCondition?) async throws
+        -> [CompositePrimaryKey<AttributesType>]
+
+    /**
+     * Queries a partition in the database table and optionally a sort key condition. If the
+       partition doesn't exist, this operation will return an empty list as a response. This
+       function will return paginated results based on the limit and exclusiveStartKey provided.
+     */
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                               sortKeyCondition: AttributeCondition?,
+                               limit: Int?,
+                               exclusiveStartKey: String?) async throws
+        -> ([CompositePrimaryKey<AttributesType>], String?)
+    
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                               sortKeyCondition: AttributeCondition?,
+                               limit: Int?,
+                               scanIndexForward: Bool,
+                               exclusiveStartKey: String?) async throws
+        -> ([CompositePrimaryKey<AttributesType>], String?)
+#endif
+}
+
+// For async/await APIs, simply delegate to the EventLoopFuture implementation until support is dropped for Swift <5.5
+public extension DynamoDBCompositePrimaryKeysProjection {
+#if compiler(>=5.5) && canImport(_Concurrency)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                               sortKeyCondition: AttributeCondition?) async throws
+    -> [CompositePrimaryKey<AttributesType>] {
+        return try await query(forPartitionKey: partitionKey,
+                               sortKeyCondition: sortKeyCondition).get()
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                               sortKeyCondition: AttributeCondition?,
+                               limit: Int?,
+                               exclusiveStartKey: String?) async throws
+    -> ([CompositePrimaryKey<AttributesType>], String?) {
+        return try await query(forPartitionKey: partitionKey,
+                               sortKeyCondition: sortKeyCondition,
+                               limit: limit,
+                               exclusiveStartKey: exclusiveStartKey).get()
+    }
+    
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                               sortKeyCondition: AttributeCondition?,
+                               limit: Int?,
+                               scanIndexForward: Bool,
+                               exclusiveStartKey: String?) async throws
+    -> ([CompositePrimaryKey<AttributesType>], String?) {
+        return try await query(forPartitionKey: partitionKey,
+                               sortKeyCondition: sortKeyCondition,
+                               limit: limit,
+                               scanIndexForward: scanIndexForward,
+                               exclusiveStartKey: exclusiveStartKey).get()
+    }
+#endif
 }

--- a/Sources/SmokeDynamoDB/QueryInput+forSortKeyCondition.swift
+++ b/Sources/SmokeDynamoDB/QueryInput+forSortKeyCondition.swift
@@ -19,7 +19,7 @@ import Foundation
 import DynamoDBModel
 
 extension QueryInput {
-        internal static func forSortKeyCondition<AttributesType>(forPartitionKey partitionKey: String,
+        internal static func forSortKeyCondition<AttributesType>(partitionKey: String,
                                                                  targetTableName: String,
                                                                  primaryKeyType: AttributesType.Type,
                                                                  sortKeyCondition: AttributeCondition?,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add async/await apis, primarily just as wrappers around the EventLoopFuture-returning APIs. A couple of APIs make sense to accept async functions as parameters and an async implementation is required.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
