### PR TITLE
Add async shutdown of tables.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "1081b0b0541f535ca088acdb56f5ca5598bc6247",
-          "version": "1.6.3"
+          "revision": "70826d038d5bdc3142a386b735792d87ef7a5dfc",
+          "version": "1.8.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "40e61c4e055e91bb36ac8f82d2ddfc80fd1dbb17",
-          "version": "2.41.17"
+          "revision": "3181f04b53977676581a30977c104d45daa8de06",
+          "version": "2.42.37"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "cc2ca1f0d64cfd0f543b23b4f1a95329943ed22c",
-          "version": "2.10.0"
+          "revision": "fba50e336245de832d81484e0514a92a8c8bf8bd",
+          "version": "2.12.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "6aa9347d9bc5bbfe6a84983aec955c17ffea96ef",
-          "version": "2.33.0"
+          "revision": "51c3fc2e4a0fcdf4a25089b288dd65b73df1b0ef",
+          "version": "2.37.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "326f7f9a8c8c8402e3691adac04911cac9f9d87f",
-          "version": "1.18.4"
+          "revision": "6e94a7be32891d1b303a3fcfde8b5bf64d162e74",
+          "version": "1.19.1"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "5e68c1ded15619bb281b273fa8c2d8fd7f7b2b7d",
-          "version": "2.16.1"
+          "revision": "52a486ff6de9bc3e26bf634c5413c41c5fa89ca5",
+          "version": "2.17.2"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
-          "version": "1.11.3"
+          "revision": "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
+          "version": "1.11.4"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.41.17"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.42.37"),
         .package(url: "https://github.com/amzn/smoke-http.git", from: "2.10.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -89,11 +89,27 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
 
     /**
      Gracefully shuts down the client behind this table. This function is idempotent and
-     will handle being called multiple times.
+     will handle being called multiple times. Will block until shutdown is complete.
      */
-    public func close() throws {
-        try dynamodb.close()
+    public func syncShutdown() throws {
+        try self.dynamodb.syncShutdown()
     }
+
+    // renamed `syncShutdown` to make it clearer this version of shutdown will block.
+    @available(*, deprecated, renamed: "syncShutdown")
+    public func close() throws {
+        try self.dynamodb.close()
+    }
+
+    /**
+     Gracefully shuts down the client behind this table. This function is idempotent and
+     will handle being called multiple times. Will return when shutdown is complete.
+     */
+    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    public func shutdown() async throws {
+        try await self.dynamodb.shutdown()
+    }
+    #endif
 
     internal func getInputForInsert<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) throws
         -> DynamoDBModel.PutItemInput {

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
@@ -75,11 +75,27 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
 
     /**
      Gracefully shuts down the client behind this table. This function is idempotent and
-     will handle being called multiple times.
+     will handle being called multiple times. Will block until shutdown is complete.
      */
-    public func close() throws {
-        try dynamodbGenerator.close()
+    public func syncShutdown() throws {
+        try self.dynamodbGenerator.syncShutdown()
     }
+
+    // renamed `syncShutdown` to make it clearer this version of shutdown will block.
+    @available(*, deprecated, renamed: "syncShutdown")
+    public func close() throws {
+        try self.dynamodbGenerator.close()
+    }
+
+    /**
+     Gracefully shuts down the client behind this table. This function is idempotent and
+     will handle being called multiple times. Will return when shutdown is complete.
+     */
+    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    public func shutdown() async throws {
+        try await self.dynamodbGenerator.shutdown()
+    }
+    #endif
     
     public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(
             reporting: NewInvocationReportingType) -> AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType> {

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
@@ -94,11 +94,27 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
 
     /**
      Gracefully shuts down the client behind this table. This function is idempotent and
-     will handle being called multiple times.
+     will handle being called multiple times. Will block until shutdown is complete.
      */
-    public func close() throws {
-        try dynamodb.close()
+    public func syncShutdown() throws {
+        try self.dynamodb.syncShutdown()
     }
+
+    // renamed `syncShutdown` to make it clearer this version of shutdown will block.
+    @available(*, deprecated, renamed: "syncShutdown")
+    public func close() throws {
+        try self.dynamodb.close()
+    }
+
+    /**
+     Gracefully shuts down the client behind this table. This function is idempotent and
+     will handle being called multiple times. Will return when shutdown is complete.
+     */
+    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    public func shutdown() async throws {
+        try await self.dynamodb.shutdown()
+    }
+    #endif
 }
 
 extension AWSDynamoDBCompositePrimaryKeysProjection {

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjectionGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjectionGenerator.swift
@@ -75,11 +75,27 @@ public class AWSDynamoDBCompositePrimaryKeysProjectionGenerator {
 
     /**
      Gracefully shuts down the client behind this table. This function is idempotent and
-     will handle being called multiple times.
+     will handle being called multiple times. Will block until shutdown is complete.
      */
-    public func close() throws {
-        try dynamodbGenerator.close()
+    public func syncShutdown() throws {
+        try self.dynamodbGenerator.syncShutdown()
     }
+
+    // renamed `syncShutdown` to make it clearer this version of shutdown will block.
+    @available(*, deprecated, renamed: "syncShutdown")
+    public func close() throws {
+        try self.dynamodbGenerator.close()
+    }
+
+    /**
+     Gracefully shuts down the client behind this table. This function is idempotent and
+     will handle being called multiple times. Will return when shutdown is complete.
+     */
+    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    public func shutdown() async throws {
+        try await self.dynamodbGenerator.shutdown()
+    }
+    #endif
     
     public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(
             reporting: NewInvocationReportingType) -> AWSDynamoDBCompositePrimaryKeysProjection<NewInvocationReportingType> {

--- a/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClient.swift
+++ b/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClient.swift
@@ -122,13 +122,33 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
 
     /**
      Gracefully shuts down this client. This function is idempotent and
-     will handle being called multiple times.
+     will handle being called multiple times. Will block until shutdown is complete.
      */
-    public func close() throws {
+    public func syncShutdown() throws {
         if self.ownsHttpClients {
-            try httpClient.close()
+            try self.httpClient.syncShutdown()
         }
     }
+
+    // renamed `syncShutdown` to make it clearer this version of shutdown will block.
+    @available(*, deprecated, renamed: "syncShutdown")
+    public func close() throws {
+        if self.ownsHttpClients {
+            try self.httpClient.close()
+        }
+    }
+
+    /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times. Will return when shutdown is complete.
+     */
+    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    public func shutdown() async throws {
+        if self.ownsHttpClients {
+            try await self.httpClient.shutdown()
+        }
+    }
+    #endif
 
     /**
      Invokes the BatchExecuteStatement operation returning immediately with an `EventLoopFuture` that will be completed at a later time.

--- a/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClientGenerator.swift
+++ b/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClientGenerator.swift
@@ -91,11 +91,27 @@ struct _AWSDynamoDBClientGenerator {
 
     /**
      Gracefully shuts down this client. This function is idempotent and
-     will handle being called multiple times.
+     will handle being called multiple times. Will block until shutdown is complete.
      */
-    public func close() throws {
-        try httpClient.close()
+    public func syncShutdown() throws {
+        try self.httpClient.syncShutdown()
     }
+
+    // renamed `syncShutdown` to make it clearer this version of shutdown will block.
+    @available(*, deprecated, renamed: "syncShutdown")
+    public func close() throws {
+        try self.httpClient.close()
+    }
+
+    /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times. Will return when shutdown is complete.
+     */
+    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    public func shutdown() async throws {
+        try await self.httpClient.shutdown()
+    }
+    #endif
     
     public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(
             reporting: NewInvocationReportingType) -> _AWSDynamoDBClient<NewInvocationReportingType> {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add async shutdown method for tables and gsi indicies.
2. Add a syncShutdown method for tables and gsi indicies and deprecate the existing close method for clarity and consistency.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
