### PR TITLE
use EventLoop for MonomorphicBulkWriteWithoutThrowing api

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
@@ -157,10 +157,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             return dynamodb.batchExecuteStatement(input: executeInput).map { result -> Set<BatchStatementErrorCodeEnum> in
                 var errorSet: Set<BatchStatementErrorCodeEnum> = Set()
                 result.responses?.forEach { response in
-                    if let error = response.error {
-                        if let code = error.code {
-                            errorSet.insert(code)
-                        }
+                    if let error = response.error, let code = error.code {
+                        errorSet.insert(code)
                     }
                 }
                 return errorSet

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -106,7 +106,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
     func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<Void>
     
     func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
-    -> EventLoopFuture<[Int: BatchStatementError]>
+    -> EventLoopFuture<Set<BatchStatementErrorCodeEnum>>
 
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.
@@ -290,7 +290,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
     func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
 
     func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
-    -> [Int: BatchStatementError]
+    -> Set<BatchStatementErrorCodeEnum>
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.
      */
@@ -470,7 +470,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
         return try await monomorphicBulkWrite(entries).get()
     }
     func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
-    -> [Int: BatchStatementError]{
+    -> Set<BatchStatementErrorCodeEnum>{
         return try await monomorphicBulkWriteWithoutThrowing(entries).get()
     }
 

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -105,8 +105,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      */
     func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<Void>
     
-    func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
-    -> [Int: BatchStatementError]
+    func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
+    -> EventLoopFuture<[Int: BatchStatementError]>
 
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.
@@ -289,6 +289,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      */
     func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
 
+    func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
+    -> [Int: BatchStatementError]
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.
      */
@@ -466,6 +468,10 @@ public extension DynamoDBCompositePrimaryKeyTable {
     
     func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws {
         return try await monomorphicBulkWrite(entries).get()
+    }
+    func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
+    -> [Int: BatchStatementError]{
+        return try await monomorphicBulkWriteWithoutThrowing(entries).get()
     }
 
     func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>) async throws

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -85,7 +85,7 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
         return storeWrapper.monomorphicBulkWrite(entries, eventLoop: self.eventLoop)
     }
 
-    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<[Int : BatchStatementError]> {
+    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<Set<BatchStatementErrorCodeEnum>> {
         return storeWrapper.monomorphicBulkWriteWithoutThrowing(entries, eventLoop: eventLoop)
     }
     

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -85,8 +85,8 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
         return storeWrapper.monomorphicBulkWrite(entries, eventLoop: self.eventLoop)
     }
 
-    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws -> [Int : BatchStatementError] where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
-        return try await storeWrapper.monomorphicBulkWriteWithoutThrowing(entries, eventLoop: eventLoop)
+    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<[Int : BatchStatementError]> {
+        return storeWrapper.monomorphicBulkWriteWithoutThrowing(entries, eventLoop: eventLoop)
     }
     
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>)

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -169,56 +169,59 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
     
     public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(
         _ entries: [WriteEntry<AttributesType, ItemType>],
-        eventLoop: EventLoop) -> EventLoopFuture<[Int: BatchStatementError]> {
+        eventLoop: EventLoop) -> EventLoopFuture<Set<BatchStatementErrorCodeEnum>> {
             
-            let futures = entries.enumerated().map { (index, entry) -> EventLoopFuture<Int?> in
+            let futures = entries.map { entry -> EventLoopFuture<BatchStatementErrorCodeEnum?> in
                 switch entry {
                 case .update(new: let new, existing: let existing):
                     return updateItem(newItem: new, existingItem: existing, eventLoop: eventLoop)
-                        .map { _ -> Int? in
+                        .map { () -> BatchStatementErrorCodeEnum? in
                             return nil
-                        }.flatMapError{ error -> EventLoopFuture<Int?> in
-                            let promise = eventLoop.makePromise(of: Int?.self)
-                            promise.succeed(index)
+                        }.flatMapError { error -> EventLoopFuture<BatchStatementErrorCodeEnum?> in
+                            let promise = eventLoop.makePromise(of: BatchStatementErrorCodeEnum?.self)
+                            promise.succeed(BatchStatementErrorCodeEnum.duplicateitem)
                             return promise.futureResult
                         }
                 case .insert(new: let new):
-                    return insertItem(new, eventLoop: eventLoop).map { _ -> Int? in
-                        return nil
-                    }.flatMapError{ error -> EventLoopFuture<Int?> in
-                        let promise = eventLoop.makePromise(of: Int?.self)
-                        promise.succeed(index)
-                        return promise.futureResult
-                    }
+                    return insertItem(new, eventLoop: eventLoop)
+                        .map { () -> BatchStatementErrorCodeEnum? in
+                            return nil
+                        }.flatMapError { error -> EventLoopFuture<BatchStatementErrorCodeEnum?> in
+                            let promise = eventLoop.makePromise(of: BatchStatementErrorCodeEnum?.self)
+                            promise.succeed(BatchStatementErrorCodeEnum.duplicateitem)
+                            return promise.futureResult
+                        }
                 case .deleteAtKey(key: let key):
-                    return deleteItem(forKey: key, eventLoop: eventLoop).map { _ -> Int? in
-                        return nil
-                    }.flatMapError{ error -> EventLoopFuture<Int?> in
-                        let promise = eventLoop.makePromise(of: Int?.self)
-                        promise.succeed(index)
-                        return promise.futureResult
-                    }
+                    return deleteItem(forKey: key, eventLoop: eventLoop)
+                        .map { () -> BatchStatementErrorCodeEnum? in
+                            return nil
+                        }.flatMapError { error -> EventLoopFuture<BatchStatementErrorCodeEnum?> in
+                            let promise = eventLoop.makePromise(of: BatchStatementErrorCodeEnum?.self)
+                            promise.succeed(BatchStatementErrorCodeEnum.duplicateitem)
+                            return promise.futureResult
+                        }
                 case .deleteItem(existing: let existing):
-                    return deleteItem(existingItem: existing, eventLoop: eventLoop).map { _ -> Int? in
-                        return nil
-                    }.flatMapError{ error -> EventLoopFuture<Int?> in
-                        let promise = eventLoop.makePromise(of: Int?.self)
-                        promise.succeed(index)
-                        return promise.futureResult
-                    }
+                    return deleteItem(existingItem: existing, eventLoop: eventLoop)
+                        .map { () -> BatchStatementErrorCodeEnum? in
+                            return nil
+                        }.flatMapError { error -> EventLoopFuture<BatchStatementErrorCodeEnum?> in
+                            let promise = eventLoop.makePromise(of: BatchStatementErrorCodeEnum?.self)
+                            promise.succeed(BatchStatementErrorCodeEnum.duplicateitem)
+                            return promise.futureResult
+                        }
                 }
             }
             
             return EventLoopFuture.whenAllComplete(futures, on: eventLoop)
-                .flatMapThrowing { results -> [Int: BatchStatementError] in
-                    var errors: [Int: BatchStatementError] = [:]
-                    for result in results {
-                        if let index = try result.get() {
-                            errors[index] = BatchStatementError(code: .duplicateitem, message: "")
+                    .flatMapThrowing { results in
+                        var errors: Set<BatchStatementErrorCodeEnum> = Set()
+                        try results.forEach { result in
+                            if let error = try result.get() {
+                                errors.insert(error)
+                            }
                         }
+                        return errors
                     }
-                    return errors
-                }
         }
 
     func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>,

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -109,8 +109,8 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         return EventLoopFuture.andAllSucceed(futures, on: self.eventLoop)
     }
     
-    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws -> [Int : BatchStatementError] where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
-        return try await self.wrappedDynamoDBTable.monomorphicBulkWriteWithoutThrowing(entries)
+    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<[Int : BatchStatementError]> where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
+        return self.wrappedDynamoDBTable.monomorphicBulkWriteWithoutThrowing(entries)
     }
     
     public func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>)

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -109,7 +109,9 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         return EventLoopFuture.andAllSucceed(futures, on: self.eventLoop)
     }
     
