### PR TITLE
add async/await monomorphicBulkWriteWithoutThrowing api

### DIFF
--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -102,7 +102,13 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      * Provides the ability to bulk write database rows
      */
     func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
-
+    
+    /**
+     * Provides the ability to bulk write database rows without throwing
+     */
+    func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
+    -> [Int: BatchStatementError]
+    
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.
      */

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -69,6 +69,11 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimary
         return try await storeWrapper.getItem(forKey: key)
     }
     
+    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
+    -> [Int: BatchStatementError] {
+        return try await storeWrapper.monomorphicBulkWriteWithoutThrowing(entries)
+    }
+
     public func getItems<ReturnedType: PolymorphicOperationReturnType & BatchCapableReturnType>(
         forKeys keys: [CompositePrimaryKey<ReturnedType.AttributesType>]) async throws
     -> [CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType] {

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -72,6 +72,11 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         }
     }
     
+    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
+    -> [Int: BatchStatementError] {
+        return try await self.primaryTable.monomorphicBulkWriteWithoutThrowing(entries)
+    }
+    
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>) async throws
     -> TypedDatabaseItem<AttributesType, ItemType>? {
         return try await self.primaryTable.getItem(forKey: key)

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -103,6 +103,11 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         }
     }
     
+    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
+    -> [Int: BatchStatementError] {
+        return try await wrappedDynamoDBTable.monomorphicBulkWriteWithoutThrowing(entries)
+    }
+    
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>) async throws
     -> TypedDatabaseItem<AttributesType, ItemType>? {
         // simply delegate to the wrapped implementation

--- a/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
@@ -24,8 +24,7 @@ enum TestPolymorphicOperationReturnType: PolymorphicOperationReturnType {
     typealias AttributesType = StandardPrimaryKeyAttributes
     
     static var types: [(Codable.Type, PolymorphicOperationReturnOption<StandardPrimaryKeyAttributes, Self>)] = [
-        (TestTypeA.self, .init( {.testTypeA($0)} )),
-        ]
+        (TestTypeA.self, .init( {.testTypeA($0)} ))]
     
     case testTypeA(StandardTypedDatabaseItem<TestTypeA>)
 }
@@ -387,8 +386,6 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         let payload1 = TestTypeA(firstly: "firstly", secondly: "secondly")
         let payload2 = TestTypeB(thirdly: "thirdly", fourthly: "fourthly")
         
-        
-        
         let databaseItem1 = StandardTypedDatabaseItem.newItem(withKey: key1, andValue: payload1)
         let databaseItem2 = StandardTypedDatabaseItem.newItem(withKey: key2, andValue: payload2)
         
@@ -421,8 +418,6 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         let payload1 = TestTypeA(firstly: "firstly", secondly: "secondly")
         let payload2 = TestTypeA(firstly: "thirdly", secondly: "fourthly")
         
-        
-        
         let databaseItem1 = StandardTypedDatabaseItem.newItem(withKey: key1, andValue: payload1)
         let databaseItem2 = StandardTypedDatabaseItem.newItem(withKey: key2, andValue: payload2)
         
@@ -445,4 +440,64 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         XCTAssertEqual(payload1, retrievedDatabaseItem1.rowValue)
         XCTAssertEqual(payload2, retrievedDatabaseItem2.rowValue)
     }
+    
+    func testMonomorphicBulkWriteWithoutThrowing() async throws {
+        typealias TestObject = TestTypeA
+        typealias TestObjectDatabaseItem = StandardTypedDatabaseItem<TestObject>
+        typealias TestObjectWriteEntry = StandardWriteEntry<TestObject>
+
+        let table = InMemoryDynamoDBCompositePrimaryKeyTable()
+    
+        var entryList: [TestObjectWriteEntry] = []
+        var index = 0
+        while index < 26 {
+            let key = StandardCompositePrimaryKey(partitionKey: "partitionId\(index%25)", sortKey: "sortId\(index%25)")
+            let test = TestObject(firstly: "firstly", secondly: "secondly")
+            let testItem: TestObjectDatabaseItem = TestObjectDatabaseItem.newItem(withKey: key, andValue: test)
+            entryList.append(TestObjectWriteEntry.insert(new: testItem))
+            index += 1
+        }
+        
+        let result1 = try await table.monomorphicBulkWriteWithoutThrowing(entryList)
+        XCTAssertEqual(result1.count, 1)
+        if result1[25] != nil {
+            return
+        } else {
+            XCTFail("should return duplicated index = 25")
+        }
+
+        entryList = []
+        index = 0
+        while index < 30 {
+            let key = StandardCompositePrimaryKey(partitionKey: "partitionId\(index)", sortKey: "sortId\(index)")
+            let test = TestObject(firstly: "firstly", secondly: "secondly")
+            let testItem: TestObjectDatabaseItem = TestObjectDatabaseItem.newItem(withKey: key, andValue: test)
+            entryList.append(TestObjectWriteEntry.insert(new: testItem))
+            index += 1
+        }
+
+        let result25 = try await table.monomorphicBulkWriteWithoutThrowing(entryList)
+        XCTAssertEqual(result25.count, 25)
+
+        let result30 = try await table.monomorphicBulkWriteWithoutThrowing(entryList)
+        XCTAssertEqual(result30.count, 30)
+    }
+  
+    static var allTests = [
+        ("testInsertAndUpdate", testInsertAndUpdate),
+        ("testDoubleInsert", testDoubleInsert),
+        ("testUpdateWithoutInsert", testUpdateWithoutInsert),
+        ("testUpdateWithoutInsert", testUpdateWithoutInsert),
+        ("testPaginatedQuery", testPaginatedQuery),
+        ("testReversedPaginatedQuery", testReversedPaginatedQuery),
+        ("testQuery", testQuery),
+        ("testMonomorphicQuery", testMonomorphicQuery),
+        ("testDeleteForKey", testDeleteForKey),
+        ("testDeleteForExistingItem", testDeleteForExistingItem),
+        ("testDeleteForExistingItemAfterUpdate", testDeleteForExistingItemAfterUpdate),
+        ("testDeleteForExistingItemAfterRecreation", testDeleteForExistingItemAfterRecreation),
+        ("testGetItems", testGetItems),
+        ("testMonomorphicGetItems", testMonomorphicGetItems),
+        ("testMonomorphicBulkWriteWithoutThrowing", testMonomorphicBulkWriteWithoutThrowing)
+    ]
 }


### PR DESCRIPTION

*Description of changes:*

implemented monomorphicBulkWriteWithoutThrowing api. it will track the index and error for each failed statement 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
