### PR TITLE
add validate writeEntry api

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
@@ -24,12 +24,23 @@ import NIO
 import CollectionConcurrencyKit
 // BatchExecuteStatement has a maximum of 25 statements
 private let maximumUpdatesPerExecuteStatement = 25
+private let maxStatementLength = 8192
 
 /// DynamoDBTable conformance updateItems function
 public extension AWSDynamoDBCompositePrimaryKeyTable {
     
-    private func entryToBatchStatementRequest<AttributesType, ItemType>(
-        _ entry: WriteEntry<AttributesType, ItemType>) throws -> BatchStatementRequest {
+    func validateEntry<AttributesType, ItemType>(entry: WriteEntry<AttributesType, ItemType>) throws {
+        
+        let statement: String = try entryToStatement(entry)
+        
+        if statement.count > maxStatementLength {
+            throw SmokeDynamoDBError.statementLengthExceeded(
+                reason: "failed to satisfy constraint: Member must have length less than or equal to \(maxStatementLength)")
+        }
+    }
+    
+    func entryToStatement<AttributesType, ItemType>(
+        _ entry: WriteEntry<AttributesType, ItemType>) throws -> String {
         
         let statement: String
         switch entry {
@@ -47,6 +58,14 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             statement = try getDeleteExpression(tableName: self.targetTableName,
                                                 existingItem: existing)
         }
+        
+        return statement
+    }
+
+    private func entryToBatchStatementRequest<AttributesType, ItemType>(
+        _ entry: WriteEntry<AttributesType, ItemType>) throws -> BatchStatementRequest {
+        
+        let statement: String = try entryToStatement(entry)
         
         return BatchStatementRequest(consistentRead: true, statement: statement)
     }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
@@ -35,11 +35,11 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         
         if statement.count > maxStatementLength {
             throw SmokeDynamoDBError.statementLengthExceeded(
-                reason: "failed to satisfy constraint: Member must have length less than or equal to \(maxStatementLength)")
+                reason: "failed to satisfy constraint: Member must have length less than or equal to \(maxStatementLength). Actual length \(statement.count)")
         }
     }
     
-    func entryToStatement<AttributesType, ItemType>(
+    private func entryToStatement<AttributesType, ItemType>(
         _ entry: WriteEntry<AttributesType, ItemType>) throws -> String {
         
         let statement: String

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -265,7 +265,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
         additionalWhereClause: String?, nextToken: String?) -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
 
     /**
-    * This is a helper function to convert WriteEntry to Statement
+    * This is a helper function to validate WriteEntry
     */
     func validateEntry<AttributesType, ItemType>(entry: WriteEntry<AttributesType, ItemType>) throws 
     

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -38,6 +38,7 @@ public enum SmokeDynamoDBError: Error {
     case batchAPIExceededRetries(retryCount: Int)
     case validationError(reason: String)
     case batchErrorsReturned(errorCount: Int, messageMap: [String: Int])
+    case statementLengthExceeded(reason: String)
 }
 
 public typealias SmokeDynamoDBErrorResult<SuccessPayload> = Result<SuccessPayload, SmokeDynamoDBError>
@@ -262,6 +263,11 @@ public protocol DynamoDBCompositePrimaryKeyTable {
         partitionKeys: [String],
         attributesFilter: [String]?,
         additionalWhereClause: String?, nextToken: String?) -> EventLoopFuture<([TypedDatabaseItem<AttributesType, ItemType>], String?)>
+
+    /**
+    * This is a helper function to convert WriteEntry to Statement
+    */
+    func validateEntry<AttributesType, ItemType>(entry: WriteEntry<AttributesType, ItemType>) throws 
     
 #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -21,7 +21,7 @@ import SmokeHTTPClient
 import DynamoDBModel
 import NIO
 
-private let maxStatementLength = 1200
+private let maxStatementLength = 8192
 
 public protocol PolymorphicOperationReturnTypeConvertable {
     var createDate: Foundation.Date { get }
@@ -73,7 +73,7 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
         let entryString = "\(entry)"
         if entryString.count > maxStatementLength {
             throw SmokeDynamoDBError.statementLengthExceeded(
-                reason: "failed to satisfy constraint: Member must have length less than or equal to \(maxStatementLength)")
+                reason: "failed to satisfy constraint: Member must have length less than or equal to \(maxStatementLength). Actual length \(entryString.count)")
         }
     }
 

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -21,7 +21,7 @@ import SmokeHTTPClient
 import DynamoDBModel
 import NIO
 