-    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<[Int : BatchStatementError]> where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
+    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
+    -> EventLoopFuture<Set<BatchStatementErrorCodeEnum>>
+    where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         return self.wrappedDynamoDBTable.monomorphicBulkWriteWithoutThrowing(entries)
     }
     

--- a/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
@@ -481,7 +481,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
             index += 1
         }
 
-        let result1 = try await table.monomorphicBulkWriteWithoutThrowing(entryList)
+        let result1 = try table.monomorphicBulkWriteWithoutThrowing(entryList).wait()
         XCTAssertEqual(result1.count, 1)
         if result1[25] != nil {
             return
@@ -499,10 +499,10 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
             index += 1
         }
 
-        let result25 = try await table.monomorphicBulkWriteWithoutThrowing(entryList)
+        let result25 = try table.monomorphicBulkWriteWithoutThrowing(entryList).wait()
         XCTAssertEqual(result25.count, 25)
 
-        let result30 = try await table.monomorphicBulkWriteWithoutThrowing(entryList)
+        let result30 = try table.monomorphicBulkWriteWithoutThrowing(entryList).wait()
         XCTAssertEqual(result30.count, 30)
     }
 

--- a/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
@@ -483,27 +483,11 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
 
         let result1 = try table.monomorphicBulkWriteWithoutThrowing(entryList).wait()
         XCTAssertEqual(result1.count, 1)
-        if result1[25] != nil {
+        if result1.contains(BatchStatementErrorCodeEnum.duplicateitem) {
             return
         } else {
-            XCTFail("should return duplicated index = 25")
+            XCTFail("should contain duplicateitem error")
         }
-
-        entryList = []
-        index = 0
-        while index < 30 {
-            let key = StandardCompositePrimaryKey(partitionKey: "partitionId\(index)", sortKey: "sortId\(index)")
-            let test = TestObject(firstly: "firstly", secondly: "secondly")
-            let testItem: TestObjectDatabaseItem = TestObjectDatabaseItem.newItem(withKey: key, andValue: test)
-            entryList.append(TestObjectWriteEntry.insert(new: testItem))
-            index += 1
-        }
-
-        let result25 = try table.monomorphicBulkWriteWithoutThrowing(entryList).wait()
-        XCTAssertEqual(result25.count, 25)
-
-        let result30 = try table.monomorphicBulkWriteWithoutThrowing(entryList).wait()
-        XCTAssertEqual(result30.count, 30)
     }
 
         static var allTests = [


### PR DESCRIPTION

*Description of changes:*

use EventLoop for MonomorphicBulkWriteWithoutThrowing api to solve seg error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
