### PR TITLE
Add option to escape single quotes in monomophicBulkWrite and deleteItems

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+deleteItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+deleteItems.swift
@@ -34,7 +34,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         
         let statements: [BatchStatementRequest] = try keys.map { existingKey -> BatchStatementRequest in
             let statement = try getDeleteExpression(tableName: self.targetTableName,
-                                                    existingKey: existingKey)
+                                                    existingKey: existingKey,
+                                                    escapeSingleQuote: escapeSingleQuoteInPartiQL)
                 
             return BatchStatementRequest(consistentRead: true, statement: statement)
         }
@@ -53,7 +54,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         
         let statements: [BatchStatementRequest] = try existingItems.map { existingItem -> BatchStatementRequest in
             let statement = try getDeleteExpression(tableName: self.targetTableName,
-                                                    existingItem: existingItem)
+                                                    existingItem: existingItem,
+                                                    escapeSingleQuote: self.escapeSingleQuoteInPartiQL)
                 
             return BatchStatementRequest(consistentRead: true, statement: statement)
         }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -26,6 +26,7 @@ import AsyncHTTPClient
 public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPClientCoreInvocationReporting>: DynamoDBCompositePrimaryKeyTable {
     internal let dynamodb: _AWSDynamoDBClient<InvocationReportingType>
     internal let targetTableName: String
+    internal let escapeSingleQuoteInPartiQL: Bool
     internal let logger: Logger
 
     public init(accessKeyId: String, secretAccessKey: String,
@@ -36,7 +37,8 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSCore.SmokeAWSClientReportingConfiguration<DynamoDBModel.DynamoDBModelOperations>
-                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>()) {
+                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
+                escapeSingleQuoteInPartiQL: Bool = false) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -51,6 +53,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                            eventLoopProvider: eventLoopProvider,
                                            reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
 
         self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
@@ -63,7 +66,8 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSCore.SmokeAWSClientReportingConfiguration<DynamoDBModel.DynamoDBModelOperations>
-                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>()) {
+                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
+                escapeSingleQuoteInPartiQL: Bool = false) {
         self.logger = reporting.logger
         self.dynamodb = _AWSDynamoDBClient(credentialsProvider: credentialsProvider,
                                            awsRegion: region, reporting: reporting,
@@ -74,15 +78,18 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                            eventLoopProvider: eventLoopProvider,
                                            reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
 
         self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
     
     internal init(dynamodb: _AWSDynamoDBClient<InvocationReportingType>,
                   targetTableName: String,
+                  escapeSingleQuoteInPartiQL: Bool,
                   logger: Logger) {
         self.dynamodb = dynamodb
         self.targetTableName = targetTableName
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
         self.logger = logger
     }
 

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
@@ -27,6 +27,7 @@ import AsyncHTTPClient
 public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
     internal let dynamodbGenerator: _AWSDynamoDBClientGenerator
     internal let targetTableName: String
+    internal let escapeSingleQuoteInPartiQL: Bool
 
     public init(accessKeyId: String, secretAccessKey: String,
                 region: AWSRegion,
@@ -36,7 +37,8 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSCore.SmokeAWSClientReportingConfiguration<DynamoDBModel.DynamoDBModelOperations>
-                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>()) {
+                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
+                escapeSingleQuoteInPartiQL: Bool = false) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -50,6 +52,7 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
                                                              eventLoopProvider: eventLoopProvider,
                                                              reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
     }
 
     public init(credentialsProvider: CredentialsProvider,
@@ -60,7 +63,8 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSCore.SmokeAWSClientReportingConfiguration<DynamoDBModel.DynamoDBModelOperations>
-                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>()) {
+                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
+                escapeSingleQuoteInPartiQL: Bool = false) {
         self.dynamodbGenerator = _AWSDynamoDBClientGenerator(credentialsProvider: credentialsProvider,
                                                              awsRegion: region,
                                                              endpointHostName: endpointHostName,
@@ -70,6 +74,7 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
                                                              eventLoopProvider: eventLoopProvider,
                                                              reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
     }
 
     /**
@@ -101,6 +106,7 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
         return AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType>(
             dynamodb: self.dynamodbGenerator.with(reporting: reporting),
             targetTableName: self.targetTableName,
+            escapeSingleQuoteInPartiQL: self.escapeSingleQuoteInPartiQL,
             logger: reporting.logger)
     }
     

--- a/Tests/SmokeDynamoDBTests/TypedDatabaseItem+RowWithItemVersionProtocolTests.swift
+++ b/Tests/SmokeDynamoDBTests/TypedDatabaseItem+RowWithItemVersionProtocolTests.swift
@@ -104,29 +104,36 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
     }
     
     func testStringFieldDifference() throws {
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "eigthly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "eigthly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        XCTAssertEqual(pathMap["theString"], .update(path: "theString", value: "'eigthly'"))
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            if escapeSingleQuote {
+                XCTAssertEqual(pathMap["theString"], .update(path: "theString", value: "'eigthly''s'"))
+            } else {
+                XCTAssertEqual(pathMap["theString"], .update(path: "theString", value: "'eigthly's'"))
+            }
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+        }
     }
     
     func testNumberFieldDifference() throws {
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "firstly", theNumber: 12, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: 12, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
         
         let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
                                                                  sortKey: "sortKey")
@@ -134,81 +141,106 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        XCTAssertEqual(pathMap["theNumber"], .update(path: "theNumber", value: "12"))
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            XCTAssertEqual(pathMap["theNumber"], .update(path: "theNumber", value: "12"))
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+        }
     }
     
     func testStructFieldDifference() throws {
-        let theStructA = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let theStructB = TestTypeA(firstly: "eigthly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStructA, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStructB, theList: ["thirdly", "fourthly"])
+        let theStructA = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let theStructB = TestTypeA(firstly: "eigthly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStructA, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStructB, theList: ["thirdly's", "fourthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        XCTAssertEqual(pathMap["theStruct.firstly"], .update(path: "theStruct.firstly", value: "'eigthly'"))
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            if escapeSingleQuote {
+                XCTAssertEqual(pathMap["theStruct.firstly"], .update(path: "theStruct.firstly", value: "'eigthly''s'"))
+            } else {
+                XCTAssertEqual(pathMap["theStruct.firstly"], .update(path: "theStruct.firstly", value: "'eigthly's'"))
+            }
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+        }
     }
     
     func testListFieldDifference() throws {
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "eigthly", "ninthly", "tenthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "eigthly's", "ninthly's", "tenthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        XCTAssertEqual(pathMap["theList[1]"], .update(path: "theList[1]", value: "'eigthly'"))
-        XCTAssertEqual(pathMap["theList"], .listAppend(path: "theList", value: "['ninthly', 'tenthly']"))
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            if escapeSingleQuote {
+                XCTAssertEqual(pathMap["theList[1]"], .update(path: "theList[1]", value: "'eigthly''s'"))
+                XCTAssertEqual(pathMap["theList"], .listAppend(path: "theList", value: "['ninthly''s', 'tenthly''s']"))
+            } else {
+                XCTAssertEqual(pathMap["theList[1]"], .update(path: "theList[1]", value: "'eigthly's'"))
+                XCTAssertEqual(pathMap["theList"], .listAppend(path: "theList", value: "['ninthly's', 'tenthly's']"))
+            }
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+        }
     }
     
     func testStringFieldAddition() throws {
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: nil, theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "eigthly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: nil, theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "eigthly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        XCTAssertEqual(pathMap["theString"], .update(path: "theString", value: "'eigthly'"))
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            if escapeSingleQuote {
+                XCTAssertEqual(pathMap["theString"], .update(path: "theString", value: "'eigthly''s'"))
+            } else {
+                XCTAssertEqual(pathMap["theString"], .update(path: "theString", value: "'eigthly's'"))
+            }
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+        }
     }
     
     func testNumberFieldAddition() throws {
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: nil, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "firstly", theNumber: 12, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: nil, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: 12, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
         
         let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
                                                                  sortKey: "sortKey")
@@ -216,151 +248,180 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        XCTAssertEqual(pathMap["theNumber"], .update(path: "theNumber", value: "12"))
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            XCTAssertEqual(pathMap["theNumber"], .update(path: "theNumber", value: "12"))
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+        }
     }
     
     func testStructFieldAddition() throws {
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: nil, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: nil, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        guard case .update(_, let value) = pathMap["theStruct"] else {
-            XCTFail()
-            return
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            guard case .update(_, let value) = pathMap["theStruct"] else {
+                XCTFail()
+                return
+            }
+
+            if escapeSingleQuote {
+                XCTAssertTrue((value == "{'firstly': 'firstly''s', 'secondly': 'secondly''s'}") ||
+                              (value == "{'secondly': 'secondly''s', 'firstly': 'firstly''s'}"))
+            } else {
+                XCTAssertTrue((value == "{'firstly': 'firstly's', 'secondly': 'secondly's'}") ||
+                              (value == "{'secondly': 'secondly's', 'firstly': 'firstly's'}"))
+            }
+
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
         }
-        
-        let valueMatches = (value == "{'firstly': 'firstly', 'secondly': 'secondly'}") ||
-            (value == "{'secondly': 'secondly', 'firstly': 'firstly'}")
-        
-        XCTAssertTrue(valueMatches)
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
     }
     
     func testListFieldAddition() throws {
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: nil)
-        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "eigthly", "ninthly", "tenthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: nil)
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "eigthly's", "ninthly's", "tenthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        XCTAssertEqual(pathMap["theList"], .update(path: "theList", value: "['thirdly', 'eigthly', 'ninthly', 'tenthly']"))
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+            if escapeSingleQuote {
+                XCTAssertEqual(pathMap["theList"], .update(path: "theList", value: "['thirdly''s', 'eigthly''s', 'ninthly''s', 'tenthly''s']"))
+            } else {
+                XCTAssertEqual(pathMap["theList"], .update(path: "theList", value: "['thirdly's', 'eigthly's', 'ninthly's', 'tenthly's']"))
+            }
+        }
     }
     
     func testStringFieldRemoval() throws {
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: nil, theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: nil, theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        XCTAssertEqual(pathMap["theString"], .remove(path: "theString"))
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            XCTAssertEqual(pathMap["theString"], .remove(path: "theString"))
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+        }
     }
     
     func testNumberFieldRemoval() throws {
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "firstly", theNumber: nil, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: nil, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        XCTAssertEqual(pathMap["theNumber"], .remove(path: "theNumber"))
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            XCTAssertEqual(pathMap["theNumber"], .remove(path: "theNumber"))
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+        }
     }
     
     func testStructFieldRemoval() throws {
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: nil, theList: ["thirdly", "fourthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: nil, theList: ["thirdly's", "fourthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        XCTAssertEqual(pathMap["theStruct"], .remove(path: "theStruct"))
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            XCTAssertEqual(pathMap["theStruct"], .remove(path: "theStruct"))
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+        }
     }
     
     func testListFieldRemoval() throws {
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: nil)
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: nil)
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = databaseItemA.createUpdatedItem(withValue: payloadB)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
-        
-        let differences = try table.diffItems(newItem: databaseItemB,
-                                              existingItem: databaseItemA)
-        let pathMap = differences.pathMap
-        
-        XCTAssertEqual(pathMap["theList"], .remove(path: "theList"))
-        XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+
+        for escapeSingleQuote in [true, false] {
+            let differences = try table.diffItems(newItem: databaseItemB,
+                                                  existingItem: databaseItemA,
+                                                  escapeSingleQuote: escapeSingleQuote)
+            let pathMap = differences.pathMap
+
+            XCTAssertEqual(pathMap["theList"], .remove(path: "theList"))
+            XCTAssertEqual(pathMap["RowVersion"], .update(path: "RowVersion", value: "2"))
+        }
     }
     
     func testListFieldDifferenceExpression() throws {
         let tableName = "TableName"
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "eigthly", "ninthly", "tenthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "eigthly's", "ninthly's", "tenthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadB)
         
@@ -368,22 +429,33 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
         
         let expression = try table.getUpdateExpression(tableName: tableName,
                                                        newItem: databaseItemB,
-                                                       existingItem: databaseItemA)
+                                                       existingItem: databaseItemA,
+                                                       escapeSingleQuote: false)
         XCTAssertEqual(expression, "UPDATE \"TableName\" "
-                                 + "SET \"theList[1]\"='eigthly' "
-                                 + "SET \"theList\"=list_append(theList,['ninthly', 'tenthly']) "
-                                 + "WHERE PK='partitionKey' AND SK='sortKey' "
+                                 + "SET \"theList[1]\"='eigthly's' "
+                                 + "SET \"theList\"=list_append(theList,['ninthly's', 'tenthly's']) "
+                                 + "WHERE PK='partitionKey's' AND SK='sortKey's' "
                                  + "AND RowVersion=1")
+
+        let escapedExpression = try table.getUpdateExpression(tableName: tableName,
+                                                              newItem: databaseItemB,
+                                                              existingItem: databaseItemA,
+                                                              escapeSingleQuote: true)
+        XCTAssertEqual(escapedExpression, "UPDATE \"TableName\" "
+                                        + "SET \"theList[1]\"='eigthly''s' "
+                                        + "SET \"theList\"=list_append(theList,['ninthly''s', 'tenthly''s']) "
+                                        + "WHERE PK='partitionKey''s' AND SK='sortKey''s' "
+                                        + "AND RowVersion=1")
     }
     
     func testListFieldAdditionExpression() throws {
         let tableName = "TableName"
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: nil)
-        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "eigthly", "ninthly", "tenthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: nil)
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "eigthly's", "ninthly's", "tenthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadB)
         
@@ -391,21 +463,31 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
         
         let expression = try table.getUpdateExpression(tableName: tableName,
                                                        newItem: databaseItemB,
-                                                       existingItem: databaseItemA)
+                                                       existingItem: databaseItemA,
+                                                       escapeSingleQuote: false)
         XCTAssertEqual(expression, "UPDATE \"TableName\" "
-                                 + "SET \"theList\"=['thirdly', 'eigthly', 'ninthly', 'tenthly'] "
-                                 + "WHERE PK='partitionKey' AND SK='sortKey' "
+                                 + "SET \"theList\"=['thirdly's', 'eigthly's', 'ninthly's', 'tenthly's'] "
+                                 + "WHERE PK='partitionKey's' AND SK='sortKey's' "
                                  + "AND RowVersion=1")
+
+        let escapedExpression = try table.getUpdateExpression(tableName: tableName,
+                                                              newItem: databaseItemB,
+                                                              existingItem: databaseItemA,
+                                                              escapeSingleQuote: true)
+        XCTAssertEqual(escapedExpression, "UPDATE \"TableName\" "
+                                        + "SET \"theList\"=['thirdly''s', 'eigthly''s', 'ninthly''s', 'tenthly''s'] "
+                                        + "WHERE PK='partitionKey''s' AND SK='sortKey''s' "
+                                        + "AND RowVersion=1")
     }
     
     func testListFieldRemovalExpression() throws {
         let tableName = "TableName"
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        let payloadB = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: nil)
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
+        let payloadB = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: nil)
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         let databaseItemB = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadB)
         
@@ -413,47 +495,68 @@ class TypedDatabaseItemRowWithItemVersionProtocolTests: XCTestCase {
         
         let expression = try table.getUpdateExpression(tableName: tableName,
                                                        newItem: databaseItemB,
-                                                       existingItem: databaseItemA)
+                                                       existingItem: databaseItemA,
+                                                       escapeSingleQuote: false)
         XCTAssertEqual(expression, "UPDATE \"TableName\" "
                                  + "REMOVE \"theList\" "
-                                 + "WHERE PK='partitionKey' AND SK='sortKey' "
+                                 + "WHERE PK='partitionKey's' AND SK='sortKey's' "
                                  + "AND RowVersion=1")
+
+        let escapedExpression = try table.getUpdateExpression(tableName: tableName,
+                                                              newItem: databaseItemB,
+                                                              existingItem: databaseItemA,
+                                                              escapeSingleQuote: true)
+        XCTAssertEqual(escapedExpression, "UPDATE \"TableName\" "
+                                        + "REMOVE \"theList\" "
+                                        + "WHERE PK='partitionKey''s' AND SK='sortKey''s' "
+                                        + "AND RowVersion=1")
     }
     
     func testDeleteItemExpression() throws {
         let tableName = "TableName"
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
+        let theStruct = TestTypeA(firstly: "firstly's", secondly: "secondly's")
+        let payloadA = TestTypeC(theString: "firstly's", theNumber: 4, theStruct: theStruct, theList: ["thirdly's", "fourthly's"])
         
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
         let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
         
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
         
         let expression = try table.getDeleteExpression(tableName: tableName,
-                                                       existingItem: databaseItemA)
+                                                       existingItem: databaseItemA,
+                                                       escapeSingleQuote: false)
         XCTAssertEqual(expression, "DELETE FROM \"TableName\" "
-                                 + "WHERE PK='partitionKey' AND SK='sortKey' "
+                                 + "WHERE PK='partitionKey's' AND SK='sortKey's' "
                                  + "AND RowVersion=1")
+
+        let escapedExpression = try table.getDeleteExpression(tableName: tableName,
+                                                              existingItem: databaseItemA,
+                                                              escapeSingleQuote: true)
+        XCTAssertEqual(escapedExpression, "DELETE FROM \"TableName\" "
+                                        + "WHERE PK='partitionKey''s' AND SK='sortKey''s' "
+                                        + "AND RowVersion=1")
     }
     
     func testDeleteKeyExpression() throws {
         let tableName = "TableName"
-        let theStruct = TestTypeA(firstly: "firstly", secondly: "secondly")
-        let payloadA = TestTypeC(theString: "firstly", theNumber: 4, theStruct: theStruct, theList: ["thirdly", "fourthly"])
-        
-        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey",
-                                                                 sortKey: "sortKey")
-        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
-        
+
+        let compositeKey = StandardCompositePrimaryKey(partitionKey: "partitionKey's",
+                                                       sortKey: "sortKey's")
+
         let table = InMemoryDynamoDBCompositePrimaryKeyTable()
         
         let expression = try table.getDeleteExpression(tableName: tableName,
-                                                       existingItem: databaseItemA)
+                                                       existingKey: compositeKey,
+                                                       escapeSingleQuote: false)
         XCTAssertEqual(expression, "DELETE FROM \"TableName\" "
-                                 + "WHERE PK='partitionKey' AND SK='sortKey' "
-                                 + "AND RowVersion=1")
+                                 + "WHERE PK='partitionKey's' AND SK='sortKey's'")
+
+        let expressionEscaped = try table.getDeleteExpression(tableName: tableName,
+                                                              existingKey: compositeKey,
+                                                              escapeSingleQuote: true)
+        XCTAssertEqual(expressionEscaped, "DELETE FROM \"TableName\" "
+                                        + "WHERE PK='partitionKey''s' AND SK='sortKey''s'")
     }
 }
 


### PR DESCRIPTION
Issue #68 

Added an option `escapeSingleQuoteInPartiQL` in `AWSDynamoDBCompositePrimaryKeyTableGenerator` and `AWSDynamoDBCompositePrimaryKeyTable` to escape single quotes in generated PartiQL statements.

The single quotes will optionally be replaced in `monomophicBulkWrite` and `deleteItems` for
* Partition keys
* Sort keys
* New and updated "S" items.

I updated existing test to cover both conditions where escaping single quotes is enabled and disabled.

I tested `monomophicBulkWrite` `insert` and `deleteAtKey` cases with DynamoDB service.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
