### PR TITLE
Move DynamoDBCompositePrimaryKeysProjection to async only.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "70826d038d5bdc3142a386b735792d87ef7a5dfc",
-          "version": "1.8.1"
+          "revision": "cbf533073d9a5edfb16c266d14151f69137ba7c9",
+          "version": "1.8.2"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "cbf533073d9a5edfb16c266d14151f69137ba7c9",
-          "version": "1.8.2"
+          "revision": "5bee16a79922e3efcb5cea06ecd27e6f8048b56b",
+          "version": "1.13.1"
         }
       },
       {
@@ -24,8 +24,17 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "3181f04b53977676581a30977c104d45daa8de06",
-          "version": "2.42.37"
+          "revision": "dbfb28404f4dd5d3d9357f3dad38daf15cdb23a5",
+          "version": "2.44.114"
+        }
+      },
+      {
+        "package": "smoke-aws-support",
+        "repositoryURL": "https://github.com/amzn/smoke-aws-support.git",
+        "state": {
+          "branch": null,
+          "revision": "1103463edf3a4ee0315f293180432495fa79fff8",
+          "version": "1.0.0"
         }
       },
       {
@@ -33,8 +42,26 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "fba50e336245de832d81484e0514a92a8c8bf8bd",
-          "version": "2.12.0"
+          "revision": "7a38547e6ef16b53238ac2b41340cd00c07caa93",
+          "version": "2.15.0"
+        }
+      },
+      {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
+          "version": "1.0.3"
         }
       },
       {
@@ -42,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
-          "version": "1.1.6"
+          "revision": "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+          "version": "1.1.7"
         }
       },
       {
@@ -51,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
+          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
+          "version": "1.4.4"
         }
       },
       {
@@ -60,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
-          "version": "2.2.0"
+          "revision": "53be78637ecd165d1ddedc4e20de69b8f43ec3b7",
+          "version": "2.3.2"
         }
       },
       {
@@ -69,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "51c3fc2e4a0fcdf4a25089b288dd65b73df1b0ef",
-          "version": "2.37.0"
+          "revision": "e855380cb5234e96b760d93e0bfdc403e381e928",
+          "version": "2.45.0"
         }
       },
       {
@@ -78,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-          "version": "1.10.2"
+          "revision": "91dd2d61fb772e1311bb5f13b59266b579d77e42",
+          "version": "1.15.0"
         }
       },
       {
@@ -87,8 +114,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "6e94a7be32891d1b303a3fcfde8b5bf64d162e74",
-          "version": "1.19.1"
+          "revision": "d6656967f33ed8b368b38e4b198631fc7c484a40",
+          "version": "1.23.1"
         }
       },
       {
@@ -96,8 +123,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "52a486ff6de9bc3e26bf634c5413c41c5fa89ca5",
-          "version": "2.17.2"
+          "revision": "4fb7ead803e38949eb1d6fabb849206a72c580f3",
+          "version": "2.23.0"
         }
       },
       {
@@ -105,8 +132,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
-          "version": "1.11.4"
+          "revision": "c0d9a144cfaec8d3d596aadde3039286a266c15c",
+          "version": "1.15.0"
         }
       },
       {

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
@@ -112,7 +112,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             sortKeyCondition: AttributeCondition?,
             exclusiveStartKey: String?,
             consistentRead: Bool) async throws -> [ReturnedType] {
-        let paginatedItems: ([ReturnedType], String?) =
+        let paginatedItems: (items: [ReturnedType], lastEvaluatedKey: String?) =
             try await query(forPartitionKey: partitionKey,
                   sortKeyCondition: sortKeyCondition,
                   limit: nil,
@@ -121,7 +121,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                   consistentRead: consistentRead)
         
         // if there are more items
-        if let lastEvaluatedKey = paginatedItems.1 {
+        if let lastEvaluatedKey = paginatedItems.lastEvaluatedKey {
             // returns a future with all the results from all later paginated calls
             let partialResult: [ReturnedType] = try await self.partialQuery(
                 forPartitionKey: partitionKey,
@@ -130,10 +130,10 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                 consistentRead: consistentRead)
                 
             // return the results from 'this' call and all later paginated calls
-            return paginatedItems.0 + partialResult
+            return paginatedItems.items + partialResult
         } else {
             // this is it, all results have been obtained
-            return paginatedItems.0
+            return paginatedItems.items
         }
     }
     
@@ -142,7 +142,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                                                              limit: Int?,
                                                              exclusiveStartKey: String?,
                                                              consistentRead: Bool) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         return try await query(forPartitionKey: partitionKey,
                                sortKeyCondition: sortKeyCondition,
                                limit: limit,
@@ -157,7 +157,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                                                              scanIndexForward: Bool,
                                                              exclusiveStartKey: String?,
                                                              consistentRead: Bool) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         let queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(partitionKey: partitionKey, targetTableName: targetTableName,
                                                                           primaryKeyType: ReturnedType.AttributesType.self,
                                                                           sortKeyCondition: sortKeyCondition, limit: limit,
@@ -248,7 +248,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             sortKeyCondition: AttributeCondition?,
             exclusiveStartKey: String?,
             consistentRead: Bool) async throws -> [TypedDatabaseItem<AttributesType, ItemType>] {
-        let paginatedItems: ([TypedDatabaseItem<AttributesType, ItemType>], String?) =
+        let paginatedItems: (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) =
             try await monomorphicQuery(forPartitionKey: partitionKey,
                                        sortKeyCondition: sortKeyCondition,
                                        limit: nil,
@@ -257,7 +257,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                                        consistentRead: consistentRead)
         
         // if there are more items
-        if let lastEvaluatedKey = paginatedItems.1 {
+        if let lastEvaluatedKey = paginatedItems.lastEvaluatedKey {
             // returns a future with all the results from all later paginated calls
             let partialResult: [TypedDatabaseItem<AttributesType, ItemType>] = try await self.monomorphicPartialQuery(
                 forPartitionKey: partitionKey,
@@ -266,10 +266,10 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                 consistentRead: consistentRead)
                 
             // return the results from 'this' call and all later paginated calls
-            return paginatedItems.0 + partialResult
+            return paginatedItems.items + partialResult
         } else {
             // this is it, all results have been obtained
-            return paginatedItems.0
+            return paginatedItems.items
         }
     }
     
@@ -279,7 +279,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                                                         scanIndexForward: Bool,
                                                         exclusiveStartKey: String?,
                                                         consistentRead: Bool) async throws
