### PR TITLE
Add simpler and more flexible table initialization options.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ smoke-dynamodb-3.x ]
   pull_request:
-    branches: [ main ]
+    branches: [ smoke-dynamodb-3.x ]
       
 jobs:
   LatestVersionBuild:
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04]
-        swift: ["5.5"]
+        swift: ["5.6.1"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e
+      - uses: swift-actions/setup-swift@v1.15.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -28,10 +28,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.4.3", "5.3.3"]
+        swift: ["5.5.3", "5.4.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e
+      - uses: swift-actions/setup-swift@v1.15.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,15 +11,6 @@
         }
       },
       {
-        "package": "CollectionConcurrencyKit",
-        "repositoryURL": "https://github.com/JohnSundell/CollectionConcurrencyKit",
-        "state": {
-          "branch": null,
-          "revision": "b4f23e24b5a1bff301efc5e70871083ca029ff95",
-          "version": "0.2.0"
-        }
-      },
-      {
         "package": "smoke-aws",
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "70826d038d5bdc3142a386b735792d87ef7a5dfc",
-          "version": "1.8.1"
+          "revision": "794dc9d42720af97cedd395e8cd2add9173ffd9a",
+          "version": "1.11.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "3181f04b53977676581a30977c104d45daa8de06",
-          "version": "2.42.37"
+          "revision": "783cb502ba0d6a5f42bdfa7a51957798879afcba",
+          "version": "2.44.24"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "fba50e336245de832d81484e0514a92a8c8bf8bd",
-          "version": "2.12.0"
+          "revision": "0a529d2cc79de1f66f867aec861f5bdd346c1b38",
+          "version": "2.13.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
-          "version": "1.1.6"
+          "revision": "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+          "version": "1.1.7"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
-          "version": "2.2.0"
+          "revision": "1c1408bf8fc21be93713e897d2badf500ea38419",
+          "version": "2.3.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "51c3fc2e4a0fcdf4a25089b288dd65b73df1b0ef",
-          "version": "2.37.0"
+          "revision": "124119f0bb12384cef35aa041d7c3a686108722d",
+          "version": "2.40.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-          "version": "1.10.2"
+          "revision": "a75e92bde3683241c15df3dd905b7a6dcac4d551",
+          "version": "1.12.1"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "6e94a7be32891d1b303a3fcfde8b5bf64d162e74",
-          "version": "1.19.1"
+          "revision": "108ac15087ea9b79abb6f6742699cf31de0e8772",
+          "version": "1.22.0"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "52a486ff6de9bc3e26bf634c5413c41c5fa89ca5",
-          "version": "2.17.2"
+          "revision": "42436a25ff32c390465567f5c089a9a8ce8d7baf",
+          "version": "2.20.0"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
-          "version": "1.11.4"
+          "revision": "2cb54f91ddafc90832c5fa247faf5798d0a7c204",
+          "version": "1.13.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.42.37"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.10.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.13.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit", from :"0.2.0")

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,6 @@ let package = Package(
         .package(url: "https://github.com/amzn/smoke-http.git", from: "2.13.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
-        .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit", from :"0.2.0")
     ],
     targets: [
         .target(
@@ -40,7 +39,6 @@ let package = Package(
                 .product(name: "DynamoDBClient", package: "smoke-aws"),
                 .product(name: "SmokeHTTPClient", package: "smoke-http"),
                 .product(name: "_SmokeAWSHttpConcurrency", package: "smoke-aws"),
-                .product(name: "CollectionConcurrencyKit", package: "CollectionConcurrencyKit")
             ]),
         .testTarget(
             name: "SmokeDynamoDBTests", dependencies: [

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-dynamodb/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.3, 5.4 and 5.5 Tested">
+<img src="https://img.shields.io/badge/swift-5.4|5.5|5.6-orange.svg?style=flat" alt="Swift 5.4, 5.5 and 5.6 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 18.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ let table = AWSDynamoDBCompositePrimaryKeyTable(tableName: tableName,
 try await table.shutdown()
 ```
 
-The initialisers of this class can also accept optional parameters such as the `Logger`, `EventLoop` and InternalRequestId to use. 
+The initialisers of this class can also accept optional parameters such as the `Logger`, `EventLoop` and `InternalRequestId` to use. 
 
 Passing the `EventLoop` is useful for applications that also use SwiftNIO as a server and want to handle downstream 
 service calls on the same `EventLoop` as the incoming request to the server. 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This package enables operations to be performed on a DynamoDB table using a type
 For basic use cases, you can initialise a table with the tableName, credentialsProvider and awsRegion.
 
 ```swift 
-let table = AWSDynamoDBCompositePrimaryKeyTable(tableName: String,
+let table = AWSDynamoDBCompositePrimaryKeyTable(tableName: tableName,
                 credentialsProvider: credentialsProvider,
                 awsRegion: awsRegion)
                 
@@ -82,9 +82,9 @@ let table = AWSDynamoDBCompositePrimaryKeyTable(tableName: String,
 try await table.shutdown()
 ```
 
-The initialisers of this class can also accept optional parameters such as the Logger, EventLoop and InternalRequestId to use. 
+The initialisers of this class can also accept optional parameters such as the `Logger`, `EventLoop` and InternalRequestId to use. 
 
-Passing the EventLoop is useful for applications that also use SwiftNIO as a server and want to maintain handle downstream 
+Passing the `EventLoop` is useful for applications that also use SwiftNIO as a server and want to handle downstream 
 service calls on the same `EventLoop` as the incoming request to the server. 
 
 To share client configuration or the underlying http client between instances (such as in a request-based service where you might

--- a/README.md
+++ b/README.md
@@ -70,44 +70,76 @@ For consistency in naming across the library, SmokeDynamoDB will case DynamoDB t
 
 This package enables operations to be performed on a DynamoDB table using a type that conforms to the `DynamoDBCompositePrimaryKeyTable` protocol. In a production scenario, operations can be performed using `AWSDynamoDBCompositePrimaryKeyTable`.
 
-Typically for request-based applications such as microservices, a `AWSDynamoDBCompositePrimaryKeyTableGenerator` is created per application at application start-
-
-```swift
-let generator = AWSDynamoDBCompositePrimaryKeyTableGenerator(
-    credentialsProvider: credentialsProvider, region: region,
-    endpointHostName: dynamodbEndpointHostName, tableName: dynamodbTableName)
-```
-
-And a `AWSDynamoDBCompositePrimaryKeyTable` is created from this generator for each request-
+For basic use cases, you can initialise a table with the tableName, credentialsProvider and awsRegion.
 
 ```swift 
-let table = generator.with(logger: logger)
+let table = AWSDynamoDBCompositePrimaryKeyTable(tableName: String,
+                credentialsProvider: credentialsProvider,
+                awsRegion: awsRegion)
+                
+...
+                
+try await table.shutdown()
 ```
 
-SmokeDynamoDB uses SwiftNIO for its networking and by default a new SwiftNIO `EventLoopGroup` will be created for a table to perform that networking. Optionally, you can provide an existing `EventLoopGroup` when you create the generator-
+The initialisers of this class can also accept optional parameters such as the Logger, EventLoop and InternalRequestId to use. 
+
+Passing the EventLoop is useful for applications that also use SwiftNIO as a server and want to maintain handle downstream 
+service calls on the same `EventLoop` as the incoming request to the server. 
+
+To share client configuration or the underlying http client between instances (such as in a request-based service where you might
+want to create an instance per request) the `AWSDynamoDBClientConfiguration` and `AWSDynamoDBTableOperationsClient` types
+can also be used-
+
+One option is to create the configuration once (such at application startup)-
 
 ```swift
-let generator = AWSDynamoDBCompositePrimaryKeyTableGenerator(
-    credentialsProvider: credentialsProvider, region: region,
-    endpointHostName: dynamodbEndpointHostName, tableName: dynamodbTableName,
-    eventLoopProvider: .shared(existingEventLoopGroup)
+let config = AWSDynamoDBClientConfiguration(
+    credentialsProvider: credentialsProvider, region: region)
 ```
 
-Typically this existing `EventLoopGroup` will correspond to the group used by the rest of an application. For each particular table instance created from a generator, you can force affinity to a particular `EventLoop` within the provided `EventLoopGroup` by passing it when the table instance is being created-
+And then create the `AWSDynamoDBCompositePrimaryKeyTable` when required-
 
 ```swift 
-let table = generator.with(logger: logger,
-                           eventLoop: eventLoop)
+let table = AWSDynamoDBCompositePrimaryKeyTable(config: config,
+                tableName: tableName,
+                logger: theCurrentLogger,
+                internalRequestId: theCurrentRequestId,
+                eventLoop: theCurrentEventLoop)
+                
+...
+
+try await table.shutdown()
 ```
 
-This is useful for applications that also use SwiftNIO as a server and want to maintain handle downstream service calls on the same `EventLoop` as the incoming request to the server. 
+Alternatively, create the operations client once (such at application startup)-
 
-SmokeFramework (https://github.com/amzn/smoke-framework) based applications can automatically achieve this request-based `EventLoop` affinity by passing the reporting context into the `AWSDynamoDBCompositePrimaryKeyTableGenerator.with(reporting:)` function when creating the table-
+```swift
+let operationsClient = AWSDynamoDBTableOperationsClient(
+    tableName: tableName, credentialsProvider: credentialsProvider, region: region)
+    
+...
+
+try await operationsClient.shutdown()
+```
+
+And then create the `AWSDynamoDBCompositePrimaryKeyTable` when required-
+
+```swift 
+let table = AWSDynamoDBCompositePrimaryKeyTable(operationsClient: operationsClient,
+                logger: theCurrentLogger,
+                internalRequestId: theCurrentRequestId,
+                eventLoop: theCurrentEventLoop)
+```
+
+SmokeFramework (https://github.com/amzn/smoke-framework) based applications can automatically achieve request-based `EventLoop` affinity by passing 
+the reporting context when creating the table-
 
 ```swift
 public func getInvocationContext(invocationReporting: SmokeServerInvocationReporting<SmokeInvocationTraceContext>) -> MyContext {
     let awsClientInvocationReporting = invocationReporting.withInvocationTraceContext(traceContext: awsClientInvocationTraceContext)
-    let dynamodbTable = self.dynamodbTableGenerator.with(reporting: awsClientInvocationReporting)
+    let table = AWSDynamoDBCompositePrimaryKeyTable(operationsClient: operationsClient,
+        reporting: awsClientInvocationReporting)
     
     return MyContext(dynamodbTable: dynamodbTable)
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBClientConfiguration.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBClientConfiguration.swift
@@ -1,0 +1,195 @@
+// Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// AWSDynamoDBClientConfiguration.swift
+// DynamoDBClient
+//
+
+import DynamoDBModel
+import DynamoDBClient
+import SmokeAWSCore
+import SmokeHTTPClient
+import NIO
+import SmokeAWSHttp
+import AsyncHTTPClient
+import Logging
+
+internal extension SmokeHTTPClient.HTTPClientError {
+    func isRetriable() -> Bool {
+        if let typedError = self.cause as? DynamoDBError, let isRetriable = typedError.isRetriable() {
+            return isRetriable
+        } else {
+            return self.isRetriableAccordingToCategory
+        }
+    }
+}
+
+public typealias AWSDynamoDBClientConfiguration =
+    AWSGenericDynamoDBClientConfiguration<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>>
+
+/**
+ Configuration for an AWS DynamoDB client.
+ */
+public struct AWSGenericDynamoDBClientConfiguration<InvocationReportingType: HTTPClientCoreInvocationReporting> {
+    public let endpointHostName: String
+    public let endpointPort: Int
+    public let contentType: String
+    public let timeoutConfiguration: HTTPClient.Configuration.Timeout
+    public let connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool?
+    public let awsRegion: AWSRegion
+    public let retryConfiguration: HTTPClientRetryConfiguration
+    public let eventLoopGroup: EventLoopGroup
+    public let reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
+    
+    internal let clientDelegate: JSONAWSHttpClientDelegate<DynamoDBError>
+    internal let reportingProvider: (Logger, String, EventLoop?) -> InvocationReportingType
+    internal let credentialsProvider: CredentialsProvider
+    
+    public init<NewTraceContextType: InvocationTraceContext>(
+        credentialsProvider: CredentialsProvider,
+        awsRegion: AWSRegion,
+        endpointHostName endpointHostNameOptional: String? = nil,
+        endpointPort: Int = 443,
+        requiresTLS: Bool? = nil,
+        service: String = "dynamodb",
+        contentType: String = "application/x-amz-json-1.0",
+        target: String? = "DynamoDB_20120810",
+        traceContext: NewTraceContextType,
+        timeoutConfiguration: HTTPClient.Configuration.Timeout = .init(),
+        retryConfiguration: HTTPClientRetryConfiguration = .default,
+        eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
+        reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
+            = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
+        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil)
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<NewTraceContextType> {
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        
+        self.credentialsProvider = credentialsProvider
+        self.endpointHostName = endpointHostNameOptional ?? "dynamodb.\(awsRegion.rawValue).amazonaws.com"
+        self.endpointPort = endpointPort
+        self.contentType = contentType
+        self.clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>(requiresTLS: useTLS)
+        self.connectionPoolConfiguration = connectionPoolConfiguration
+        self.awsRegion = awsRegion
+        self.retryConfiguration = retryConfiguration
+        self.eventLoopGroup = AWSClientHelper.getEventLoop(eventLoopGroupProvider: eventLoopProvider)
+        self.timeoutConfiguration = timeoutConfiguration
+        self.reportingConfiguration = reportingConfiguration
+                
+        self.reportingProvider = { (logger, internalRequestId, eventLoop) in
+            return StandardHTTPClientCoreInvocationReporting(
+                logger: logger,
+                internalRequestId: internalRequestId,
+                traceContext: traceContext,
+                eventLoop: eventLoop)
+        }
+    }
+    
+    public init(
+        credentialsProvider: CredentialsProvider,
+        awsRegion: AWSRegion,
+        endpointHostName endpointHostNameOptional: String? = nil,
+        endpointPort: Int = 443,
+        requiresTLS: Bool? = nil,
+        service: String = "dynamodb",
+        contentType: String = "application/x-amz-json-1.0",
+        target: String? = "DynamoDB_20120810",
+        timeoutConfiguration: HTTPClient.Configuration.Timeout = .init(),
+        retryConfiguration: HTTPClientRetryConfiguration = .default,
+        eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
+        reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
+            = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
+        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil)
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext> {
+        self.init(credentialsProvider: credentialsProvider,
+                  awsRegion: awsRegion,
+                  endpointHostName: endpointHostNameOptional,
+                  endpointPort: endpointPort,
+                  requiresTLS: requiresTLS,
+                  service: service,
+                  contentType: contentType,
+                  target: target,
+                  traceContext: AWSClientInvocationTraceContext(),
+                  timeoutConfiguration: timeoutConfiguration,
+                  retryConfiguration: retryConfiguration,
+                  eventLoopProvider: eventLoopProvider,
+                  reportingConfiguration: reportingConfiguration,
+                  connectionPoolConfiguration: connectionPoolConfiguration)
+    }
+    
+    public func createOperationsClient(forTableName tableName: String)
+    -> AWSGenericDynamoDBTableOperationsClient<InvocationReportingType> {
+        return AWSGenericDynamoDBTableOperationsClient(config: self,
+                                                       tableName: tableName)
+    }
+    
+    internal func createClient() -> HTTPOperationsClient {
+        return HTTPOperationsClient(
+            endpointHostName: self.endpointHostName,
+            endpointPort: self.endpointPort,
+            contentType: self.contentType,
+            clientDelegate: self.clientDelegate,
+            timeoutConfiguration: self.timeoutConfiguration,
+            eventLoopProvider: .shared(self.eventLoopGroup),
+            connectionPoolConfiguration: self.connectionPoolConfiguration)
+    }
+    
+    internal func createAWSClient(logger: Logger, internalRequestId: String,
+                                  eventLoopOverride: EventLoop?, httpClientOverride: HTTPOperationsClient?)
+    -> _AWSDynamoDBClient<InvocationReportingType> {
+
+        let httpClient: HTTPOperationsClient
+        let ownsHttpClient: Bool
+        if let httpClientOverride = httpClientOverride {
+            httpClient = httpClientOverride
+            ownsHttpClient = false
+        } else {
+            httpClient = createClient()
+            ownsHttpClient = true
+        }
+        
+        return _AWSDynamoDBClient(credentialsProvider: self.credentialsProvider,
+                                  awsRegion: self.awsRegion,
+                                  reporting: self.reportingProvider(logger, internalRequestId, eventLoopOverride),
+                                  httpClient: httpClient,
+                                  ownsHttpClient: ownsHttpClient,
+                                  retryConfiguration: self.retryConfiguration,
+                                  reportingConfiguration: self.reportingConfiguration,
+                                  retryOnErrorProvider: { error in error.isRetriable() })
+    }
+    
+    internal func createAWSClient<OverrideInvocationReportingType: HTTPClientCoreInvocationReporting>(
+        reporting: OverrideInvocationReportingType,
+        httpClient: HTTPOperationsClient?)
+    -> _AWSDynamoDBClient<OverrideInvocationReportingType> {
+
+        let theHttpClient: HTTPOperationsClient
+        let ownsHttpClient: Bool
+        if let httpClient = httpClient {
+            theHttpClient = httpClient
+            ownsHttpClient = false
+        } else {
+            theHttpClient = createClient()
+            ownsHttpClient = true
+        }
+        
+        return _AWSDynamoDBClient(credentialsProvider: self.credentialsProvider,
+                                  awsRegion: self.awsRegion,
+                                  reporting: reporting,
+                                  httpClient: theHttpClient,
+                                  ownsHttpClient: ownsHttpClient,
+                                  retryConfiguration: self.retryConfiguration,
+                                  reportingConfiguration: self.reportingConfiguration,
+                                  retryOnErrorProvider: { error in error.isRetriable() })
+    }
+}

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
@@ -21,7 +21,6 @@ import DynamoDBModel
 import SmokeHTTPClient
 import Logging
 import NIO
-import CollectionConcurrencyKit
 // BatchExecuteStatement has a maximum of 25 statements
 private let maximumUpdatesPerExecuteStatement = 25
 private let maxStatementLength = 8192

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -86,7 +86,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 httpClient: HTTPOperationsClient? = nil) {
         self.logger = reporting.logger
         self.dynamodb = config.createAWSClient(reporting: reporting,
-                                               httpClient: httpClient)
+                                               httpClientOverride: httpClient)
         self.targetTableName = tableName
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
@@ -97,7 +97,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 reporting: InvocationReportingType) {
         self.logger = reporting.logger
         self.dynamodb = operationsClient.config.createAWSClient(reporting: reporting,
-                                                                httpClient: operationsClient.httpClient)
+                                                                httpClientOverride: operationsClient.httpClient)
         self.targetTableName = operationsClient.tableName
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -93,7 +93,11 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
         self.logger.info("AWSDynamoDBTable created with region '\(config.awsRegion)' and hostname: '\(endpointHostName)'")
     }
     
-    public init(operationsClient: AWSGenericDynamoDBTableOperationsClient<InvocationReportingType>,
+    // This initialiser is generic with respect to the reporting type from the operations client
+    // As we are using the providing reporting instance and not creating a reporting instance from
+    // the operations client, this generic type can be ignored.
+    public init<OperationsClientInvocationReportingType: HTTPClientCoreInvocationReporting>(
+                operationsClient: AWSGenericDynamoDBTableOperationsClient<OperationsClientInvocationReportingType>,
                 reporting: InvocationReportingType) {
         self.logger = reporting.logger
         self.dynamodb = operationsClient.config.createAWSClient(reporting: reporting,
@@ -104,14 +108,14 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
         self.logger.info("AWSDynamoDBTable created with region '\(operationsClient.config.awsRegion)' and hostname: '\(endpointHostName)'")
     }
     
-    public init<NewTraceContextType: InvocationTraceContext>(
-                config: AWSGenericDynamoDBClientConfiguration<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>>,
+    public init<TraceContextType: InvocationTraceContext>(
+                config: AWSGenericDynamoDBClientConfiguration<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
                 tableName: String,
                 logger: Logging.Logger = Logger(label: "AWSDynamoDBTable"),
                 internalRequestId: String = "none",
                 eventLoop: EventLoop? = nil,
                 httpClient: HTTPOperationsClient? = nil)
-    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<NewTraceContextType> {
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.logger = logger
         self.dynamodb = config.createAWSClient(logger: logger, internalRequestId: internalRequestId,
                                                eventLoopOverride: eventLoop, httpClientOverride: httpClient)
@@ -121,12 +125,12 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
         self.logger.info("AWSDynamoDBTable created with region '\(config.awsRegion)' and hostname: '\(endpointHostName)'")
     }
     
-    public init<NewTraceContextType: InvocationTraceContext>(
-                operationsClient: AWSGenericDynamoDBTableOperationsClient<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>>,
+    public init<TraceContextType: InvocationTraceContext>(
+                operationsClient: AWSGenericDynamoDBTableOperationsClient<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
                 logger: Logging.Logger = Logger(label: "AWSDynamoDBTable"),
                 internalRequestId: String = "none",
                 eventLoop: EventLoop? = nil)
-    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<NewTraceContextType> {
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.logger = logger
         self.dynamodb = operationsClient.config.createAWSClient(logger: logger, internalRequestId: internalRequestId,
                                                                 eventLoopOverride: eventLoop, httpClientOverride: operationsClient.httpClient)

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
@@ -91,7 +91,7 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
                 httpClient: HTTPOperationsClient? = nil) {
         self.logger = reporting.logger
         self.dynamodb = config.createAWSClient(reporting: reporting,
-                                               httpClient: httpClient)
+                                               httpClientOverride: httpClient)
         self.targetTableName = tableName
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
@@ -102,7 +102,7 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
                 reporting: InvocationReportingType) {
         self.logger = reporting.logger
         self.dynamodb = operationsClient.config.createAWSClient(reporting: reporting,
-                                                                httpClient: operationsClient.httpClient)
+                                                                httpClientOverride: operationsClient.httpClient)
         self.targetTableName = operationsClient.tableName
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
@@ -98,7 +98,11 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
         self.logger.info("AWSDynamoDBCompositePrimaryKeysProjection created with region '\(config.awsRegion)' and hostname: '\(endpointHostName)'")
     }
     
-    public init(operationsClient: AWSGenericDynamoDBTableOperationsClient<InvocationReportingType>,
+    // This initialiser is generic with respect to the reporting type from the operations client
+    // As we are using the providing reporting instance and not creating a reporting instance from
+    // the operations client, this generic type can be ignored.
+    public init<OperationsClientInvocationReportingType: HTTPClientCoreInvocationReporting>(
+                operationsClient: AWSGenericDynamoDBTableOperationsClient<OperationsClientInvocationReportingType>,
                 reporting: InvocationReportingType) {
         self.logger = reporting.logger
         self.dynamodb = operationsClient.config.createAWSClient(reporting: reporting,
@@ -109,14 +113,14 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
         self.logger.info("AWSDynamoDBCompositePrimaryKeysProjection created with region '\(operationsClient.config.awsRegion)' and hostname: '\(endpointHostName)'")
     }
     
-    public init<NewTraceContextType: InvocationTraceContext>(
-                config: AWSGenericDynamoDBClientConfiguration<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>>,
+    public init<TraceContextType: InvocationTraceContext>(
+                config: AWSGenericDynamoDBClientConfiguration<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
                 tableName: String,
                 logger: Logging.Logger = Logger(label: "AWSDynamoDBCompositePrimaryKeysProjection"),
                 internalRequestId: String = "none",
                 eventLoop: EventLoop? = nil,
                 httpClient: HTTPOperationsClient? = nil)
-    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<NewTraceContextType> {
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.logger = logger
         self.dynamodb = config.createAWSClient(logger: logger, internalRequestId: internalRequestId,
                                                eventLoopOverride: eventLoop, httpClientOverride: httpClient)
@@ -126,12 +130,12 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
         self.logger.info("AWSDynamoDBCompositePrimaryKeysProjection created with region '\(config.awsRegion)' and hostname: '\(endpointHostName)'")
     }
     
-    public init<NewTraceContextType: InvocationTraceContext>(
-                operationsClient: AWSGenericDynamoDBTableOperationsClient<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>>,
+    public init<TraceContextType: InvocationTraceContext>(
+                operationsClient: AWSGenericDynamoDBTableOperationsClient<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
                 logger: Logging.Logger = Logger(label: "AWSDynamoDBCompositePrimaryKeysProjection"),
                 internalRequestId: String = "none",
                 eventLoop: EventLoop? = nil)
-    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<NewTraceContextType> {
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.logger = logger
         self.dynamodb = operationsClient.config.createAWSClient(logger: logger, internalRequestId: internalRequestId,
                                                                 eventLoopOverride: eventLoop, httpClientOverride: operationsClient.httpClient)

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeysProjection.swift
@@ -20,6 +20,7 @@ import Logging
 import DynamoDBClient
 import DynamoDBModel
 import SmokeAWSCore
+import SmokeAWSHttp
 import SmokeHTTPClient
 import AsyncHTTPClient
 import NIO
@@ -58,7 +59,7 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
                                            reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
 
-        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
+        self.logger.info("AWSDynamoDBCompositePrimaryKeysProjection created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
 
     public init(credentialsProvider: CredentialsProvider,
@@ -81,7 +82,104 @@ public class AWSDynamoDBCompositePrimaryKeysProjection<InvocationReportingType: 
                                            reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
 
-        self.logger.info("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
+        self.logger.info("AWSDynamoDBCompositePrimaryKeysProjection created with region '\(region)' and hostname: '\(endpointHostName)'")
+    }
+    
+    public init(config: AWSGenericDynamoDBClientConfiguration<InvocationReportingType>,
+                reporting: InvocationReportingType,
+                tableName: String,
+                httpClient: HTTPOperationsClient? = nil) {
+        self.logger = reporting.logger
+        self.dynamodb = config.createAWSClient(reporting: reporting,
+                                               httpClient: httpClient)
+        self.targetTableName = tableName
+        
+        let endpointHostName = self.dynamodb.httpClient.endpointHostName
+        self.logger.info("AWSDynamoDBCompositePrimaryKeysProjection created with region '\(config.awsRegion)' and hostname: '\(endpointHostName)'")
+    }
+    
+    public init(operationsClient: AWSGenericDynamoDBTableOperationsClient<InvocationReportingType>,
+                reporting: InvocationReportingType) {
+        self.logger = reporting.logger
+        self.dynamodb = operationsClient.config.createAWSClient(reporting: reporting,
+                                                                httpClient: operationsClient.httpClient)
+        self.targetTableName = operationsClient.tableName
+        
+        let endpointHostName = self.dynamodb.httpClient.endpointHostName
+        self.logger.info("AWSDynamoDBCompositePrimaryKeysProjection created with region '\(operationsClient.config.awsRegion)' and hostname: '\(endpointHostName)'")
+    }
+    
+    public init<NewTraceContextType: InvocationTraceContext>(
+                config: AWSGenericDynamoDBClientConfiguration<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>>,
+                tableName: String,
+                logger: Logging.Logger = Logger(label: "AWSDynamoDBCompositePrimaryKeysProjection"),
+                internalRequestId: String = "none",
+                eventLoop: EventLoop? = nil,
+                httpClient: HTTPOperationsClient? = nil)
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<NewTraceContextType> {
+        self.logger = logger
+        self.dynamodb = config.createAWSClient(logger: logger, internalRequestId: internalRequestId,
+                                               eventLoopOverride: eventLoop, httpClientOverride: httpClient)
+        self.targetTableName = tableName
+        
+        let endpointHostName = self.dynamodb.httpClient.endpointHostName
+        self.logger.info("AWSDynamoDBCompositePrimaryKeysProjection created with region '\(config.awsRegion)' and hostname: '\(endpointHostName)'")
+    }
+    
+    public init<NewTraceContextType: InvocationTraceContext>(
+                operationsClient: AWSGenericDynamoDBTableOperationsClient<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>>,
+                logger: Logging.Logger = Logger(label: "AWSDynamoDBCompositePrimaryKeysProjection"),
+                internalRequestId: String = "none",
+                eventLoop: EventLoop? = nil)
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<NewTraceContextType> {
+        self.logger = logger
+        self.dynamodb = operationsClient.config.createAWSClient(logger: logger, internalRequestId: internalRequestId,
+                                                                eventLoopOverride: eventLoop, httpClientOverride: operationsClient.httpClient)
+        self.targetTableName = operationsClient.tableName
+        
+        let endpointHostName = self.dynamodb.httpClient.endpointHostName
+        self.logger.info("AWSDynamoDBCompositePrimaryKeysProjection created with region '\(operationsClient.config.awsRegion)' and hostname: '\(endpointHostName)'")
+    }
+    
+    public init(tableName: String,
+                credentialsProvider: CredentialsProvider,
+                awsRegion: AWSRegion,
+                endpointHostName endpointHostNameOptional: String? = nil,
+                endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
+                service: String = "dynamodb",
+                contentType: String = "application/x-amz-json-1.0",
+                target: String? = "DynamoDB_20120810",
+                timeoutConfiguration: HTTPClient.Configuration.Timeout = .init(),
+                retryConfiguration: HTTPClientRetryConfiguration = .default,
+                eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
+                reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
+                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
+                connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil,
+                logger: Logging.Logger = Logger(label: "AWSDynamoDBTable"),
+                internalRequestId: String = "none")
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext> {
+        let config = AWSGenericDynamoDBClientConfiguration(
+            credentialsProvider: credentialsProvider,
+            awsRegion: awsRegion,
+            endpointHostName: endpointHostNameOptional,
+            endpointPort: endpointPort,
+            requiresTLS: requiresTLS,
+            service: service,
+            contentType: contentType,
+            target: target,
+            timeoutConfiguration: timeoutConfiguration,
+            retryConfiguration: retryConfiguration,
+            eventLoopProvider: eventLoopProvider,
+            reportingConfiguration: reportingConfiguration,
+            connectionPoolConfiguration: connectionPoolConfiguration)
+        self.logger = logger
+        self.dynamodb = config.createAWSClient(logger: logger, internalRequestId: internalRequestId,
+                                               eventLoopOverride: nil, httpClientOverride: nil)
+        self.targetTableName = tableName
+        
+        let endpointHostName = self.dynamodb.httpClient.endpointHostName
+        self.logger.info("AWSDynamoDBCompositePrimaryKeysProjection created with region '\(awsRegion)' and hostname: '\(endpointHostName)'")
     }
     
     internal init(dynamodb: _AWSDynamoDBClient<InvocationReportingType>,

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTableOperationsClient.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTableOperationsClient.swift
@@ -1,0 +1,129 @@
+// Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// AWSDynamoDBTableOperationsClient.swift
+// DynamoDBClient
+//
+
+import DynamoDBModel
+import SmokeAWSCore
+import SmokeHTTPClient
+import SmokeAWSHttp
+import AsyncHTTPClient
+
+public typealias AWSDynamoDBTableOperationsClient =
+    AWSGenericDynamoDBTableOperationsClient<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>>
+
+public struct AWSGenericDynamoDBTableOperationsClient<InvocationReportingType: HTTPClientCoreInvocationReporting> {
+    public let config: AWSGenericDynamoDBClientConfiguration<InvocationReportingType>
+    public let tableName: String
+    public let httpClient: HTTPOperationsClient
+    
+    public init<NewTraceContextType: InvocationTraceContext>(
+        tableName: String,
+        credentialsProvider: CredentialsProvider,
+        awsRegion: AWSRegion,
+        endpointHostName endpointHostNameOptional: String? = nil,
+        endpointPort: Int = 443,
+        requiresTLS: Bool? = nil,
+        service: String = "dynamodb",
+        contentType: String = "application/x-amz-json-1.0",
+        target: String? = "DynamoDB_20120810",
+        traceContext: NewTraceContextType,
+        timeoutConfiguration: HTTPClient.Configuration.Timeout = .init(),
+        retryConfiguration: HTTPClientRetryConfiguration = .default,
+        eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
+        reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
+            = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
+        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil)
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<NewTraceContextType> {
+        self.config = AWSGenericDynamoDBClientConfiguration(
+            credentialsProvider: credentialsProvider,
+            awsRegion: awsRegion,
+            endpointHostName: endpointHostNameOptional,
+            endpointPort: endpointPort,
+            requiresTLS: requiresTLS,
+            service: service,
+            contentType: contentType,
+            target: target,
+            traceContext: traceContext,
+            timeoutConfiguration: timeoutConfiguration,
+            retryConfiguration: retryConfiguration,
+            eventLoopProvider: eventLoopProvider,
+            reportingConfiguration: reportingConfiguration,
+            connectionPoolConfiguration: connectionPoolConfiguration)
+        self.httpClient = self.config.createClient()
+        self.tableName = tableName
+    }
+    
+    public init(
+        tableName: String,
+        credentialsProvider: CredentialsProvider,
+        awsRegion: AWSRegion,
+        endpointHostName endpointHostNameOptional: String? = nil,
+        endpointPort: Int = 443,
+        requiresTLS: Bool? = nil,
+        service: String = "dynamodb",
+        contentType: String = "application/x-amz-json-1.0",
+        target: String? = "DynamoDB_20120810",
+        timeoutConfiguration: HTTPClient.Configuration.Timeout = .init(),
+        retryConfiguration: HTTPClientRetryConfiguration = .default,
+        eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
+        reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
+            = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
+        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil)
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext> {
+        self.init(tableName: tableName,
+                  credentialsProvider: credentialsProvider,
+                  awsRegion: awsRegion,
+                  endpointHostName: endpointHostNameOptional,
+                  endpointPort: endpointPort,
+                  requiresTLS: requiresTLS,
+                  service: service,
+                  contentType: contentType,
+                  target: target,
+                  traceContext: AWSClientInvocationTraceContext(),
+                  timeoutConfiguration: timeoutConfiguration,
+                  retryConfiguration: retryConfiguration,
+                  eventLoopProvider: eventLoopProvider,
+                  reportingConfiguration: reportingConfiguration,
+                  connectionPoolConfiguration: connectionPoolConfiguration)
+    }
+    
+    internal init(config: AWSGenericDynamoDBClientConfiguration<InvocationReportingType>,
+                  tableName: String) {
+        self.config = config
+        self.tableName = tableName
+        self.httpClient = self.config.createClient()
+    }
+    
+    /**
+     Gracefully shuts down the eventloop if owned by this client.
+     This function is idempotent and will handle being called multiple
+     times. Will block until shutdown is complete.
+     */
+    public func syncShutdown() throws {
+        try httpClient.syncShutdown()
+    }
+    
+    /**
+     Gracefully shuts down the eventloop if owned by this client.
+     This function is idempotent and will handle being called multiple
+     times. Will return when shutdown is complete.
+     */
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    public func shutdown() async throws {
+        try await httpClient.shutdown()
+    }
+#endif
+}

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTableOperationsClient.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTableOperationsClient.swift
@@ -62,7 +62,7 @@ public struct AWSGenericDynamoDBTableOperationsClient<InvocationReportingType: H
             eventLoopProvider: eventLoopProvider,
             reportingConfiguration: reportingConfiguration,
             connectionPoolConfiguration: connectionPoolConfiguration)
-        self.httpClient = self.config.createClient()
+        self.httpClient = self.config.createHTTPOperationsClient()
         self.tableName = tableName
     }
     
@@ -104,7 +104,7 @@ public struct AWSGenericDynamoDBTableOperationsClient<InvocationReportingType: H
                   tableName: String) {
         self.config = config
         self.tableName = tableName
-        self.httpClient = self.config.createClient()
+        self.httpClient = self.config.createHTTPOperationsClient()
     }
     
     /**

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTableOperationsClient.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTableOperationsClient.swift
@@ -29,7 +29,7 @@ public struct AWSGenericDynamoDBTableOperationsClient<InvocationReportingType: H
     public let tableName: String
     public let httpClient: HTTPOperationsClient
     
-    public init<NewTraceContextType: InvocationTraceContext>(
+    public init<TraceContextType: InvocationTraceContext>(
         tableName: String,
         credentialsProvider: CredentialsProvider,
         awsRegion: AWSRegion,
@@ -39,14 +39,14 @@ public struct AWSGenericDynamoDBTableOperationsClient<InvocationReportingType: H
         service: String = "dynamodb",
         contentType: String = "application/x-amz-json-1.0",
         target: String? = "DynamoDB_20120810",
-        traceContext: NewTraceContextType,
+        traceContext: TraceContextType,
         timeoutConfiguration: HTTPClient.Configuration.Timeout = .init(),
         retryConfiguration: HTTPClientRetryConfiguration = .default,
         eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
         reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
             = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
         connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil)
-    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<NewTraceContextType> {
+    where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.config = AWSGenericDynamoDBClientConfiguration(
             credentialsProvider: credentialsProvider,
             awsRegion: awsRegion,

--- a/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClient.swift
+++ b/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClient.swift
@@ -95,8 +95,7 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
          ownsHttpClient: Bool,
          retryConfiguration: HTTPClientRetryConfiguration,
          reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>,
-         retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool)
-    {
+         retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool) {
         self.httpClient = httpClient
         self.ownsHttpClients = ownsHttpClient
         self.eventLoopGroup = httpClient.eventLoopGroup

--- a/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClient.swift
+++ b/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClient.swift
@@ -32,16 +32,6 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension SmokeHTTPClient.HTTPClientError {
-    func isRetriable() -> Bool {
-        if let typedError = self.cause as? DynamoDBError, let isRetriable = typedError.isRetriable() {
-            return isRetriable
-        } else {
-            return self.isRetriableAccordingToCategory
-        }
-    }
-}
-
 /**
  AWS Client for the DynamoDB service.
  */
@@ -93,6 +83,30 @@ struct _AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocationRepor
         self.retryConfiguration = retryConfiguration
         self.reporting = reporting
         self.retryOnErrorProvider = { error in error.isRetriable() }
+        self.operationsReporting = DynamoDBOperationsReporting(clientName: "AWSDynamoDBClient", reportingConfiguration: reportingConfiguration)
+        self.invocationsReporting = DynamoDBInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
+    }
+    
+    init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+         reporting: InvocationReportingType,
+         service: String = "dynamodb",
+         target: String? = "DynamoDB_20120810",
+         httpClient: HTTPOperationsClient,
+         ownsHttpClient: Bool,
+         retryConfiguration: HTTPClientRetryConfiguration,
+         reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>,
+         retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool)
+    {
+        self.httpClient = httpClient
+        self.ownsHttpClients = ownsHttpClient
+        self.eventLoopGroup = httpClient.eventLoopGroup
+        self.awsRegion = awsRegion
+        self.service = service
+        self.target = target
+        self.credentialsProvider = credentialsProvider
+        self.retryConfiguration = retryConfiguration
+        self.reporting = reporting
+        self.retryOnErrorProvider = retryOnErrorProvider
         self.operationsReporting = DynamoDBOperationsReporting(clientName: "AWSDynamoDBClient", reportingConfiguration: reportingConfiguration)
         self.invocationsReporting = DynamoDBInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }

--- a/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClientGenerator.swift
+++ b/Sources/SmokeDynamoDB/_DynamoDBClient/_AWSDynamoDBClientGenerator.swift
@@ -36,7 +36,6 @@ import Logging
  */
 struct _AWSDynamoDBClientGenerator {
     let httpClient: HTTPOperationsClient
-    let ownsHttpClients: Bool
     let awsRegion: AWSRegion
     let service: String
     let target: String?
@@ -71,7 +70,6 @@ struct _AWSDynamoDBClientGenerator {
             clientDelegate: clientDelegate,
             connectionTimeoutSeconds: connectionTimeoutSeconds,
             eventLoopProvider: .shared(self.eventLoopGroup))
-        self.ownsHttpClients = true
         self.awsRegion = awsRegion
         self.service = service
         self.target = target
@@ -86,17 +84,13 @@ struct _AWSDynamoDBClientGenerator {
      will handle being called multiple times. Will block until shutdown is complete.
      */
     public func syncShutdown() throws {
-        if self.ownsHttpClients {
-            try self.httpClient.syncShutdown()
-        }
+        try self.httpClient.syncShutdown()
     }
 
     // renamed `syncShutdown` to make it clearer this version of shutdown will block.
     @available(*, deprecated, renamed: "syncShutdown")
     public func close() throws {
-        if self.ownsHttpClients {
-            try self.httpClient.close()
-        }
+        try self.httpClient.close()
     }
 
     /**
@@ -105,9 +99,7 @@ struct _AWSDynamoDBClientGenerator {
      */
     #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     public func shutdown() async throws {
-        if self.ownsHttpClients {
-            try await self.httpClient.shutdown()
-        }
+        try await self.httpClient.shutdown()
     }
     #endif
     

--- a/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
@@ -464,7 +464,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         XCTAssertEqual(payload2, retrievedDatabaseItem2.rowValue)
     }
   
-    func testMonomorphicBulkWriteWithoutThrowing() async throws {
+    func testMonomorphicBulkWriteWithoutThrowing() throws {
         typealias TestObject = TestTypeA
         typealias TestObjectDatabaseItem = StandardTypedDatabaseItem<TestObject>
         typealias TestObjectWriteEntry = StandardWriteEntry<TestObject>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add simpler and more flexible table initialization options.
1. The ability to initialise a table without a generator using the default reporting/tracing types
2. The ability to create a configuration object to define attributes upfront.
3. The ability to create an operations client that can then be shared across multiple table/projection instances.

Updated the README to describe these three options.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
