### PR TITLE
Support async APIs on older Apple OSs.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "2b6a0212a24c0b1a383046e775225ad99a958e5f",
-          "version": "2.41.0"
+          "revision": "40e61c4e055e91bb36ac8f82d2ddfc80fd1dbb17",
+          "version": "2.41.17"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "c13504dd1724b30eefef588ba1bb9082b05fd681",
-          "version": "2.9.1"
+          "revision": "cc2ca1f0d64cfd0f543b23b4f1a95329943ed22c",
+          "version": "2.10.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,8 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.38.40"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.41.17"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.10.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
     ],

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyGSILogic.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyGSILogic.swift
@@ -52,25 +52,22 @@ public protocol DynamoDBCompositePrimaryKeyGSILogic {
     func onDeleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>,
                                       gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) -> EventLoopFuture<Void>
     
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     /**
      * Called when an item is inserted on the main table. Can be used to transform the provided item to the item that would be made available on the GSI.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func onInsertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
                                                 gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws
 
     /**
      * Called when an item is clobbered on the main table. Can be used to transform the provided item to the item that would be made available on the GSI.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func onClobberItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
                                                  gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws
 
     /**
      * Called when an item is updated on the main table. Can be used to transform the provided item to the item that would be made available on the GSI.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func onUpdateItem<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
                                                 existingItem: TypedDatabaseItem<AttributesType, ItemType>,
                                                 gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws
@@ -79,7 +76,6 @@ public protocol DynamoDBCompositePrimaryKeyGSILogic {
      * Called when an item is delete on the main table. Can be used to also delete the corresponding item on the GSI.
 
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func onDeleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>,
                                       gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws
 #endif
@@ -87,8 +83,7 @@ public protocol DynamoDBCompositePrimaryKeyGSILogic {
 
 // For async/await APIs, simply delegate to the EventLoopFuture implementation until support is dropped for Swift <5.5
 public extension DynamoDBCompositePrimaryKeyGSILogic {
-#if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     func onInsertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
                                                 gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws {
         try await onInsertItem(item, gsiDataStore: gsiDataStore).get()
@@ -97,7 +92,6 @@ public extension DynamoDBCompositePrimaryKeyGSILogic {
     /**
      * Called when an item is clobbered on the main table. Can be used to transform the provided item to the item that would be made available on the GSI.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func onClobberItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
                                                  gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws {
         try await onClobberItem(item, gsiDataStore: gsiDataStore).get()
@@ -106,7 +100,6 @@ public extension DynamoDBCompositePrimaryKeyGSILogic {
     /**
      * Called when an item is updated on the main table. Can be used to transform the provided item to the item that would be made available on the GSI.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func onUpdateItem<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
                                                 existingItem: TypedDatabaseItem<AttributesType, ItemType>,
                                                 gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws {
@@ -117,7 +110,6 @@ public extension DynamoDBCompositePrimaryKeyGSILogic {
      * Called when an item is delete on the main table. Can be used to also delete the corresponding item on the GSI.
 
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func onDeleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>,
                                       gsiDataStore: InMemoryDynamoDBCompositePrimaryKeyTable) async throws {
         try await onDeleteItem(forKey: key, gsiDataStore: gsiDataStore).get()

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+clobberVersionedItemWithHistoricalRow.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+clobberVersionedItemWithHistoricalRow.swift
@@ -72,7 +72,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                                 historicalItemProvider: historicalItemProvider)
     }
     
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     /**
      * This operation provide a mechanism for managing mutable database rows
      * and storing all previous versions of that row in a historical partition.
@@ -90,7 +90,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                            version number.
      - completion: completion handler providing an error that was thrown or nil
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func clobberVersionedItemWithHistoricalRow<AttributesType: PrimaryKeyAttributes, ItemType: Codable>(
         forPrimaryKey partitionKey: String,
         andHistoricalKey historicalKey: String,

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
@@ -88,7 +88,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
         }
     }
     
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     /**
      Method to conditionally update an item at the specified key for a number of retries.
      This method is useful for database rows that may be updated simultaneously by different clients
@@ -103,7 +103,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
          withRetries: the number of times to attempt to retry the update before failing.
          updatedPayloadProvider: the provider that will return updated payloads.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func conditionallyUpdateItem<AttributesType, ItemType: Codable>(
             forKey key: CompositePrimaryKey<AttributesType>,
             withRetries retries: Int = 10,
@@ -116,7 +115,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
     
     // Explicitly specify an overload with sync updatedPayloadProvider
     // to avoid the compiler matching a call site with such a provider with the EventLoopFuture-returning overload.
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func conditionallyUpdateItem<AttributesType, ItemType: Codable>(
             forKey key: CompositePrimaryKey<AttributesType>,
             withRetries retries: Int = 10,
@@ -127,7 +125,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
             updatedPayloadProvider: updatedPayloadProvider)
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     private func conditionallyUpdateItemInternal<AttributesType, ItemType: Codable>(
             forKey key: CompositePrimaryKey<AttributesType>,
             withRetries retries: Int = 10,

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
@@ -78,8 +78,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                 consistentRead: true)
     }
     
-#if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                              sortKeyCondition: AttributeCondition?) async throws
     -> [ReturnedType] {
@@ -87,7 +86,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                sortKeyCondition: sortKeyCondition).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                              sortKeyCondition: AttributeCondition?,
                                                              limit: Int?,
@@ -99,7 +97,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                exclusiveStartKey: exclusiveStartKey).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                              sortKeyCondition: AttributeCondition?,
                                                              limit: Int?,
@@ -113,7 +110,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                exclusiveStartKey: exclusiveStartKey).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
                                                     sortKeyCondition: AttributeCondition?) async throws
     -> [TypedDatabaseItem<AttributesType, ItemType>] {
@@ -121,7 +117,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                           sortKeyCondition: sortKeyCondition).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
                                                     sortKeyCondition: AttributeCondition?,
                                                     limit: Int?,

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -260,46 +260,40 @@ public protocol DynamoDBCompositePrimaryKeyTable {
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
     
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     
     /**
      * Insert item is a non-destructive API. If an item already exists with the specified key this
      * API should fail.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func insertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) async throws
 
     /**
      * Clobber item is destructive API. Regardless of what is present in the database the provided
      * item will be inserted.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func clobberItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) async throws
 
     /**
      * Update item requires having gotten an item from the database previously and will not update
      * if the item at the specified key is not the existing item provided.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func updateItem<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
                                               existingItem: TypedDatabaseItem<AttributesType, ItemType>) async throws
     
     /**
      * Provides the ability to bulk write database rows
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
 
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>) async throws -> TypedDatabaseItem<AttributesType, ItemType>?
     
     /**
      * Retrieves items from the database table as a dictionary mapped to the provided key. Missing entries from the provided map indicate that item doesn't exist.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func getItems<ReturnedType: PolymorphicOperationReturnType & BatchCapableReturnType>(
         forKeys keys: [CompositePrimaryKey<ReturnedType.AttributesType>]) async throws
     -> [CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType]
@@ -308,7 +302,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      * Removes an item from the database table. Is an idempotent operation; running it multiple times
      * on the same item or attribute does not result in an error response.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func deleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>) async throws
     
     /**
@@ -316,14 +309,12 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      * on the same item or attribute does not result in an error response. This operation will not modify the table
      * if the item at the specified key is not the existing item provided.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func deleteItem<AttributesType, ItemType>(existingItem: TypedDatabaseItem<AttributesType, ItemType>) async throws
     
     /**
      * Removes items from the database table. Is an idempotent operation; running it multiple times
      * on the same item or attribute does not result in an error response.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func deleteItems<AttributesType>(forKeys keys: [CompositePrimaryKey<AttributesType>]) async throws
     
     /**
@@ -331,7 +322,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      * on the same item or attribute does not result in an error response. This operation will not modify the table
      * if the item at the specified key is not the existing item provided.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func deleteItems<ItemType: DatabaseItem>(existingItems: [ItemType]) async throws
 
     /**
@@ -340,7 +330,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
        function will potentially make multiple calls to DynamoDB to retrieve all results for
        the query.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                              sortKeyCondition: AttributeCondition?,
                                                              consistentRead: Bool) async throws
@@ -351,7 +340,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
        partition doesn't exist, this operation will return an empty list as a response. This
        function will return paginated results based on the limit and exclusiveStartKey provided.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                              sortKeyCondition: AttributeCondition?,
                                                              limit: Int?,
@@ -364,7 +352,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
        partition doesn't exist, this operation will return an empty list as a response. This
        function will return paginated results based on the limit and exclusiveStartKey provided.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                              sortKeyCondition: AttributeCondition?,
                                                              limit: Int?,
@@ -380,7 +367,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      *
      * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func execute<ReturnedType: PolymorphicOperationReturnType>(
         partitionKeys: [String],
         attributesFilter: [String]?,
@@ -393,7 +379,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      *
      * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func execute<ReturnedType: PolymorphicOperationReturnType>(
         partitionKeys: [String],
         attributesFilter: [String]?,
@@ -404,7 +389,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
     /**
      * Retrieves items from the database table as a dictionary mapped to the provided key. Missing entries from the provided map indicate that item doesn't exist.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicGetItems<AttributesType, ItemType>(
         forKeys keys: [CompositePrimaryKey<AttributesType>]) async throws
     -> [CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>]
@@ -415,7 +399,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
        function will potentially make multiple calls to DynamoDB to retrieve all results for
        the query.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
                                                     sortKeyCondition: AttributeCondition?,
                                                     consistentRead: Bool) async throws
@@ -426,7 +409,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
        partition doesn't exist, this operation will return an empty list as a response. This
        function will return paginated results based on the limit and exclusiveStartKey provided.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
                                                         sortKeyCondition: AttributeCondition?,
                                                         limit: Int?,
@@ -442,7 +424,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      *
      * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicExecute<AttributesType, ItemType>(
         partitionKeys: [String],
         attributesFilter: [String]?,
@@ -455,7 +436,6 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      *
      * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicExecute<AttributesType, ItemType>(
         partitionKeys: [String],
         attributesFilter: [String]?,
@@ -466,63 +446,52 @@ public protocol DynamoDBCompositePrimaryKeyTable {
 
 // For async/await APIs, simply delegate to the EventLoopFuture implementation until support is dropped for Swift <5.5
 public extension DynamoDBCompositePrimaryKeyTable {
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func insertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) async throws {
         return try await insertItem(item).get()
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func clobberItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) async throws {
         return try await clobberItem(item).get()
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func updateItem<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
                                               existingItem: TypedDatabaseItem<AttributesType, ItemType>) async throws {
         return try await updateItem(newItem: newItem, existingItem: existingItem).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws {
         return try await monomorphicBulkWrite(entries).get()
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>) async throws
     -> TypedDatabaseItem<AttributesType, ItemType>? {
         return try await getItem(forKey: key).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func getItems<ReturnedType: PolymorphicOperationReturnType & BatchCapableReturnType>(
         forKeys keys: [CompositePrimaryKey<ReturnedType.AttributesType>]) async throws
     -> [CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType] {
         return try await getItems(forKeys: keys).get()
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func deleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>) async throws {
         try await deleteItem(forKey: key).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func deleteItem<AttributesType, ItemType>(existingItem: TypedDatabaseItem<AttributesType, ItemType>) async throws {
         try await deleteItem(existingItem: existingItem).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func deleteItems<AttributesType>(forKeys keys: [CompositePrimaryKey<AttributesType>]) async throws {
         try await deleteItems(forKeys: keys).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func deleteItems<ItemType: DatabaseItem>(existingItems: [ItemType]) async throws {
         try await deleteItems(existingItems: existingItems).get()
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                              sortKeyCondition: AttributeCondition?,
                                                              consistentRead: Bool) async throws
@@ -532,7 +501,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                         consistentRead: consistentRead).get()
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                              sortKeyCondition: AttributeCondition?,
                                                              limit: Int?,
@@ -546,7 +514,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                         consistentRead: consistentRead).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
                                                              sortKeyCondition: AttributeCondition?,
                                                              limit: Int?,
@@ -562,7 +529,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                         consistentRead: consistentRead).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func execute<ReturnedType: PolymorphicOperationReturnType>(
             partitionKeys: [String],
             attributesFilter: [String]?,
@@ -572,7 +538,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                           additionalWhereClause: additionalWhereClause).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func execute<ReturnedType: PolymorphicOperationReturnType>(
             partitionKeys: [String],
             attributesFilter: [String]?,
@@ -583,14 +548,12 @@ public extension DynamoDBCompositePrimaryKeyTable {
                           nextToken: nextToken).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicGetItems<AttributesType, ItemType>(
         forKeys keys: [CompositePrimaryKey<AttributesType>]) async throws
     -> [CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>] {
         try await monomorphicGetItems(forKeys: keys).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
                                                     sortKeyCondition: AttributeCondition?,
                                                     consistentRead: Bool) async throws
@@ -600,7 +563,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                    consistentRead: consistentRead).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
                                                     sortKeyCondition: AttributeCondition?,
                                                     limit: Int?,
@@ -616,7 +578,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                    consistentRead: consistentRead).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicExecute<AttributesType, ItemType>(
             partitionKeys: [String],
             attributesFilter: [String]?,
@@ -626,7 +587,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                      additionalWhereClause: additionalWhereClause).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func monomorphicExecute<AttributesType, ItemType>(
         partitionKeys: [String],
         attributesFilter: [String]?,
@@ -639,3 +599,26 @@ public extension DynamoDBCompositePrimaryKeyTable {
     }
 #endif
 }
+
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+// Copy of extension from SwiftNIO; can be removed when the version in SwiftNIO removes its @available attribute
+internal extension EventLoopFuture {
+    /// Get the value/error from an `EventLoopFuture` in an `async` context.
+    ///
+    /// This function can be used to bridge an `EventLoopFuture` into the `async` world. Ie. if you're in an `async`
+    /// function and want to get the result of this future.
+    @inlinable
+    func get() async throws -> Value {
+        return try await withUnsafeThrowingContinuation { cont in
+            self.whenComplete { result in
+                switch result {
+                case .success(let value):
+                    cont.resume(returning: value)
+                case .failure(let error):
+                    cont.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTableHistoricalItemExtensions.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTableHistoricalItemExtensions.swift
@@ -165,19 +165,17 @@ public extension DynamoDBCompositePrimaryKeyTable {
         }
     }
     
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     /**
      * Historical items exist across multiple rows. This method provides an interface to record all
      * rows in a single call.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func insertItemWithHistoricalRow<AttributesType, ItemType>(primaryItem: TypedDatabaseItem<AttributesType, ItemType>,
                                                                historicalItem: TypedDatabaseItem<AttributesType, ItemType>) async throws {
         try await insertItem(primaryItem)
         try await insertItem(historicalItem)
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func updateItemWithHistoricalRow<AttributesType, ItemType>(primaryItem: TypedDatabaseItem<AttributesType, ItemType>,
                                                                existingItem: TypedDatabaseItem<AttributesType, ItemType>,
                                                                historicalItem: TypedDatabaseItem<AttributesType, ItemType>) async throws {
@@ -197,7 +195,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
      * Clobbering a historical item requires knowledge of existing rows to accurately record
      * historical data.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func clobberItemWithHistoricalRow<AttributesType, ItemType>(
             primaryItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>?) -> TypedDatabaseItem<AttributesType, ItemType>,
             historicalItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) -> TypedDatabaseItem<AttributesType, ItemType>,
@@ -221,7 +218,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
         - primaryItemProvider: Function to provide the updated item or throw if the current item can't be updated.
         - historicalItemProvider: Function to provide the historical item for the primary item.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func conditionallyUpdateItemWithHistoricalRow<AttributesType, ItemType>(
             compositePrimaryKey: CompositePrimaryKey<AttributesType>,
             primaryItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) async throws -> TypedDatabaseItem<AttributesType, ItemType>,
@@ -236,7 +232,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
     
     // Explicitly specify an overload with sync updatedPayloadProvider
     // to avoid the compiler matching a call site with such a provider with the EventLoopFuture-returning overload.
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func conditionallyUpdateItemWithHistoricalRow<AttributesType, ItemType>(
             compositePrimaryKey: CompositePrimaryKey<AttributesType>,
             primaryItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) throws -> TypedDatabaseItem<AttributesType, ItemType>,
@@ -249,7 +244,6 @@ public extension DynamoDBCompositePrimaryKeyTable {
             withRetries: retries)
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     private func conditionallyUpdateItemWithHistoricalRowInternal<AttributesType, ItemType>(
             compositePrimaryKey: CompositePrimaryKey<AttributesType>,
             primaryItemProvider: @escaping (TypedDatabaseItem<AttributesType, ItemType>) async throws -> TypedDatabaseItem<AttributesType, ItemType>,

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
@@ -55,14 +55,13 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
                                exclusiveStartKey: String?)
         -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
     
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     /**
      * Queries a partition in the database table and optionally a sort key condition. If the
        partition doesn't exist, this operation will return an empty list as a response. This
        function will potentially make multiple calls to DynamoDB to retrieve all results for
        the query.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<AttributesType>(forPartitionKey partitionKey: String,
                                sortKeyCondition: AttributeCondition?) async throws
         -> [CompositePrimaryKey<AttributesType>]
@@ -72,14 +71,12 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
        partition doesn't exist, this operation will return an empty list as a response. This
        function will return paginated results based on the limit and exclusiveStartKey provided.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<AttributesType>(forPartitionKey partitionKey: String,
                                sortKeyCondition: AttributeCondition?,
                                limit: Int?,
                                exclusiveStartKey: String?) async throws
         -> ([CompositePrimaryKey<AttributesType>], String?)
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<AttributesType>(forPartitionKey partitionKey: String,
                                sortKeyCondition: AttributeCondition?,
                                limit: Int?,
@@ -91,8 +88,7 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
 
 // For async/await APIs, simply delegate to the EventLoopFuture implementation until support is dropped for Swift <5.5
 public extension DynamoDBCompositePrimaryKeysProjection {
-#if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     func query<AttributesType>(forPartitionKey partitionKey: String,
                                sortKeyCondition: AttributeCondition?) async throws
     -> [CompositePrimaryKey<AttributesType>] {
@@ -100,7 +96,6 @@ public extension DynamoDBCompositePrimaryKeysProjection {
                                sortKeyCondition: sortKeyCondition).get()
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<AttributesType>(forPartitionKey partitionKey: String,
                                sortKeyCondition: AttributeCondition?,
                                limit: Int?,
@@ -112,7 +107,6 @@ public extension DynamoDBCompositePrimaryKeysProjection {
                                exclusiveStartKey: exclusiveStartKey).get()
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query<AttributesType>(forPartitionKey partitionKey: String,
                                sortKeyCondition: AttributeCondition?,
                                limit: Int?,

--- a/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClient.swift
+++ b/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClient.swift
@@ -1075,7 +1075,7 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
             errorType: DynamoDBError.self)
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     /**
      Invokes the BatchExecuteStatement operation returning aynchronously at a later time once the operation is complete.
 
@@ -1085,7 +1085,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, requestLimitExceeded.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func batchExecuteStatement(
             input: DynamoDBModel.BatchExecuteStatementInput) async throws -> DynamoDBModel.BatchExecuteStatementOutput {
         return try await executeWithOutput(
@@ -1105,7 +1104,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func batchGetItem(
             input: DynamoDBModel.BatchGetItemInput) async throws -> DynamoDBModel.BatchGetItemOutput {
         return try await executeWithOutput(
@@ -1125,7 +1123,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, itemCollectionSizeLimitExceeded, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func batchWriteItem(
             input: DynamoDBModel.BatchWriteItemInput) async throws -> DynamoDBModel.BatchWriteItemOutput {
         return try await executeWithOutput(
@@ -1145,7 +1142,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: backupInUse, continuousBackupsUnavailable, internalServer, limitExceeded, tableInUse, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func createBackup(
             input: DynamoDBModel.CreateBackupInput) async throws -> DynamoDBModel.CreateBackupOutput {
         return try await executeWithOutput(
@@ -1165,7 +1161,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: globalTableAlreadyExists, internalServer, limitExceeded, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func createGlobalTable(
             input: DynamoDBModel.CreateGlobalTableInput) async throws -> DynamoDBModel.CreateGlobalTableOutput {
         return try await executeWithOutput(
@@ -1185,7 +1180,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func createTable(
             input: DynamoDBModel.CreateTableInput) async throws -> DynamoDBModel.CreateTableOutput {
         return try await executeWithOutput(
@@ -1205,7 +1199,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: backupInUse, backupNotFound, internalServer, limitExceeded.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func deleteBackup(
             input: DynamoDBModel.DeleteBackupInput) async throws -> DynamoDBModel.DeleteBackupOutput {
         return try await executeWithOutput(
@@ -1225,7 +1218,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: conditionalCheckFailed, internalServer, itemCollectionSizeLimitExceeded, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionConflict.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func deleteItem(
             input: DynamoDBModel.DeleteItemInput) async throws -> DynamoDBModel.DeleteItemOutput {
         return try await executeWithOutput(
@@ -1245,7 +1237,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func deleteTable(
             input: DynamoDBModel.DeleteTableInput) async throws -> DynamoDBModel.DeleteTableOutput {
         return try await executeWithOutput(
@@ -1265,7 +1256,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: backupNotFound, internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeBackup(
             input: DynamoDBModel.DescribeBackupInput) async throws -> DynamoDBModel.DescribeBackupOutput {
         return try await executeWithOutput(
@@ -1285,7 +1275,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeContinuousBackups(
             input: DynamoDBModel.DescribeContinuousBackupsInput) async throws -> DynamoDBModel.DescribeContinuousBackupsOutput {
         return try await executeWithOutput(
@@ -1305,7 +1294,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeContributorInsights(
             input: DynamoDBModel.DescribeContributorInsightsInput) async throws -> DynamoDBModel.DescribeContributorInsightsOutput {
         return try await executeWithOutput(
@@ -1324,7 +1312,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
      - Returns: The DescribeEndpointsResponse object to be passed back from the caller of this async operation.
          Will be validated before being returned to caller.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeEndpoints(
             input: DynamoDBModel.DescribeEndpointsRequest) async throws -> DynamoDBModel.DescribeEndpointsResponse {
         return try await executeWithOutput(
@@ -1344,7 +1331,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: exportNotFound, internalServer, limitExceeded.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeExport(
             input: DynamoDBModel.DescribeExportInput) async throws -> DynamoDBModel.DescribeExportOutput {
         return try await executeWithOutput(
@@ -1364,7 +1350,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: globalTableNotFound, internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeGlobalTable(
             input: DynamoDBModel.DescribeGlobalTableInput) async throws -> DynamoDBModel.DescribeGlobalTableOutput {
         return try await executeWithOutput(
@@ -1384,7 +1369,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: globalTableNotFound, internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeGlobalTableSettings(
             input: DynamoDBModel.DescribeGlobalTableSettingsInput) async throws -> DynamoDBModel.DescribeGlobalTableSettingsOutput {
         return try await executeWithOutput(
@@ -1404,7 +1388,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeKinesisStreamingDestination(
             input: DynamoDBModel.DescribeKinesisStreamingDestinationInput) async throws -> DynamoDBModel.DescribeKinesisStreamingDestinationOutput {
         return try await executeWithOutput(
@@ -1424,7 +1407,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeLimits(
             input: DynamoDBModel.DescribeLimitsInput) async throws -> DynamoDBModel.DescribeLimitsOutput {
         return try await executeWithOutput(
@@ -1444,7 +1426,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeTable(
             input: DynamoDBModel.DescribeTableInput) async throws -> DynamoDBModel.DescribeTableOutput {
         return try await executeWithOutput(
@@ -1464,7 +1445,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeTableReplicaAutoScaling(
             input: DynamoDBModel.DescribeTableReplicaAutoScalingInput) async throws -> DynamoDBModel.DescribeTableReplicaAutoScalingOutput {
         return try await executeWithOutput(
@@ -1484,7 +1464,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func describeTimeToLive(
             input: DynamoDBModel.DescribeTimeToLiveInput) async throws -> DynamoDBModel.DescribeTimeToLiveOutput {
         return try await executeWithOutput(
@@ -1504,7 +1483,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func disableKinesisStreamingDestination(
             input: DynamoDBModel.KinesisStreamingDestinationInput) async throws -> DynamoDBModel.KinesisStreamingDestinationOutput {
         return try await executeWithOutput(
@@ -1524,7 +1502,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func enableKinesisStreamingDestination(
             input: DynamoDBModel.KinesisStreamingDestinationInput) async throws -> DynamoDBModel.KinesisStreamingDestinationOutput {
         return try await executeWithOutput(
@@ -1544,7 +1521,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: conditionalCheckFailed, duplicateItem, internalServer, itemCollectionSizeLimitExceeded, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionConflict.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func executeStatement(
             input: DynamoDBModel.ExecuteStatementInput) async throws -> DynamoDBModel.ExecuteStatementOutput {
         return try await executeWithOutput(
@@ -1564,7 +1540,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: idempotentParameterMismatch, internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionCanceled, transactionInProgress.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func executeTransaction(
             input: DynamoDBModel.ExecuteTransactionInput) async throws -> DynamoDBModel.ExecuteTransactionOutput {
         return try await executeWithOutput(
@@ -1584,7 +1559,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: exportConflict, internalServer, invalidExportTime, limitExceeded, pointInTimeRecoveryUnavailable, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func exportTableToPointInTime(
             input: DynamoDBModel.ExportTableToPointInTimeInput) async throws -> DynamoDBModel.ExportTableToPointInTimeOutput {
         return try await executeWithOutput(
@@ -1604,7 +1578,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func getItem(
             input: DynamoDBModel.GetItemInput) async throws -> DynamoDBModel.GetItemOutput {
         return try await executeWithOutput(
@@ -1624,7 +1597,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func listBackups(
             input: DynamoDBModel.ListBackupsInput) async throws -> DynamoDBModel.ListBackupsOutput {
         return try await executeWithOutput(
@@ -1644,7 +1616,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func listContributorInsights(
             input: DynamoDBModel.ListContributorInsightsInput) async throws -> DynamoDBModel.ListContributorInsightsOutput {
         return try await executeWithOutput(
@@ -1664,7 +1635,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func listExports(
             input: DynamoDBModel.ListExportsInput) async throws -> DynamoDBModel.ListExportsOutput {
         return try await executeWithOutput(
@@ -1684,7 +1654,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func listGlobalTables(
             input: DynamoDBModel.ListGlobalTablesInput) async throws -> DynamoDBModel.ListGlobalTablesOutput {
         return try await executeWithOutput(
@@ -1704,7 +1673,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func listTables(
             input: DynamoDBModel.ListTablesInput) async throws -> DynamoDBModel.ListTablesOutput {
         return try await executeWithOutput(
@@ -1724,7 +1692,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func listTagsOfResource(
             input: DynamoDBModel.ListTagsOfResourceInput) async throws -> DynamoDBModel.ListTagsOfResourceOutput {
         return try await executeWithOutput(
@@ -1744,7 +1711,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: conditionalCheckFailed, internalServer, itemCollectionSizeLimitExceeded, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionConflict.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func putItem(
             input: DynamoDBModel.PutItemInput) async throws -> DynamoDBModel.PutItemOutput {
         return try await executeWithOutput(
@@ -1764,7 +1730,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func query(
             input: DynamoDBModel.QueryInput) async throws -> DynamoDBModel.QueryOutput {
         return try await executeWithOutput(
@@ -1784,7 +1749,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: backupInUse, backupNotFound, internalServer, limitExceeded, tableAlreadyExists, tableInUse.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func restoreTableFromBackup(
             input: DynamoDBModel.RestoreTableFromBackupInput) async throws -> DynamoDBModel.RestoreTableFromBackupOutput {
         return try await executeWithOutput(
@@ -1804,7 +1768,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, invalidRestoreTime, limitExceeded, pointInTimeRecoveryUnavailable, tableAlreadyExists, tableInUse, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func restoreTableToPointInTime(
             input: DynamoDBModel.RestoreTableToPointInTimeInput) async throws -> DynamoDBModel.RestoreTableToPointInTimeOutput {
         return try await executeWithOutput(
@@ -1824,7 +1787,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func scan(
             input: DynamoDBModel.ScanInput) async throws -> DynamoDBModel.ScanOutput {
         return try await executeWithOutput(
@@ -1842,7 +1804,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          - input: The validated TagResourceInput object being passed to this operation.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func tagResource(
             input: DynamoDBModel.TagResourceInput) async throws {
         return try await executeWithoutOutput(
@@ -1862,7 +1823,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionCanceled.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func transactGetItems(
             input: DynamoDBModel.TransactGetItemsInput) async throws -> DynamoDBModel.TransactGetItemsOutput {
         return try await executeWithOutput(
@@ -1882,7 +1842,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: idempotentParameterMismatch, internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionCanceled, transactionInProgress.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func transactWriteItems(
             input: DynamoDBModel.TransactWriteItemsInput) async throws -> DynamoDBModel.TransactWriteItemsOutput {
         return try await executeWithOutput(
@@ -1900,7 +1859,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          - input: The validated UntagResourceInput object being passed to this operation.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func untagResource(
             input: DynamoDBModel.UntagResourceInput) async throws {
         return try await executeWithoutOutput(
@@ -1920,7 +1878,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: continuousBackupsUnavailable, internalServer, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func updateContinuousBackups(
             input: DynamoDBModel.UpdateContinuousBackupsInput) async throws -> DynamoDBModel.UpdateContinuousBackupsOutput {
         return try await executeWithOutput(
@@ -1940,7 +1897,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func updateContributorInsights(
             input: DynamoDBModel.UpdateContributorInsightsInput) async throws -> DynamoDBModel.UpdateContributorInsightsOutput {
         return try await executeWithOutput(
@@ -1960,7 +1916,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: globalTableNotFound, internalServer, replicaAlreadyExists, replicaNotFound, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func updateGlobalTable(
             input: DynamoDBModel.UpdateGlobalTableInput) async throws -> DynamoDBModel.UpdateGlobalTableOutput {
         return try await executeWithOutput(
@@ -1980,7 +1935,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: globalTableNotFound, indexNotFound, internalServer, limitExceeded, replicaNotFound, resourceInUse.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func updateGlobalTableSettings(
             input: DynamoDBModel.UpdateGlobalTableSettingsInput) async throws -> DynamoDBModel.UpdateGlobalTableSettingsOutput {
         return try await executeWithOutput(
@@ -2000,7 +1954,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: conditionalCheckFailed, internalServer, itemCollectionSizeLimitExceeded, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionConflict.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func updateItem(
             input: DynamoDBModel.UpdateItemInput) async throws -> DynamoDBModel.UpdateItemOutput {
         return try await executeWithOutput(
@@ -2020,7 +1973,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func updateTable(
             input: DynamoDBModel.UpdateTableInput) async throws -> DynamoDBModel.UpdateTableOutput {
         return try await executeWithOutput(
@@ -2040,7 +1992,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func updateTableReplicaAutoScaling(
             input: DynamoDBModel.UpdateTableReplicaAutoScalingInput) async throws -> DynamoDBModel.UpdateTableReplicaAutoScalingOutput {
         return try await executeWithOutput(
@@ -2060,7 +2011,6 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func updateTimeToLive(
             input: DynamoDBModel.UpdateTimeToLiveInput) async throws -> DynamoDBModel.UpdateTimeToLiveOutput {
         return try await executeWithOutput(

--- a/Sources/SmokeDynamoDB/_DynamoDBClient/_DynamoDBClientProtocol.swift
+++ b/Sources/SmokeDynamoDB/_DynamoDBClient/_DynamoDBClientProtocol.swift
@@ -130,7 +130,7 @@ protocol _DynamoDBClientProtocol {
             _ input: DynamoDBModel.UpdateTableReplicaAutoScalingInput) -> EventLoopFuture<DynamoDBModel.UpdateTableReplicaAutoScalingOutput>
     typealias UpdateTimeToLiveEventLoopFutureAsyncType = (
             _ input: DynamoDBModel.UpdateTimeToLiveInput) -> EventLoopFuture<DynamoDBModel.UpdateTimeToLiveOutput>
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     typealias BatchExecuteStatementFunctionType = (
             _ input: DynamoDBModel.BatchExecuteStatementInput) async throws -> DynamoDBModel.BatchExecuteStatementOutput
     typealias BatchGetItemFunctionType = (
@@ -828,7 +828,7 @@ protocol _DynamoDBClientProtocol {
     func updateTimeToLive(
             input: DynamoDBModel.UpdateTimeToLiveInput) -> EventLoopFuture<DynamoDBModel.UpdateTimeToLiveOutput>
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     /**
      Invokes the BatchExecuteStatement operation returning aynchronously at a later time once the operation is complete.
 
@@ -838,7 +838,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, requestLimitExceeded.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func batchExecuteStatement(
             input: DynamoDBModel.BatchExecuteStatementInput) async throws -> DynamoDBModel.BatchExecuteStatementOutput
 
@@ -851,7 +850,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func batchGetItem(
             input: DynamoDBModel.BatchGetItemInput) async throws -> DynamoDBModel.BatchGetItemOutput
 
@@ -864,7 +862,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, itemCollectionSizeLimitExceeded, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func batchWriteItem(
             input: DynamoDBModel.BatchWriteItemInput) async throws -> DynamoDBModel.BatchWriteItemOutput
 
@@ -877,7 +874,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: backupInUse, continuousBackupsUnavailable, internalServer, limitExceeded, tableInUse, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func createBackup(
             input: DynamoDBModel.CreateBackupInput) async throws -> DynamoDBModel.CreateBackupOutput
 
@@ -890,7 +886,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: globalTableAlreadyExists, internalServer, limitExceeded, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func createGlobalTable(
             input: DynamoDBModel.CreateGlobalTableInput) async throws -> DynamoDBModel.CreateGlobalTableOutput
 
@@ -903,7 +898,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func createTable(
             input: DynamoDBModel.CreateTableInput) async throws -> DynamoDBModel.CreateTableOutput
 
@@ -916,7 +910,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: backupInUse, backupNotFound, internalServer, limitExceeded.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func deleteBackup(
             input: DynamoDBModel.DeleteBackupInput) async throws -> DynamoDBModel.DeleteBackupOutput
 
@@ -929,7 +922,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: conditionalCheckFailed, internalServer, itemCollectionSizeLimitExceeded, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionConflict.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func deleteItem(
             input: DynamoDBModel.DeleteItemInput) async throws -> DynamoDBModel.DeleteItemOutput
 
@@ -942,7 +934,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func deleteTable(
             input: DynamoDBModel.DeleteTableInput) async throws -> DynamoDBModel.DeleteTableOutput
 
@@ -955,7 +946,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: backupNotFound, internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeBackup(
             input: DynamoDBModel.DescribeBackupInput) async throws -> DynamoDBModel.DescribeBackupOutput
 
@@ -968,7 +958,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeContinuousBackups(
             input: DynamoDBModel.DescribeContinuousBackupsInput) async throws -> DynamoDBModel.DescribeContinuousBackupsOutput
 
@@ -981,7 +970,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeContributorInsights(
             input: DynamoDBModel.DescribeContributorInsightsInput) async throws -> DynamoDBModel.DescribeContributorInsightsOutput
 
@@ -993,7 +981,6 @@ protocol _DynamoDBClientProtocol {
      - Returns: The DescribeEndpointsResponse object to be passed back from the caller of this async operation.
          Will be validated before being returned to caller.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeEndpoints(
             input: DynamoDBModel.DescribeEndpointsRequest) async throws -> DynamoDBModel.DescribeEndpointsResponse
 
@@ -1006,7 +993,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: exportNotFound, internalServer, limitExceeded.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeExport(
             input: DynamoDBModel.DescribeExportInput) async throws -> DynamoDBModel.DescribeExportOutput
 
@@ -1019,7 +1005,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: globalTableNotFound, internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeGlobalTable(
             input: DynamoDBModel.DescribeGlobalTableInput) async throws -> DynamoDBModel.DescribeGlobalTableOutput
 
@@ -1032,7 +1017,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: globalTableNotFound, internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeGlobalTableSettings(
             input: DynamoDBModel.DescribeGlobalTableSettingsInput) async throws -> DynamoDBModel.DescribeGlobalTableSettingsOutput
 
@@ -1045,7 +1029,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeKinesisStreamingDestination(
             input: DynamoDBModel.DescribeKinesisStreamingDestinationInput) async throws -> DynamoDBModel.DescribeKinesisStreamingDestinationOutput
 
@@ -1058,7 +1041,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeLimits(
             input: DynamoDBModel.DescribeLimitsInput) async throws -> DynamoDBModel.DescribeLimitsOutput
 
@@ -1071,7 +1053,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeTable(
             input: DynamoDBModel.DescribeTableInput) async throws -> DynamoDBModel.DescribeTableOutput
 
@@ -1084,7 +1065,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeTableReplicaAutoScaling(
             input: DynamoDBModel.DescribeTableReplicaAutoScalingInput) async throws -> DynamoDBModel.DescribeTableReplicaAutoScalingOutput
 
@@ -1097,7 +1077,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func describeTimeToLive(
             input: DynamoDBModel.DescribeTimeToLiveInput) async throws -> DynamoDBModel.DescribeTimeToLiveOutput
 
@@ -1110,7 +1089,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func disableKinesisStreamingDestination(
             input: DynamoDBModel.KinesisStreamingDestinationInput) async throws -> DynamoDBModel.KinesisStreamingDestinationOutput
 
@@ -1123,7 +1101,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func enableKinesisStreamingDestination(
             input: DynamoDBModel.KinesisStreamingDestinationInput) async throws -> DynamoDBModel.KinesisStreamingDestinationOutput
 
@@ -1136,7 +1113,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: conditionalCheckFailed, duplicateItem, internalServer, itemCollectionSizeLimitExceeded, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionConflict.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func executeStatement(
             input: DynamoDBModel.ExecuteStatementInput) async throws -> DynamoDBModel.ExecuteStatementOutput
 
@@ -1149,7 +1125,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: idempotentParameterMismatch, internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionCanceled, transactionInProgress.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func executeTransaction(
             input: DynamoDBModel.ExecuteTransactionInput) async throws -> DynamoDBModel.ExecuteTransactionOutput
 
@@ -1162,7 +1137,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: exportConflict, internalServer, invalidExportTime, limitExceeded, pointInTimeRecoveryUnavailable, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func exportTableToPointInTime(
             input: DynamoDBModel.ExportTableToPointInTimeInput) async throws -> DynamoDBModel.ExportTableToPointInTimeOutput
 
@@ -1175,7 +1149,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func getItem(
             input: DynamoDBModel.GetItemInput) async throws -> DynamoDBModel.GetItemOutput
 
@@ -1188,7 +1161,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func listBackups(
             input: DynamoDBModel.ListBackupsInput) async throws -> DynamoDBModel.ListBackupsOutput
 
@@ -1201,7 +1173,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func listContributorInsights(
             input: DynamoDBModel.ListContributorInsightsInput) async throws -> DynamoDBModel.ListContributorInsightsOutput
 
@@ -1214,7 +1185,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func listExports(
             input: DynamoDBModel.ListExportsInput) async throws -> DynamoDBModel.ListExportsOutput
 
@@ -1227,7 +1197,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func listGlobalTables(
             input: DynamoDBModel.ListGlobalTablesInput) async throws -> DynamoDBModel.ListGlobalTablesOutput
 
@@ -1240,7 +1209,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func listTables(
             input: DynamoDBModel.ListTablesInput) async throws -> DynamoDBModel.ListTablesOutput
 
@@ -1253,7 +1221,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func listTagsOfResource(
             input: DynamoDBModel.ListTagsOfResourceInput) async throws -> DynamoDBModel.ListTagsOfResourceOutput
 
@@ -1266,7 +1233,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: conditionalCheckFailed, internalServer, itemCollectionSizeLimitExceeded, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionConflict.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func putItem(
             input: DynamoDBModel.PutItemInput) async throws -> DynamoDBModel.PutItemOutput
 
@@ -1279,7 +1245,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func query(
             input: DynamoDBModel.QueryInput) async throws -> DynamoDBModel.QueryOutput
 
@@ -1292,7 +1257,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: backupInUse, backupNotFound, internalServer, limitExceeded, tableAlreadyExists, tableInUse.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func restoreTableFromBackup(
             input: DynamoDBModel.RestoreTableFromBackupInput) async throws -> DynamoDBModel.RestoreTableFromBackupOutput
 
@@ -1305,7 +1269,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, invalidRestoreTime, limitExceeded, pointInTimeRecoveryUnavailable, tableAlreadyExists, tableInUse, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func restoreTableToPointInTime(
             input: DynamoDBModel.RestoreTableToPointInTimeInput) async throws -> DynamoDBModel.RestoreTableToPointInTimeOutput
 
@@ -1318,7 +1281,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func scan(
             input: DynamoDBModel.ScanInput) async throws -> DynamoDBModel.ScanOutput
 
@@ -1329,7 +1291,6 @@ protocol _DynamoDBClientProtocol {
          - input: The validated TagResourceInput object being passed to this operation.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func tagResource(
             input: DynamoDBModel.TagResourceInput) async throws
 
@@ -1342,7 +1303,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionCanceled.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func transactGetItems(
             input: DynamoDBModel.TransactGetItemsInput) async throws -> DynamoDBModel.TransactGetItemsOutput
 
@@ -1355,7 +1315,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: idempotentParameterMismatch, internalServer, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionCanceled, transactionInProgress.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func transactWriteItems(
             input: DynamoDBModel.TransactWriteItemsInput) async throws -> DynamoDBModel.TransactWriteItemsOutput
 
@@ -1366,7 +1325,6 @@ protocol _DynamoDBClientProtocol {
          - input: The validated UntagResourceInput object being passed to this operation.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func untagResource(
             input: DynamoDBModel.UntagResourceInput) async throws
 
@@ -1379,7 +1337,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: continuousBackupsUnavailable, internalServer, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func updateContinuousBackups(
             input: DynamoDBModel.UpdateContinuousBackupsInput) async throws -> DynamoDBModel.UpdateContinuousBackupsOutput
 
@@ -1392,7 +1349,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func updateContributorInsights(
             input: DynamoDBModel.UpdateContributorInsightsInput) async throws -> DynamoDBModel.UpdateContributorInsightsOutput
 
@@ -1405,7 +1361,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: globalTableNotFound, internalServer, replicaAlreadyExists, replicaNotFound, tableNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func updateGlobalTable(
             input: DynamoDBModel.UpdateGlobalTableInput) async throws -> DynamoDBModel.UpdateGlobalTableOutput
 
@@ -1418,7 +1373,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: globalTableNotFound, indexNotFound, internalServer, limitExceeded, replicaNotFound, resourceInUse.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func updateGlobalTableSettings(
             input: DynamoDBModel.UpdateGlobalTableSettingsInput) async throws -> DynamoDBModel.UpdateGlobalTableSettingsOutput
 
@@ -1431,7 +1385,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: conditionalCheckFailed, internalServer, itemCollectionSizeLimitExceeded, provisionedThroughputExceeded, requestLimitExceeded, resourceNotFound, transactionConflict.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func updateItem(
             input: DynamoDBModel.UpdateItemInput) async throws -> DynamoDBModel.UpdateItemOutput
 
@@ -1444,7 +1397,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func updateTable(
             input: DynamoDBModel.UpdateTableInput) async throws -> DynamoDBModel.UpdateTableOutput
 
@@ -1457,7 +1409,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func updateTableReplicaAutoScaling(
             input: DynamoDBModel.UpdateTableReplicaAutoScalingInput) async throws -> DynamoDBModel.UpdateTableReplicaAutoScalingOutput
 
@@ -1470,7 +1421,6 @@ protocol _DynamoDBClientProtocol {
          Will be validated before being returned to caller.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func updateTimeToLive(
             input: DynamoDBModel.UpdateTimeToLiveInput) async throws -> DynamoDBModel.UpdateTimeToLiveOutput
     #endif


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Remove `@available` annotation from async APIs, increase the requirement for non Linux platforms to the upcoming 5.5.2 (which will backport async support to the earlier Apple OSs).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
