### PR TITLE
throw batchStatementError instead of batchStatementErrorCode

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "8669b7c5be5e45f6d8f1177ddc41c33d66eb71dc",
-          "version": "2.44.46"
+          "revision": "f1195aca906fd28a799298144635502c32d9af27",
+          "version": "2.44.62"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["SmokeDynamoDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.42.37"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.44.62"),
         .package(url: "https://github.com/amzn/smoke-http.git", from: "2.13.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
@@ -159,12 +159,12 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
     }
     
     func writeChunkedItemsWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
-    -> EventLoopFuture<Set<BatchStatementErrorCodeEnum>> {
+    -> EventLoopFuture<Set<BatchStatementError>> {
         // if there are no items, there is nothing to update
         
         guard entries.count > 0 else {
             self.logger.trace("\(entries) with count = 0")
-            let promise = self.eventLoop.makePromise(of: Set<BatchStatementErrorCodeEnum>.self)
+            let promise = self.eventLoop.makePromise(of: Set<BatchStatementError>.self)
             promise.succeed(Set())
             return promise.futureResult
         }
@@ -172,29 +172,26 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         do {
             let statements: [BatchStatementRequest] = try entries.map { try entryToBatchStatementRequest( $0 ) }
             let executeInput = BatchExecuteStatementInput(statements: statements)
-            return dynamodb.batchExecuteStatement(input: executeInput).map { result -> Set<BatchStatementErrorCodeEnum> in
-                var errorCodeSet: Set<BatchStatementErrorCodeEnum> = Set()
-                // TODO: Remove errorCodeSet and return errorSet instead
+            return dynamodb.batchExecuteStatement(input: executeInput).map { result -> Set<BatchStatementError> in
                 var errorSet: Set<BatchStatementError> = Set()
                 result.responses?.forEach { response in
-                    if let error = response.error, let code = error.code {
-                        errorCodeSet.insert(code)
+                    if let error = response.error {
                         errorSet.insert(error)
                     }
                 }
 
                 self.logger.error("Received BatchStatmentErrors from dynamodb are \(errorSet)")
-                return errorCodeSet
+                return errorSet
             }
         } catch {
-            let promise = self.eventLoop.makePromise(of: Set<BatchStatementErrorCodeEnum>.self)
+            let promise = self.eventLoop.makePromise(of: Set<BatchStatementError>.self)
             promise.fail(error)
             return promise.futureResult
         }
     }
 
     func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
-    -> EventLoopFuture<Set<BatchStatementErrorCodeEnum>> {
+    -> EventLoopFuture<Set<BatchStatementError>> {
         // BatchExecuteStatement has a maximum of 25 statements
         // This function handles pagination internally.
         let chunkedEntries = entries.chunked(by: maximumUpdatesPerExecuteStatement)
@@ -204,7 +201,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         }  
 
         return EventLoopFuture.whenAllComplete(futures, on: self.eventLoop).flatMapThrowing { results in
-            var errors: Set<BatchStatementErrorCodeEnum> = Set()
+            var errors: Set<BatchStatementError> = Set()
             try results.forEach { result in
                 let error = try result.get()
                 errors = errors.union(error)
@@ -212,13 +209,5 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             
             return errors
         }
-    }
-}
-
-extension BatchStatementError: Hashable {
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.code)
-        hasher.combine(self.message)
     }
 }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -107,7 +107,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
     func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<Void>
     
     func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
-    -> EventLoopFuture<Set<BatchStatementErrorCodeEnum>>
+    -> EventLoopFuture<Set<BatchStatementError>>
 
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.
@@ -296,7 +296,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
     func monomorphicBulkWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
 
     func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
-    -> Set<BatchStatementErrorCodeEnum>
+    -> Set<BatchStatementError>
     /**
      * Retrieves an item from the database table. Returns nil if the item doesn't exist.
      */
@@ -476,7 +476,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
         return try await monomorphicBulkWrite(entries).get()
     }
     func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
-    -> Set<BatchStatementErrorCodeEnum>{
+    -> Set<BatchStatementError>{
         return try await monomorphicBulkWriteWithoutThrowing(entries).get()
     }
 

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -95,7 +95,7 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
         return storeWrapper.monomorphicBulkWrite(entries, eventLoop: self.eventLoop)
     }
 
-    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<Set<BatchStatementErrorCodeEnum>> {
+    public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) -> EventLoopFuture<Set<BatchStatementError>> {
         return storeWrapper.monomorphicBulkWriteWithoutThrowing(entries, eventLoop: eventLoop)
     }
     

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -169,44 +169,45 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
     
     public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(
         _ entries: [WriteEntry<AttributesType, ItemType>],
-        eventLoop: EventLoop) -> EventLoopFuture<Set<BatchStatementErrorCodeEnum>> {
+        eventLoop: EventLoop) -> EventLoopFuture<Set<BatchStatementError>> {
+            let batchStatementError = BatchStatementError(code: .duplicateitem, message: nil)
             
-            let futures = entries.map { entry -> EventLoopFuture<BatchStatementErrorCodeEnum?> in
+            let futures = entries.map { entry -> EventLoopFuture<BatchStatementError?> in
                 switch entry {
                 case .update(new: let new, existing: let existing):
                     return updateItem(newItem: new, existingItem: existing, eventLoop: eventLoop)
-                        .map { () -> BatchStatementErrorCodeEnum? in
+                        .map { () -> BatchStatementError? in
                             return nil
-                        }.flatMapError { error -> EventLoopFuture<BatchStatementErrorCodeEnum?> in
-                            let promise = eventLoop.makePromise(of: BatchStatementErrorCodeEnum?.self)
-                            promise.succeed(BatchStatementErrorCodeEnum.duplicateitem)
+                        }.flatMapError { error -> EventLoopFuture<BatchStatementError?> in
+                            let promise = eventLoop.makePromise(of: BatchStatementError?.self)
+                            promise.succeed(batchStatementError)
                             return promise.futureResult
                         }
                 case .insert(new: let new):
                     return insertItem(new, eventLoop: eventLoop)
-                        .map { () -> BatchStatementErrorCodeEnum? in
+                        .map { () -> BatchStatementError? in
                             return nil
-                        }.flatMapError { error -> EventLoopFuture<BatchStatementErrorCodeEnum?> in
-                            let promise = eventLoop.makePromise(of: BatchStatementErrorCodeEnum?.self)
-                            promise.succeed(BatchStatementErrorCodeEnum.duplicateitem)
+                        }.flatMapError { error -> EventLoopFuture<BatchStatementError?> in
+                            let promise = eventLoop.makePromise(of: BatchStatementError?.self)
+                            promise.succeed(batchStatementError)
                             return promise.futureResult
                         }
                 case .deleteAtKey(key: let key):
                     return deleteItem(forKey: key, eventLoop: eventLoop)
-                        .map { () -> BatchStatementErrorCodeEnum? in
+                        .map { () -> BatchStatementError? in
                             return nil
-                        }.flatMapError { error -> EventLoopFuture<BatchStatementErrorCodeEnum?> in
-                            let promise = eventLoop.makePromise(of: BatchStatementErrorCodeEnum?.self)
-                            promise.succeed(BatchStatementErrorCodeEnum.duplicateitem)
+                        }.flatMapError { error -> EventLoopFuture<BatchStatementError?> in
+                            let promise = eventLoop.makePromise(of: BatchStatementError?.self)
+                            promise.succeed(batchStatementError)
                             return promise.futureResult
                         }
                 case .deleteItem(existing: let existing):
                     return deleteItem(existingItem: existing, eventLoop: eventLoop)
-                        .map { () -> BatchStatementErrorCodeEnum? in
+                        .map { () -> BatchStatementError? in
                             return nil
-                        }.flatMapError { error -> EventLoopFuture<BatchStatementErrorCodeEnum?> in
-                            let promise = eventLoop.makePromise(of: BatchStatementErrorCodeEnum?.self)
-                            promise.succeed(BatchStatementErrorCodeEnum.duplicateitem)
+                        }.flatMapError { error -> EventLoopFuture<BatchStatementError?> in
+                            let promise = eventLoop.makePromise(of: BatchStatementError?.self)
+                            promise.succeed(batchStatementError)
                             return promise.futureResult
                         }
                 }
@@ -214,7 +215,7 @@ internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
             
             return EventLoopFuture.whenAllComplete(futures, on: eventLoop)
                     .flatMapThrowing { results in
-                        var errors: Set<BatchStatementErrorCodeEnum> = Set()
+                        var errors: Set<BatchStatementError> = Set()
                         try results.forEach { result in
                             if let error = try result.get() {
                                 errors.insert(error)

--- a/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -120,7 +120,7 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
     }
     
     public func monomorphicBulkWriteWithoutThrowing<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
-    -> EventLoopFuture<Set<BatchStatementErrorCodeEnum>>
+    -> EventLoopFuture<Set<BatchStatementError>>
     where AttributesType : PrimaryKeyAttributes, ItemType : Decodable, ItemType : Encodable {
         return self.wrappedDynamoDBTable.monomorphicBulkWriteWithoutThrowing(entries)
     }

--- a/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
@@ -483,7 +483,7 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
 
         let result1 = try table.monomorphicBulkWriteWithoutThrowing(entryList).wait()
         XCTAssertEqual(result1.count, 1)
-        if result1.contains(BatchStatementErrorCodeEnum.duplicateitem) {
+        if result1.contains(BatchStatementError(code: .duplicateitem, message: nil)) {
             return
         } else {
             XCTFail("should contain duplicateitem error")


### PR DESCRIPTION
*Description of changes:*
Use batchStatementError instead of batchStatementErrorCode to include more error information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
