### PR TITLE
add InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.monomorphicBulkWriteWithoutThrowing

### DIFF
--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -104,6 +104,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      * Provides the ability to bulk write database rows
      */
     func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<Void>
+    
     func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
     -> [Int: BatchStatementError]
 

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -38,10 +38,6 @@ public typealias ExecuteItemFilterType = (String, String, String, PolymorphicOpe
     -> Bool
 
 public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryKeyTable {
-    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws -> [Int : BatchStatementError] where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
-        return try await storeWrapper.monomorphicBulkWriteWithoutThrowing(entries, eventLoop: eventLoop)
-    }
-    
 
     public let eventLoop: EventLoop
     internal let storeWrapper: InMemoryDynamoDBCompositePrimaryKeyTableStore
@@ -89,6 +85,10 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
         return storeWrapper.monomorphicBulkWrite(entries, eventLoop: self.eventLoop)
     }
 
+    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws -> [Int : BatchStatementError] where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
+        return try await storeWrapper.monomorphicBulkWriteWithoutThrowing(entries, eventLoop: eventLoop)
+    }
+    
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>)
     -> EventLoopFuture<TypedDatabaseItem<AttributesType, ItemType>?> {
         return storeWrapper.getItem(forKey: key, eventLoop: self.eventLoop)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -176,51 +176,42 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
                 switch entry {
                 case .update(new: let new, existing: let existing):
                     return updateItem(newItem: new, existingItem: existing, eventLoop: eventLoop)
-                        .flatMap { _ -> EventLoopFuture<Int?> in
-                            let promise = eventLoop.makePromise(of: Int?.self)
-                            promise.succeed(nil)
-                            return promise.futureResult
+                        .map { _ -> Int? in
+                            return nil
                         }.flatMapError{ error -> EventLoopFuture<Int?> in
                             let promise = eventLoop.makePromise(of: Int?.self)
                             promise.succeed(index)
                             return promise.futureResult
                         }
                 case .insert(new: let new):
-                    return insertItem(new, eventLoop: eventLoop).flatMap { _ -> EventLoopFuture<Int?> in
-                        let promise = eventLoop.makePromise(of: Int?.self)
-                        promise.succeed(nil)
-                        return promise.futureResult
+                    return insertItem(new, eventLoop: eventLoop).map { _ -> Int? in
+                        return nil
                     }.flatMapError{ error -> EventLoopFuture<Int?> in
                         let promise = eventLoop.makePromise(of: Int?.self)
                         promise.succeed(index)
                         return promise.futureResult
                     }
                 case .deleteAtKey(key: let key):
-                    return deleteItem(forKey: key, eventLoop: eventLoop).flatMap { _ -> EventLoopFuture<Int?> in
-                        let promise = eventLoop.makePromise(of: Int?.self)
-                        promise.succeed(nil)
-                        return promise.futureResult
+                    return deleteItem(forKey: key, eventLoop: eventLoop).map { _ -> Int? in
+                        return nil
                     }.flatMapError{ error -> EventLoopFuture<Int?> in
                         let promise = eventLoop.makePromise(of: Int?.self)
                         promise.succeed(index)
                         return promise.futureResult
                     }
                 case .deleteItem(existing: let existing):
-                    return deleteItem(existingItem: existing, eventLoop: eventLoop).flatMap { _ -> EventLoopFuture<Int?> in
-                        let promise = eventLoop.makePromise(of: Int?.self)
-                        promise.succeed(nil)
-                        return promise.futureResult
+                    return deleteItem(existingItem: existing, eventLoop: eventLoop).map { _ -> Int? in
+                        return nil
                     }.flatMapError{ error -> EventLoopFuture<Int?> in
                         let promise = eventLoop.makePromise(of: Int?.self)
                         promise.succeed(index)
                         return promise.futureResult
                     }
-                
                 }
             }
-        
-            let results = try await EventLoopFuture.whenAllComplete(futures, on: eventLoop).get()
             
+            let results = try await EventLoopFuture.whenAllComplete(futures, on: eventLoop).get()
+
             for result in results {
                 if let index = try result.get() {
                     errors[index] = BatchStatementError(code: .duplicateitem, message: "")

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -173,43 +173,62 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         eventLoop: EventLoop) async throws -> [Int: BatchStatementError] {
             var errors: [Int: BatchStatementError] = [:]
             
-            let futures = entries.enumerated().map { (index, entry) -> EventLoopFuture<Void> in
+            let futures = entries.enumerated().map { (index, entry) -> EventLoopFuture<Int> in
                 switch entry {
                 case .update(new: let new, existing: let existing):
                     return updateItem(newItem: new, existingItem: existing, eventLoop: eventLoop)
-                        .flatMapError { err in
-                            errors[index] = BatchStatementError(code: .duplicateitem, message: nil)
-                            let promise = eventLoop.makePromise(of: Void.self)
-                            promise.succeed(())
+                        .flatMap { _ -> EventLoopFuture<Int> in
+                            let promise = eventLoop.makePromise(of: Int.self)
+                            promise.succeed(-1)
+                            return promise.futureResult
+                        }.flatMapError{ error -> EventLoopFuture<Int> in
+                            let promise = eventLoop.makePromise(of: Int.self)
+                            promise.succeed(index)
                             return promise.futureResult
                         }
                 case .insert(new: let new):
-                    return insertItem(new, eventLoop: eventLoop).flatMapError { err in
-                        errors[index] = BatchStatementError(code: .duplicateitem, message: nil)
-                        let promise = eventLoop.makePromise(of: Void.self)
-                        promise.succeed(())
+                    return insertItem(new, eventLoop: eventLoop).flatMap { _ -> EventLoopFuture<Int> in
+                        let promise = eventLoop.makePromise(of: Int.self)
+                        promise.succeed(-1)
+                        return promise.futureResult
+                    }.flatMapError{ error -> EventLoopFuture<Int> in
+                        let promise = eventLoop.makePromise(of: Int.self)
+                        promise.succeed(index)
                         return promise.futureResult
                     }
                 case .deleteAtKey(key: let key):
-                    return deleteItem(forKey: key, eventLoop: eventLoop).flatMapError { err in
-                        errors[index] = BatchStatementError(code: .duplicateitem, message: nil)
-                        let promise = eventLoop.makePromise(of: Void.self)
-                        promise.succeed(())
+                    return deleteItem(forKey: key, eventLoop: eventLoop).flatMap { _ -> EventLoopFuture<Int> in
+                        let promise = eventLoop.makePromise(of: Int.self)
+                        promise.succeed(-1)
                         return promise.futureResult
-                        
+                    }.flatMapError{ error -> EventLoopFuture<Int> in
+                        let promise = eventLoop.makePromise(of: Int.self)
+                        promise.succeed(index)
+                        return promise.futureResult
                     }
                 case .deleteItem(existing: let existing):
-                    return deleteItem(existingItem: existing, eventLoop: eventLoop)
-                        .flatMapError { err in
-                            errors[index] = BatchStatementError(code: .duplicateitem, message: nil)
-                            let promise = eventLoop.makePromise(of: Void.self)
-                            promise.succeed(())
-                            return promise.futureResult
-                        }
+                    return deleteItem(existingItem: existing, eventLoop: eventLoop).flatMap { _ -> EventLoopFuture<Int> in
+                        let promise = eventLoop.makePromise(of: Int.self)
+                        promise.succeed(-1)
+                        return promise.futureResult
+                    }.flatMapError{ error -> EventLoopFuture<Int> in
+                        let promise = eventLoop.makePromise(of: Int.self)
+                        promise.succeed(index)
+                        return promise.futureResult
+                    }
+                
                 }
             }
         
-            try await EventLoopFuture.andAllComplete(futures, on: eventLoop).get()
+            let results = try await EventLoopFuture.whenAllComplete(futures, on: eventLoop).get()
+            
+            for result in results {
+                let i = try result.get()
+                if i  >= 0 {
+                    errors[i] = BatchStatementError(code: .duplicateitem, message: "")
+                }
+            }
+
             return errors
         }
 

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -167,7 +167,6 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
         return EventLoopFuture.andAllSucceed(futures, on: eventLoop)
     }
     
-    
     public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(
         _ entries: [WriteEntry<AttributesType, ItemType>],
         eventLoop: EventLoop) async throws -> [Int: BatchStatementError] {

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -85,7 +85,6 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         return errors
     }
     
-    
     public var eventLoop: EventLoop
     
     public let primaryTable: InMemoryDynamoDBCompositePrimaryKeyTable

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -26,10 +26,6 @@ import NIO
  a specified number of requests.
  */
 public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryKeyTable {
-    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws -> [Int : BatchStatementError] where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
-        return try await self.wrappedDynamoDBTable.monomorphicBulkWriteWithoutThrowing(entries)
-    }
-    
     public var eventLoop: EventLoop
     
     let wrappedDynamoDBTable: DynamoDBCompositePrimaryKeyTable
@@ -111,6 +107,10 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         }
         
         return EventLoopFuture.andAllSucceed(futures, on: self.eventLoop)
+    }
+    
+    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws -> [Int : BatchStatementError] where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
+        return try await self.wrappedDynamoDBTable.monomorphicBulkWriteWithoutThrowing(entries)
     }
     
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>)


### PR DESCRIPTION

*Description of changes:*

implement InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.monomorphicBulkWriteWithoutThrowing for testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