-    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+    -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) {
         let queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(
                 partitionKey: partitionKey, targetTableName: targetTableName,
                 primaryKeyType: AttributesType.self,

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+execute.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+execute.swift
@@ -31,7 +31,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         // if there are no partitions, there will be no results to return
         // succeed immediately with empty results
         guard partitionKeys.count > 0 else {
@@ -106,7 +106,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) async throws
-    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+    -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) {
         // if there are no partitions, there will be no results to return
         // succeed immediately with empty results
         guard partitionKeys.count > 0 else {
@@ -182,14 +182,14 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             additionalWhereClause: String?,
             nextToken: String?) async throws
     -> [ReturnedType] {
-        let paginatedItems: ([ReturnedType], String?) =
+        let paginatedItems: (items: [ReturnedType], lastEvaluatedKey: String?) =
             try await execute(partitionKeys: partitionKeys,
                     attributesFilter: attributesFilter,
                     additionalWhereClause: additionalWhereClause,
                     nextToken: nextToken)
         
         // if there are more items
-        if let returnedNextToken = paginatedItems.1 {
+        if let returnedNextToken = paginatedItems.lastEvaluatedKey {
             // returns a future with all the results from all later paginated calls
             let partialResult: [ReturnedType] = try await self.partialExecute(partitionKeys: partitionKeys,
                                                                               attributesFilter: attributesFilter,
@@ -197,10 +197,10 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                                                                               nextToken: returnedNextToken)
                 
             // return the results from 'this' call and all later paginated calls
-            return paginatedItems.0 + partialResult
+            return paginatedItems.items + partialResult
         } else {
             // this is it, all results have been obtained
-            return paginatedItems.0
+            return paginatedItems.items
         }
     }
     
@@ -210,14 +210,14 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             additionalWhereClause: String?,
             nextToken: String?) async throws
     -> [TypedDatabaseItem<AttributesType, ItemType>] {
-        let paginatedItems: ([TypedDatabaseItem<AttributesType, ItemType>], String?) =
+        let paginatedItems: (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) =
             try await monomorphicExecute(partitionKeys: partitionKeys,
                                          attributesFilter: attributesFilter,
                                          additionalWhereClause: additionalWhereClause,
                                          nextToken: nextToken)
         
         // if there are more items
-        if let returnedNextToken = paginatedItems.1 {
+        if let returnedNextToken = paginatedItems.lastEvaluatedKey {
             // returns a future with all the results from all later paginated calls
             let partialResult: [TypedDatabaseItem<AttributesType, ItemType>] = try await self.monomorphicPartialExecute(
                 partitionKeys: partitionKeys,
@@ -226,10 +226,10 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                 nextToken: returnedNextToken)
                 
             // return the results from 'this' call and all later paginated calls
-            return paginatedItems.0 + partialResult
+            return paginatedItems.items + partialResult
         } else {
             // this is it, all results have been obtained
-            return paginatedItems.0
+            return paginatedItems.items
         }
     }
     

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -88,14 +88,6 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
 
     /**
      Gracefully shuts down the client behind this table. This function is idempotent and
-     will handle being called multiple times. Will block until shutdown is complete.
-     */
-    public func syncShutdown() throws {
-        try self.dynamodb.syncShutdown()
-    }
-
-    /**
-     Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times. Will return when shutdown is complete.
      */
     public func shutdown() async throws {

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
@@ -74,27 +74,11 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
 
     /**
      Gracefully shuts down the client behind this table. This function is idempotent and
-     will handle being called multiple times. Will block until shutdown is complete.
-     */
-    public func syncShutdown() throws {
-        try self.dynamodbGenerator.syncShutdown()
-    }
-
-    // renamed `syncShutdown` to make it clearer this version of shutdown will block.
-    @available(*, deprecated, renamed: "syncShutdown")
-    public func close() throws {
-        try self.dynamodbGenerator.close()
-    }
-
-    /**
-     Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times. Will return when shutdown is complete.
      */
-    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     public func shutdown() async throws {
         try await self.dynamodbGenerator.shutdown()
     }
-    #endif
     
     public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(
             reporting: NewInvocationReportingType) -> AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType> {

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection+DynamoDBKeysProjectionAsync.swift
@@ -20,91 +20,79 @@ import SmokeAWSCore
 import DynamoDBModel
 import SmokeHTTPClient
 import Logging
-import NIO
 
 /// DynamoDBKeysProjection conformance async functions
 public extension AWSDynamoDBCompositePrimaryKeysProjection {
     
-    func query<AttributesType>(
-            forPartitionKey partitionKey: String,
-            sortKeyCondition: AttributeCondition?) -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]>
-            where AttributesType: PrimaryKeyAttributes {
-        return partialQuery(forPartitionKey: partitionKey,
-                            sortKeyCondition: sortKeyCondition,
-                            exclusiveStartKey: nil)
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                                      sortKeyCondition: AttributeCondition?) async throws
+    -> [CompositePrimaryKey<AttributesType>] {
+        return try await partialQuery(forPartitionKey: partitionKey,
+                                      sortKeyCondition: sortKeyCondition,
+                                      exclusiveStartKey: nil)
     }
     
     // function to return a future with the results of a query call and all future paginated calls
     private func partialQuery<AttributesType>(
             forPartitionKey partitionKey: String,
             sortKeyCondition: AttributeCondition?,
-            exclusiveStartKey: String?) -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]>
-            where AttributesType: PrimaryKeyAttributes {
-        let queryFuture: EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)> =
-            query(forPartitionKey: partitionKey,
-                  sortKeyCondition: sortKeyCondition,
-                  limit: nil,
-                  scanIndexForward: true,
-                  exclusiveStartKey: exclusiveStartKey)
+            exclusiveStartKey: String?) async throws
+    -> [CompositePrimaryKey<AttributesType>] {
+        let paginatedItems: ([CompositePrimaryKey<AttributesType>], String?) =
+            try await query(forPartitionKey: partitionKey,
+                            sortKeyCondition: sortKeyCondition,
+                            limit: nil,
+                            scanIndexForward: true,
+                            exclusiveStartKey: exclusiveStartKey)
         
-        return queryFuture.flatMap { paginatedItems in
-            // if there are more items
-            if let lastEvaluatedKey = paginatedItems.1 {
-                // returns a future with all the results from all later paginated calls
-                return self.partialQuery(forPartitionKey: partitionKey,
-                                         sortKeyCondition: sortKeyCondition,
-                                         exclusiveStartKey: lastEvaluatedKey)
-                    .map { partialResult in
-                        // return the results from 'this' call and all later paginated calls
-                        return paginatedItems.0 + partialResult
-                    }
-            } else {
-                // this is it, all results have been obtained
-                let promise = self.eventLoop.makePromise(of: [CompositePrimaryKey<AttributesType>].self)
-                promise.succeed(paginatedItems.0)
-                return promise.futureResult
-            }
+        // if there are more items
+        if let lastEvaluatedKey = paginatedItems.1 {
+            // returns a future with all the results from all later paginated calls
+            let partialResult: [CompositePrimaryKey<AttributesType>] = try await self.partialQuery(
+                forPartitionKey: partitionKey,
+                sortKeyCondition: sortKeyCondition,
+                exclusiveStartKey: lastEvaluatedKey)
+                
+            // return the results from 'this' call and all later paginated calls
+            return paginatedItems.0 + partialResult
+        } else {
+            // this is it, all results have been obtained
+            return paginatedItems.0
         }
     }
     
-    func query<AttributesType>(
-            forPartitionKey partitionKey: String,
-            sortKeyCondition: AttributeCondition?,
-            limit: Int?, exclusiveStartKey: String?) -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
-            where AttributesType: PrimaryKeyAttributes {
-        return query(forPartitionKey: partitionKey,
-                     sortKeyCondition: sortKeyCondition,
-                     limit: limit,
-                     scanIndexForward: true,
-                     exclusiveStartKey: exclusiveStartKey)
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                                      sortKeyCondition: AttributeCondition?,
+                                      limit: Int?,
+                                      exclusiveStartKey: String?) async throws
+    -> ([CompositePrimaryKey<AttributesType>], String?)  {
+        return try await query(forPartitionKey: partitionKey,
+                               sortKeyCondition: sortKeyCondition,
+                               limit: limit,
+                               scanIndexForward: true,
+                               exclusiveStartKey: exclusiveStartKey)
         
     }
     
-    func query<AttributesType>(
-            forPartitionKey partitionKey: String,
-            sortKeyCondition: AttributeCondition?,
-            limit: Int?,
-            scanIndexForward: Bool,
-            exclusiveStartKey: String?) -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
-            where AttributesType: PrimaryKeyAttributes {
-        let queryInput: DynamoDBModel.QueryInput
-        do {
-            queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(partitionKey: partitionKey, targetTableName: targetTableName,
+    func query<AttributesType>(forPartitionKey partitionKey: String,
+                                      sortKeyCondition: AttributeCondition?,
+                                      limit: Int?,
+                                      scanIndexForward: Bool,
+                                      exclusiveStartKey: String?) async throws
+    -> ([CompositePrimaryKey<AttributesType>], String?) {
+        let queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(partitionKey: partitionKey, targetTableName: targetTableName,
                                                                           primaryKeyType: AttributesType.self,
                                                                           sortKeyCondition: sortKeyCondition, limit: limit,
                                                                           scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
                                                                           consistentRead: false)
-        } catch {
-            let promise = self.eventLoop.makePromise(of: ([CompositePrimaryKey<AttributesType>], String?).self)
-            promise.fail(error)
-            return promise.futureResult
-        }
         
         let logMessage = "dynamodb.query with partitionKey: \(partitionKey), " +
             "sortKeyCondition: \(sortKeyCondition.debugDescription), and table name \(targetTableName)."
         self.logger.debug("\(logMessage)")
         
-        return dynamodb.query(input: queryInput).flatMapThrowing { queryOutput in
+        do {
+            let queryOutput = try await self.dynamodb.query(input: queryInput)
+            
             let lastEvaluatedKey: String?
             if let returnedLastEvaluatedKey = queryOutput.lastEvaluatedKey {
                 let encodedLastEvaluatedKey: Data
@@ -137,7 +125,7 @@ public extension AWSDynamoDBCompositePrimaryKeysProjection {
             } else {
                 return ([], lastEvaluatedKey)
             }
-        } .flatMapErrorThrowing { error in
+        } catch {
             if let typedError = error as? DynamoDBError {
                 throw typedError.asSmokeDynamoDBError()
             }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
@@ -22,7 +22,6 @@ import DynamoDBModel
 import SmokeAWSCore
 import SmokeHTTPClient
 import AsyncHTTPClient
-import NIO
 
 public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: HTTPClientCoreInvocationReporting>: DynamoDBCompositePrimaryKeysProjection {
     internal let dynamodb: _AWSDynamoDBClient<InvocationReportingType>
@@ -94,31 +93,9 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
 
     /**
      Gracefully shuts down the client behind this table. This function is idempotent and
-     will handle being called multiple times. Will block until shutdown is complete.
-     */
-    public func syncShutdown() throws {
-        try self.dynamodb.syncShutdown()
-    }
-
-    // renamed `syncShutdown` to make it clearer this version of shutdown will block.
-    @available(*, deprecated, renamed: "syncShutdown")
-    public func close() throws {
-        try self.dynamodb.close()
-    }
-
-    /**
-     Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times. Will return when shutdown is complete.
      */
-    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     public func shutdown() async throws {
         try await self.dynamodb.shutdown()
-    }
-    #endif
-}
-
-extension AWSDynamoDBCompositePrimaryKeysProjection {
-    public var eventLoop: EventLoop {
-        return self.dynamodb.reporting.eventLoop ?? self.dynamodb.eventLoopGroup.next()
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjectionGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjectionGenerator.swift
@@ -23,7 +23,6 @@ import SmokeAWSCore
 import SmokeAWSHttp
 import SmokeHTTPClient
 import AsyncHTTPClient
-import NIO
 
 public class AWSDynamoDBCompositePrimaryKeysProjectionGenerator {
     internal let dynamodbGenerator: _AWSDynamoDBClientGenerator
@@ -75,27 +74,11 @@ public class AWSDynamoDBCompositePrimaryKeysProjectionGenerator {
 
     /**
      Gracefully shuts down the client behind this table. This function is idempotent and
-     will handle being called multiple times. Will block until shutdown is complete.
-     */
-    public func syncShutdown() throws {
-        try self.dynamodbGenerator.syncShutdown()
-    }
-
-    // renamed `syncShutdown` to make it clearer this version of shutdown will block.
-    @available(*, deprecated, renamed: "syncShutdown")
-    public func close() throws {
-        try self.dynamodbGenerator.close()
-    }
-
-    /**
-     Gracefully shuts down the client behind this table. This function is idempotent and
      will handle being called multiple times. Will return when shutdown is complete.
      */
-    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     public func shutdown() async throws {
         try await self.dynamodbGenerator.shutdown()
     }
-    #endif
     
     public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(
             reporting: NewInvocationReportingType) -> AWSDynamoDBCompositePrimaryKeysProjection<NewInvocationReportingType> {
@@ -108,26 +91,24 @@ public class AWSDynamoDBCompositePrimaryKeysProjectionGenerator {
     public func with<NewTraceContextType: InvocationTraceContext>(
             logger: Logging.Logger,
             internalRequestId: String = "none",
-            traceContext: NewTraceContextType,
-            eventLoop: EventLoop? = nil) -> AWSDynamoDBCompositePrimaryKeysProjection<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
+            traceContext: NewTraceContextType)
+    -> AWSDynamoDBCompositePrimaryKeysProjection<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
         let reporting = StandardHTTPClientCoreInvocationReporting(
             logger: logger,
             internalRequestId: internalRequestId,
-            traceContext: traceContext,
-            eventLoop: eventLoop)
+            traceContext: traceContext)
 
         return with(reporting: reporting)
     }
 
     public func with(
             logger: Logging.Logger,
-            internalRequestId: String = "none",
-            eventLoop: EventLoop? = nil) -> AWSDynamoDBCompositePrimaryKeysProjection<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>> {
+            internalRequestId: String = "none")
+    -> AWSDynamoDBCompositePrimaryKeysProjection<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>> {
         let reporting = StandardHTTPClientCoreInvocationReporting(
             logger: logger,
             internalRequestId: internalRequestId,
-            traceContext: AWSClientInvocationTraceContext(),
-            eventLoop: eventLoop)
+            traceContext: AWSClientInvocationTraceContext())
 
         return with(reporting: reporting)
     }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+conditionallyUpdateItem.swift
@@ -19,7 +19,6 @@ import Foundation
 import SmokeHTTPClient
 import Logging
 import DynamoDBModel
-import NIO
 
 public extension DynamoDBCompositePrimaryKeyTable {
     /**

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
@@ -33,7 +33,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                                              sortKeyCondition: AttributeCondition?,
                                                              limit: Int?,
                                                              exclusiveStartKey: String?) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         return try await query(forPartitionKey: partitionKey,
                                sortKeyCondition: sortKeyCondition,
                                limit: limit,
@@ -46,7 +46,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                                              limit: Int?,
                                                              scanIndexForward: Bool,
                                                              exclusiveStartKey: String?) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         return try await query(forPartitionKey: partitionKey,
                                sortKeyCondition: sortKeyCondition,
                                limit: limit,
@@ -68,7 +68,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                                     limit: Int?,
                                                     scanIndexForward: Bool,
                                                     exclusiveStartKey: String?) async throws
-    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+    -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) {
         return try await monomorphicQuery(forPartitionKey: partitionKey,
                                           sortKeyCondition: sortKeyCondition,
                                           limit: limit,

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -163,7 +163,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
                                                              limit: Int?,
                                                              exclusiveStartKey: String?,
                                                              consistentRead: Bool) async throws
-    -> ([ReturnedType], String?)
+    -> (items: [ReturnedType], lastEvaluatedKey: String?)
     
     /**
      * Queries a partition in the database table and optionally a sort key condition. If the
@@ -176,7 +176,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
                                                              scanIndexForward: Bool,
                                                              exclusiveStartKey: String?,
                                                              consistentRead: Bool) async throws
-    -> ([ReturnedType], String?)
+    -> (items: [ReturnedType], lastEvaluatedKey: String?)
     
     /**
      * Uses the ExecuteStatement API to perform batch reads or writes on data stored in DynamoDB, using PartiQL.
@@ -202,7 +202,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) async throws
-    -> ([ReturnedType], String?)
+    -> (items: [ReturnedType], lastEvaluatedKey: String?)
     
     // MARK: Monomorphic batch and queries
     
@@ -235,7 +235,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
                                                         scanIndexForward: Bool,
                                                         exclusiveStartKey: String?,
                                                         consistentRead: Bool) async throws
-    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?)
+    -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?)
     
     /**
      * Uses the ExecuteStatement API to to perform batch reads or writes on data stored in DynamoDB, using PartiQL.
@@ -261,5 +261,5 @@ public protocol DynamoDBCompositePrimaryKeyTable {
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) async throws
-    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?)
+    -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?)
 }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
@@ -18,44 +18,12 @@
 import Foundation
 import SmokeHTTPClient
 import DynamoDBModel
-import NIO
 
 /**
  Protocol presenting a Keys Only projection of a DynamoDB table such as a Keys Only GSI projection.
  Provides the ability to query the projection to get the list of keys without attempting to decode the row into a particular data type.
  */
 public protocol DynamoDBCompositePrimaryKeysProjection {
-    var eventLoop: EventLoop { get }
-
-    /**
-     * Queries a partition in the database table and optionally a sort key condition. If the
-       partition doesn't exist, this operation will return an empty list as a response. This
-       function will potentially make multiple calls to DynamoDB to retrieve all results for
-       the query.
-     */
-    func query<AttributesType>(forPartitionKey partitionKey: String,
-                               sortKeyCondition: AttributeCondition?)
-        -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]>
-
-    /**
-     * Queries a partition in the database table and optionally a sort key condition. If the
-       partition doesn't exist, this operation will return an empty list as a response. This
-       function will return paginated results based on the limit and exclusiveStartKey provided.
-     */
-    func query<AttributesType>(forPartitionKey partitionKey: String,
-                               sortKeyCondition: AttributeCondition?,
-                               limit: Int?,
-                               exclusiveStartKey: String?)
-        -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
-    
-    func query<AttributesType>(forPartitionKey partitionKey: String,
-                               sortKeyCondition: AttributeCondition?,
-                               limit: Int?,
-                               scanIndexForward: Bool,
-                               exclusiveStartKey: String?)
-        -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
-    
-#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     /**
      * Queries a partition in the database table and optionally a sort key condition. If the
        partition doesn't exist, this operation will return an empty list as a response. This
@@ -83,41 +51,4 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
                                scanIndexForward: Bool,
                                exclusiveStartKey: String?) async throws
         -> ([CompositePrimaryKey<AttributesType>], String?)
-#endif
-}
-
-// For async/await APIs, simply delegate to the EventLoopFuture implementation until support is dropped for Swift <5.5
-public extension DynamoDBCompositePrimaryKeysProjection {
-#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
-    func query<AttributesType>(forPartitionKey partitionKey: String,
-                               sortKeyCondition: AttributeCondition?) async throws
-    -> [CompositePrimaryKey<AttributesType>] {
-        return try await query(forPartitionKey: partitionKey,
-                               sortKeyCondition: sortKeyCondition).get()
-    }
-
-    func query<AttributesType>(forPartitionKey partitionKey: String,
-                               sortKeyCondition: AttributeCondition?,
-                               limit: Int?,
-                               exclusiveStartKey: String?) async throws
-    -> ([CompositePrimaryKey<AttributesType>], String?) {
-        return try await query(forPartitionKey: partitionKey,
-                               sortKeyCondition: sortKeyCondition,
-                               limit: limit,
-                               exclusiveStartKey: exclusiveStartKey).get()
-    }
-    
-    func query<AttributesType>(forPartitionKey partitionKey: String,
-                               sortKeyCondition: AttributeCondition?,
-                               limit: Int?,
-                               scanIndexForward: Bool,
-                               exclusiveStartKey: String?) async throws
-    -> ([CompositePrimaryKey<AttributesType>], String?) {
-        return try await query(forPartitionKey: partitionKey,
-                               sortKeyCondition: sortKeyCondition,
-                               limit: limit,
-                               scanIndexForward: scanIndexForward,
-                               exclusiveStartKey: exclusiveStartKey).get()
-    }
-#endif
 }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeysProjection.swift
@@ -43,12 +43,12 @@ public protocol DynamoDBCompositePrimaryKeysProjection {
                                sortKeyCondition: AttributeCondition?,
                                limit: Int?,
                                exclusiveStartKey: String?) async throws
-        -> ([CompositePrimaryKey<AttributesType>], String?)
+        -> (keys: [CompositePrimaryKey<AttributesType>], lastEvaluatedKey: String?)
     
     func query<AttributesType>(forPartitionKey partitionKey: String,
                                sortKeyCondition: AttributeCondition?,
                                limit: Int?,
                                scanIndexForward: Bool,
                                exclusiveStartKey: String?) async throws
-        -> ([CompositePrimaryKey<AttributesType>], String?)
+        -> (keys: [CompositePrimaryKey<AttributesType>], lastEvaluatedKey: String?)
 }

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -110,7 +110,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimary
                                                                     limit: Int?,
                                                                     exclusiveStartKey: String?,
                                                                     consistentRead: Bool) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         return try await storeWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
                                             limit: limit, exclusiveStartKey: exclusiveStartKey, consistentRead: consistentRead)
     }
@@ -121,7 +121,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimary
                                                                     scanIndexForward: Bool,
                                                                     exclusiveStartKey: String?,
                                                                     consistentRead: Bool) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         return try await storeWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
                                             limit: limit, scanIndexForward: scanIndexForward,
                                             exclusiveStartKey: exclusiveStartKey, consistentRead: consistentRead)
@@ -140,7 +140,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimary
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         return try await storeWrapper.execute(partitionKeys: partitionKeys, attributesFilter: attributesFilter,
                                               additionalWhereClause: additionalWhereClause, nextToken: nextToken)
     }
@@ -158,7 +158,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimary
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) async throws
-    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+    -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) {
         return try await storeWrapper.monomorphicExecute(partitionKeys: partitionKeys, attributesFilter: attributesFilter,
                                                additionalWhereClause: additionalWhereClause, nextToken: nextToken)
     }
@@ -183,7 +183,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimary
                                                            scanIndexForward: Bool,
                                                            exclusiveStartKey: String?,
                                                            consistentRead: Bool) async throws
-       -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+       -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) {
         return try await storeWrapper.monomorphicQuery(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
                                                        limit: limit, scanIndexForward: scanIndexForward,
                                                        exclusiveStartKey: exclusiveStartKey, consistentRead: consistentRead)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -46,6 +46,12 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimary
     internal init(storeWrapper: InMemoryDynamoDBCompositePrimaryKeyTableStore) {
         self.storeWrapper = storeWrapper
     }
+    
+    public var store: [String: [String: PolymorphicOperationReturnTypeConvertable]] {
+        get async {
+            return await self.storeWrapper.store
+        }
+    }
 
     public func insertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) async throws {
         return try await storeWrapper.insertItem(item)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore+execute.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore+execute.swift
@@ -40,7 +40,7 @@ extension InMemoryDynamoDBCompositePrimaryKeyTableStore {
             partitionKeys: [String],
             attributesFilter: [String]?,
             additionalWhereClause: String?, nextToken: String?) throws
-    -> ([ReturnedType], String?)  {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?)  {
         let items = self.getExecuteItems(partitionKeys: partitionKeys, additionalWhereClause: additionalWhereClause)
            
         let returnedItems: [ReturnedType] = try items.map { item in
@@ -77,7 +77,7 @@ extension InMemoryDynamoDBCompositePrimaryKeyTableStore {
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) throws
-    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+    -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) {
         let items = self.getExecuteItems(partitionKeys: partitionKeys, additionalWhereClause: additionalWhereClause)
            
         let returnedItems: [TypedDatabaseItem<AttributesType, ItemType>] = try items.map { item in

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore+monomorphicQuery.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore+monomorphicQuery.swift
@@ -122,7 +122,7 @@ extension InMemoryDynamoDBCompositePrimaryKeyTableStore {
                                                     scanIndexForward: Bool,
                                                     exclusiveStartKey: String?,
                                                     consistentRead: Bool) throws
-    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+    -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) {
         // get all the results
         let rawItems: [TypedDatabaseItem<AttributesType, ItemType>] = try monomorphicQuery(forPartitionKey: partitionKey,
                                                                                            sortKeyCondition: sortKeyCondition,

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -288,7 +288,7 @@ internal actor InMemoryDynamoDBCompositePrimaryKeyTableStore {
                                                              limit: Int?,
                                                              exclusiveStartKey: String?,
                                                              consistentRead: Bool) throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         return try query(forPartitionKey: partitionKey,
                          sortKeyCondition: sortKeyCondition,
                          limit: limit,
@@ -303,7 +303,7 @@ internal actor InMemoryDynamoDBCompositePrimaryKeyTableStore {
                                                              scanIndexForward: Bool,
                                                              exclusiveStartKey: String?,
                                                              consistentRead: Bool) throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         // get all the results
         let rawItems: [ReturnedType] = try query(forPartitionKey: partitionKey,
                                                  sortKeyCondition: sortKeyCondition,

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -138,7 +138,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
                                                                     limit: Int?,
                                                                     exclusiveStartKey: String?,
                                                                     consistentRead: Bool) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         // if this is querying an index
         if let indexName = ReturnedType.AttributesType.indexName {
             // fail if it isn't the index we know about
@@ -162,7 +162,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
                                                                     scanIndexForward: Bool,
                                                                     exclusiveStartKey: String?,
                                                                     consistentRead: Bool) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         // if this is querying an index
         if let indexName = ReturnedType.AttributesType.indexName {
             // fail if it isn't the index we know about
@@ -208,7 +208,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         // if this is executing on index
         if let indexName = ReturnedType.AttributesType.indexName {
             // fail if it isn't the index we know about
@@ -261,7 +261,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
                                                            scanIndexForward: Bool,
                                                            exclusiveStartKey: String?,
                                                            consistentRead: Bool) async throws
-       -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+       -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) {
         // if this is querying an index
         if let indexName = AttributesType.indexName {
             // fail if it isn't the index we know about
@@ -307,7 +307,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) async throws
-    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+    -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) {
         // if this is executing on index
         if let indexName = AttributesType.indexName {
             // fail if it isn't the index we know about

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
@@ -30,6 +30,12 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
     internal init(keysWrapper: InMemoryDynamoDBCompositePrimaryKeysProjectionStore) {
         self.keysWrapper = keysWrapper
     }
+    
+    public var keys: [Any] {
+        get async {
+            return await self.keysWrapper.keys
+        }
+    }
 
     public func query<AttributesType>(forPartitionKey partitionKey: String,
                                       sortKeyCondition: AttributeCondition?) async throws

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
@@ -47,7 +47,7 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
                                       sortKeyCondition: AttributeCondition?,
                                       limit: Int?,
                                       exclusiveStartKey: String?) async throws
-    -> ([CompositePrimaryKey<AttributesType>], String?) {
+    -> (keys: [CompositePrimaryKey<AttributesType>], lastEvaluatedKey: String?) {
         return try await keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
                                            limit: limit, exclusiveStartKey: exclusiveStartKey)
     }
@@ -57,7 +57,7 @@ public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePr
                                       limit: Int?,
                                       scanIndexForward: Bool,
                                       exclusiveStartKey: String?) async throws
-    -> ([CompositePrimaryKey<AttributesType>], String?) {
+    -> (keys: [CompositePrimaryKey<AttributesType>], lastEvaluatedKey: String?) {
         return try await keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
                                            limit: limit, scanIndexForward: scanIndexForward,
                                            exclusiveStartKey: exclusiveStartKey)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjection.swift
@@ -19,62 +19,41 @@
 import Foundation
 import SmokeHTTPClient
 import DynamoDBModel
-import NIO
 
 public class InMemoryDynamoDBCompositePrimaryKeysProjection: DynamoDBCompositePrimaryKeysProjection {
-    public var eventLoop: EventLoop
-
     internal let keysWrapper: InMemoryDynamoDBCompositePrimaryKeysProjectionStore
-    
-    public var keys: [Any] {
-        do {
-            return try keysWrapper.getKeys(eventLoop: self.eventLoop).wait()
-        } catch {
-            fatalError("Unable to retrieve InMemoryDynamoDBCompositePrimaryKeysProjection keys.")
-        }
-    }
 
-    public init(keys: [Any] = [], eventLoop: EventLoop) {
+    public init(keys: [Any] = []) {
         self.keysWrapper = InMemoryDynamoDBCompositePrimaryKeysProjectionStore(keys: keys)
-        self.eventLoop = eventLoop
     }
     
-    internal init(eventLoop: EventLoop,
-                  keysWrapper: InMemoryDynamoDBCompositePrimaryKeysProjectionStore) {
-        self.eventLoop = eventLoop
+    internal init(keysWrapper: InMemoryDynamoDBCompositePrimaryKeysProjectionStore) {
         self.keysWrapper = keysWrapper
-    }
-    
-    public func on(eventLoop: EventLoop) -> InMemoryDynamoDBCompositePrimaryKeysProjection {
-        return InMemoryDynamoDBCompositePrimaryKeysProjection(eventLoop: eventLoop,
-                                                              keysWrapper: self.keysWrapper)
     }
 
     public func query<AttributesType>(forPartitionKey partitionKey: String,
-                                      sortKeyCondition: AttributeCondition?)
-    -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]> {
-        return keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition, eventLoop: self.eventLoop)
+                                      sortKeyCondition: AttributeCondition?) async throws
+    -> [CompositePrimaryKey<AttributesType>] {
+        return try await keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition)
     }
     
     public func query<AttributesType>(forPartitionKey partitionKey: String,
                                       sortKeyCondition: AttributeCondition?,
                                       limit: Int?,
-                                      exclusiveStartKey: String?)
-    -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
-            where AttributesType: PrimaryKeyAttributes {
-        return keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                 limit: limit, exclusiveStartKey: exclusiveStartKey, eventLoop: self.eventLoop)
+                                      exclusiveStartKey: String?) async throws
+    -> ([CompositePrimaryKey<AttributesType>], String?) {
+        return try await keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
+                                           limit: limit, exclusiveStartKey: exclusiveStartKey)
     }
 
     public func query<AttributesType>(forPartitionKey partitionKey: String,
                                       sortKeyCondition: AttributeCondition?,
                                       limit: Int?,
                                       scanIndexForward: Bool,
-                                      exclusiveStartKey: String?)
-    -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
-    where AttributesType: PrimaryKeyAttributes {
-        return keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
-                                 limit: limit, scanIndexForward: scanIndexForward,
-                                 exclusiveStartKey: exclusiveStartKey, eventLoop: self.eventLoop)
+                                      exclusiveStartKey: String?) async throws
+    -> ([CompositePrimaryKey<AttributesType>], String?) {
+        return try await keysWrapper.query(forPartitionKey: partitionKey, sortKeyCondition: sortKeyCondition,
+                                           limit: limit, scanIndexForward: scanIndexForward,
+                                           exclusiveStartKey: exclusiveStartKey)
     }
 }

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
@@ -94,7 +94,7 @@ internal actor InMemoryDynamoDBCompositePrimaryKeysProjectionStore {
                                       sortKeyCondition: AttributeCondition?,
                                       limit: Int?,
                                       exclusiveStartKey: String?) async throws
-    -> ([CompositePrimaryKey<AttributesType>], String?) {
+    -> (keys: [CompositePrimaryKey<AttributesType>], lastEvaluatedKey: String?) {
         return try await query(forPartitionKey: partitionKey,
                      sortKeyCondition: sortKeyCondition,
                      limit: limit,
@@ -107,7 +107,7 @@ internal actor InMemoryDynamoDBCompositePrimaryKeysProjectionStore {
                                       limit: Int?,
                                       scanIndexForward: Bool,
                                       exclusiveStartKey: String?) async throws
-    -> ([CompositePrimaryKey<AttributesType>], String?) {
+    -> (keys: [CompositePrimaryKey<AttributesType>], lastEvaluatedKey: String?) {
         // get all the results
         let rawItems: [CompositePrimaryKey<AttributesType>] = try await query(forPartitionKey: partitionKey,
                                                                               sortKeyCondition: sortKeyCondition)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeysProjectionStore.swift
@@ -19,156 +19,127 @@
 import Foundation
 import SmokeHTTPClient
 import DynamoDBModel
-import NIO
 
-public class InMemoryDynamoDBCompositePrimaryKeysProjectionStore {
+internal actor InMemoryDynamoDBCompositePrimaryKeysProjectionStore {
     public var keys: [Any] = []
-    private let accessQueue = DispatchQueue(
-        label: "com.amazon.SmokeDynamoDB.InMemoryDynamoDBCompositePrimaryKeysProjection.accessQueue",
-        target: DispatchQueue.global())
 
     public init(keys: [Any] = []) {
         self.keys = keys
     }
-    
-    func getKeys(eventLoop: EventLoop) -> EventLoopFuture<[Any]> {
-        let promise = eventLoop.makePromise(of: [Any].self)
-        
-        accessQueue.async {
-            promise.succeed(self.keys)
-        }
-        
-        return promise.futureResult
-    }
 
     public func query<AttributesType>(forPartitionKey partitionKey: String,
-                                      sortKeyCondition: AttributeCondition?,
-                                      eventLoop: EventLoop)
-            -> EventLoopFuture<[CompositePrimaryKey<AttributesType>]> {
-        let promise = eventLoop.makePromise(of: [CompositePrimaryKey<AttributesType>].self)
-        
-        accessQueue.async {
-            var items: [CompositePrimaryKey<AttributesType>] = []
-                
-            let sortedKeys = self.keys.compactMap { $0 as? CompositePrimaryKey<AttributesType> }.sorted(by: { (left, right) -> Bool in
-                return left.sortKey < right.sortKey
-            })
-                
-            sortKeyIteration: for key in sortedKeys {
-                if key.partitionKey != partitionKey {
-                    // don't include this in the results
-                    continue sortKeyIteration
-                }
-                
-                let sortKey = key.sortKey
+                                      sortKeyCondition: AttributeCondition?) async throws
+    -> [CompositePrimaryKey<AttributesType>] {
+        var items: [CompositePrimaryKey<AttributesType>] = []
+            
+        let sortedKeys = self.keys.compactMap { $0 as? CompositePrimaryKey<AttributesType> }.sorted(by: { (left, right) -> Bool in
+            return left.sortKey < right.sortKey
+        })
+            
+        sortKeyIteration: for key in sortedKeys {
+            if key.partitionKey != partitionKey {
+                // don't include this in the results
+                continue sortKeyIteration
+            }
+            
+            let sortKey = key.sortKey
 
-                if let currentSortKeyCondition = sortKeyCondition {
-                    switch currentSortKeyCondition {
-                    case .equals(let value):
-                        if !(value == sortKey) {
-                            // don't include this in the results
-                            continue sortKeyIteration
-                        }
-                    case .lessThan(let value):
-                        if !(sortKey < value) {
-                            // don't include this in the results
-                            continue sortKeyIteration
-                        }
-                    case .lessThanOrEqual(let value):
-                        if !(sortKey <= value) {
-                            // don't include this in the results
-                            continue sortKeyIteration
-                        }
-                    case .greaterThan(let value):
-                        if !(sortKey > value) {
-                            // don't include this in the results
-                            continue sortKeyIteration
-                        }
-                    case .greaterThanOrEqual(let value):
-                        if !(sortKey >= value) {
-                            // don't include this in the results
-                            continue sortKeyIteration
-                        }
-                    case .between(let value1, let value2):
-                        if !(sortKey > value1 && sortKey < value2) {
-                            // don't include this in the results
-                            continue sortKeyIteration
-                        }
-                    case .beginsWith(let value):
-                        if !(sortKey.hasPrefix(value)) {
-                            // don't include this in the results
-                            continue sortKeyIteration
-                        }
+            if let currentSortKeyCondition = sortKeyCondition {
+                switch currentSortKeyCondition {
+                case .equals(let value):
+                    if !(value == sortKey) {
+                        // don't include this in the results
+                        continue sortKeyIteration
+                    }
+                case .lessThan(let value):
+                    if !(sortKey < value) {
+                        // don't include this in the results
+                        continue sortKeyIteration
+                    }
+                case .lessThanOrEqual(let value):
+                    if !(sortKey <= value) {
+                        // don't include this in the results
+                        continue sortKeyIteration
+                    }
+                case .greaterThan(let value):
+                    if !(sortKey > value) {
+                        // don't include this in the results
+                        continue sortKeyIteration
+                    }
+                case .greaterThanOrEqual(let value):
+                    if !(sortKey >= value) {
+                        // don't include this in the results
+                        continue sortKeyIteration
+                    }
+                case .between(let value1, let value2):
+                    if !(sortKey > value1 && sortKey < value2) {
+                        // don't include this in the results
+                        continue sortKeyIteration
+                    }
+                case .beginsWith(let value):
+                    if !(sortKey.hasPrefix(value)) {
+                        // don't include this in the results
+                        continue sortKeyIteration
                     }
                 }
-
-                items.append(key)
             }
 
-            promise.succeed(items)
+            items.append(key)
         }
-        
-        return promise.futureResult
+
+        return items
     }
     
     public func query<AttributesType>(forPartitionKey partitionKey: String,
                                       sortKeyCondition: AttributeCondition?,
                                       limit: Int?,
-                                      exclusiveStartKey: String?,
-                                      eventLoop: EventLoop)
-            -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
-            where AttributesType: PrimaryKeyAttributes {
-        return query(forPartitionKey: partitionKey,
+                                      exclusiveStartKey: String?) async throws
+    -> ([CompositePrimaryKey<AttributesType>], String?) {
+        return try await query(forPartitionKey: partitionKey,
                      sortKeyCondition: sortKeyCondition,
                      limit: limit,
                      scanIndexForward: true,
-                     exclusiveStartKey: exclusiveStartKey,
-                     eventLoop: eventLoop)
+                     exclusiveStartKey: exclusiveStartKey)
     }
 
     public func query<AttributesType>(forPartitionKey partitionKey: String,
                                       sortKeyCondition: AttributeCondition?,
                                       limit: Int?,
                                       scanIndexForward: Bool,
-                                      exclusiveStartKey: String?,
-                                      eventLoop: EventLoop)
-            -> EventLoopFuture<([CompositePrimaryKey<AttributesType>], String?)>
-            where AttributesType: PrimaryKeyAttributes {
+                                      exclusiveStartKey: String?) async throws
+    -> ([CompositePrimaryKey<AttributesType>], String?) {
         // get all the results
-        return query(forPartitionKey: partitionKey,
-                     sortKeyCondition: sortKeyCondition,
-                     eventLoop: eventLoop)
-            .map { (rawItems: [CompositePrimaryKey<AttributesType>]) in
-                let items: [CompositePrimaryKey<AttributesType>]
-                if !scanIndexForward {
-                    items = rawItems.reversed()
-                } else {
-                    items = rawItems
-                }
+        let rawItems: [CompositePrimaryKey<AttributesType>] = try await query(forPartitionKey: partitionKey,
+                                                                              sortKeyCondition: sortKeyCondition)
+        let items: [CompositePrimaryKey<AttributesType>]
+        if !scanIndexForward {
+            items = rawItems.reversed()
+        } else {
+            items = rawItems
+        }
 
-                let startIndex: Int
-                // if there is an exclusiveStartKey
-                if let exclusiveStartKey = exclusiveStartKey {
-                    guard let storedStartIndex = Int(exclusiveStartKey) else {
-                        fatalError("Unexpectedly encoded exclusiveStartKey '\(exclusiveStartKey)'")
-                    }
-
-                    startIndex = storedStartIndex
-                } else {
-                    startIndex = 0
-                }
-
-                let endIndex: Int
-                let lastEvaluatedKey: String?
-                if let limit = limit, startIndex + limit < items.count {
-                    endIndex = startIndex + limit
-                    lastEvaluatedKey = String(endIndex)
-                } else {
-                    endIndex = items.count
-                    lastEvaluatedKey = nil
-                }
-
-                return (Array(items[startIndex..<endIndex]), lastEvaluatedKey)
+        let startIndex: Int
+        // if there is an exclusiveStartKey
+        if let exclusiveStartKey = exclusiveStartKey {
+            guard let storedStartIndex = Int(exclusiveStartKey) else {
+                fatalError("Unexpectedly encoded exclusiveStartKey '\(exclusiveStartKey)'")
             }
+
+            startIndex = storedStartIndex
+        } else {
+            startIndex = 0
+        }
+
+        let endIndex: Int
+        let lastEvaluatedKey: String?
+        if let limit = limit, startIndex + limit < items.count {
+            endIndex = startIndex + limit
+            lastEvaluatedKey = String(endIndex)
+        } else {
+            endIndex = items.count
+            lastEvaluatedKey = nil
+        }
+
+        return (Array(items[startIndex..<endIndex]), lastEvaluatedKey)
     }
 }

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -149,7 +149,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
                                                                     limit: Int?,
                                                                     exclusiveStartKey: String?,
                                                                     consistentRead: Bool) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         // simply delegate to the wrapped implementation
         return try await wrappedDynamoDBTable.query(forPartitionKey: partitionKey,
                                                     sortKeyCondition: sortKeyCondition,
@@ -164,7 +164,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
                                                                     scanIndexForward: Bool,
                                                                     exclusiveStartKey: String?,
                                                                     consistentRead: Bool) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         // simply delegate to the wrapped implementation
         return try await wrappedDynamoDBTable.query(forPartitionKey: partitionKey,
                                                     sortKeyCondition: sortKeyCondition,
@@ -189,7 +189,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) async throws
-    -> ([ReturnedType], String?) {
+    -> (items: [ReturnedType], lastEvaluatedKey: String?) {
         // simply delegate to the wrapped implementation
         return try await wrappedDynamoDBTable.execute(partitionKeys: partitionKeys,
                                                       attributesFilter: attributesFilter,
@@ -219,7 +219,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) async throws
-    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+    -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) {
         // simply delegate to the wrapped implementation
         return try await wrappedDynamoDBTable.monomorphicExecute(partitionKeys: partitionKeys,
                                                                  attributesFilter: attributesFilter,
@@ -243,7 +243,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
                                                            scanIndexForward: Bool,
                                                            exclusiveStartKey: String?,
                                                            consistentRead: Bool) async throws
-    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+    -> (items: [TypedDatabaseItem<AttributesType, ItemType>], lastEvaluatedKey: String?) {
         // simply delegate to the wrapped implementation
         return try await wrappedDynamoDBTable.monomorphicQuery(forPartitionKey: partitionKey,
                                                                sortKeyCondition: sortKeyCondition,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Move DynamoDBCompositePrimaryKeysProjection and its conforming types to async only.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