-private let maxStatementLength = 1200
+private let maxStatementLength = 8192
 
 public enum GSIError: Error {
     case unknownIndex(name: String)
@@ -51,7 +51,7 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         let entryString = "\(entry)"
         if entryString.count > maxStatementLength {
             throw SmokeDynamoDBError.statementLengthExceeded(
-                reason: "failed to satisfy constraint: Member must have length less than or equal to \(maxStatementLength)")
+                reason: "failed to satisfy constraint: Member must have length less than or equal to \(maxStatementLength). Actual length \(entryString.count)")
         }
     }
     

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -21,6 +21,8 @@ import SmokeHTTPClient
 import DynamoDBModel
 import NIO
 
+private let maxStatementLength = 1200
+
 public enum GSIError: Error {
     case unknownIndex(name: String)
 }
@@ -43,6 +45,14 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         self.gsiLogic = gsiLogic
         self.primaryTable = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop, executeItemFilter: executeItemFilter)
         self.gsiDataStore = InMemoryDynamoDBCompositePrimaryKeyTable(eventLoop: eventLoop, executeItemFilter: executeItemFilter)
+    }
+    
+    public func validateEntry<AttributesType, ItemType>(entry: WriteEntry<AttributesType, ItemType>) throws {
+        let entryString = "\(entry)"
+        if entryString.count > maxStatementLength {
+            throw SmokeDynamoDBError.statementLengthExceeded(
+                reason: "failed to satisfy constraint: Member must have length less than or equal to \(maxStatementLength)")
+        }
     }
     
     public func insertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>)

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -20,7 +20,7 @@ import SmokeHTTPClient
 import DynamoDBModel
 import NIO
 
-private let maxStatementLength = 1200
+private let maxStatementLength = 8192
 
 /**
  Implementation of the DynamoDBTable protocol that simulates concurrent access
@@ -59,7 +59,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         let entryString = "\(entry)"
         if entryString.count > maxStatementLength {
             throw SmokeDynamoDBError.statementLengthExceeded(
-                reason: "failed to satisfy constraint: Member must have length less than or equal to \(maxStatementLength)")
+                reason: "failed to satisfy constraint: Member must have length less than or equal to \(maxStatementLength). Actual length \(entryString.count)")
         }
     }
     

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -20,6 +20,8 @@ import SmokeHTTPClient
 import DynamoDBModel
 import NIO
 
+private let maxStatementLength = 1200
+
 /**
  Implementation of the DynamoDBTable protocol that simulates concurrent access
  to a database by incrementing a row's version every time it is added for
@@ -51,6 +53,14 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         self.previousConcurrencyModifications = 0
         self.simulateOnInsertItem = simulateOnInsertItem
         self.simulateOnUpdateItem = simulateOnUpdateItem
+    }
+    
+    public func validateEntry<AttributesType, ItemType>(entry: WriteEntry<AttributesType, ItemType>) throws {
+        let entryString = "\(entry)"
+        if entryString.count > maxStatementLength {
+            throw SmokeDynamoDBError.statementLengthExceeded(
+                reason: "failed to satisfy constraint: Member must have length less than or equal to \(maxStatementLength)")
+        }
     }
     
     public func insertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) -> EventLoopFuture<Void> {


### PR DESCRIPTION

*Description of changes:*

Add validate writeEntry API. Client is able to validate the statement converted by writeEntry. 
It will be useful for client to identify if Statement length exceed the limit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
