### PR TITLE
Add consistentRead as a property on the table (3.x branch).

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+deleteItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+deleteItems.swift
@@ -42,7 +42,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                 let statement = try getDeleteExpression(tableName: self.targetTableName,
                                                         existingKey: existingKey)
                 
-                return BatchStatementRequest(consistentRead: true, statement: statement)
+                // doesn't require read consistency as no items are being read
+                return BatchStatementRequest(consistentRead: false, statement: statement)
             }
         } catch {
             let promise = self.eventLoop.makePromise(of: Void.self)
@@ -72,7 +73,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                 let statement = try getDeleteExpression(tableName: self.targetTableName,
                                                         existingItem: existingItem)
                 
-                return BatchStatementRequest(consistentRead: true, statement: statement)
+                // doesn't require read consistency as no items are being read
+                return BatchStatementRequest(consistentRead: false, statement: statement)
             }
         } catch {
             let promise = self.eventLoop.makePromise(of: Void.self)

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+execute.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+execute.swift
@@ -53,7 +53,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                                      attributesFilter: attributesFilter,
                                      partitionKeyAttributeName: ReturnedType.AttributesType.partitionKeyAttributeName,
                                      additionalWhereClause: additionalWhereClause)
-        let executeInput = ExecuteStatementInput(consistentRead: true, nextToken: nextToken, statement: statement)
+        let executeInput = ExecuteStatementInput(consistentRead: self.consistentRead, nextToken: nextToken, statement: statement)
         
         return dynamodb.executeStatement(input: executeInput).flatMapThrowing { executeOutput in
             let nextToken = executeOutput.nextToken
@@ -131,7 +131,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                                      attributesFilter: attributesFilter,
                                      partitionKeyAttributeName: AttributesType.partitionKeyAttributeName,
                                      additionalWhereClause: additionalWhereClause)
-        let executeInput = ExecuteStatementInput(consistentRead: true, nextToken: nextToken, statement: statement)
+        let executeInput = ExecuteStatementInput(consistentRead: self.consistentRead, nextToken: nextToken, statement: statement)
         
         return dynamodb.executeStatement(input: executeInput).flatMapThrowing { executeOutput in
             let nextToken = executeOutput.nextToken

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
@@ -66,7 +66,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
         
         let statement: String = try entryToStatement(entry)
         
-        return BatchStatementRequest(consistentRead: true, statement: statement)
+        // doesn't require read consistency as no items are being read
+        return BatchStatementRequest(consistentRead: false, statement: statement)
     }
 
     private func writeChunkedItems<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>])
@@ -98,7 +99,8 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                                                         existingItem: existing)
                 }
                 
-                return BatchStatementRequest(consistentRead: true, statement: statement)
+                // doesn't require read consistency as no items are being read
+                return BatchStatementRequest(consistentRead: false, statement: statement)
             }
         } catch {
             let promise = self.eventLoop.makePromise(of: Void.self)
@@ -215,13 +217,5 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             
             return errors
         }
-    }
-}
-
-extension BatchStatementError: Hashable {
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.code)
-        hasher.combine(self.message)
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -262,7 +262,9 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
         try await self.dynamodb.shutdown()
     }
     #endif
+}
 
+extension AWSDynamoDBCompositePrimaryKeyTable {
     internal func getInputForInsert<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) throws
         -> DynamoDBModel.PutItemInput {
             let attributes = try getAttributes(forItem: item)
@@ -361,9 +363,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                              key: keyAttributes,
                                              tableName: targetTableName)
     }
-}
 
-extension AWSDynamoDBCompositePrimaryKeyTable {
     public var eventLoop: EventLoop {
         return self.dynamodb.reporting.eventLoop ?? self.dynamodb.eventLoopGroup.next()
     }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -28,12 +28,14 @@ import NIO
 public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPClientCoreInvocationReporting>: DynamoDBCompositePrimaryKeyTable {
     internal let dynamodb: _AWSDynamoDBClient<InvocationReportingType>
     internal let targetTableName: String
+    public let consistentRead: Bool
     internal let logger: Logger
 
     public init(accessKeyId: String, secretAccessKey: String,
                 region: AWSRegion, reporting: InvocationReportingType,
                 endpointHostName: String, endpointPort: Int = 443,
                 requiresTLS: Bool? = nil, tableName: String,
+                consistentRead: Bool = true,
                 connectionTimeoutSeconds: Int64 = 10,
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
@@ -53,6 +55,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                            eventLoopProvider: eventLoopProvider,
                                            reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
+        self.consistentRead = consistentRead
 
         self.logger.trace("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
@@ -61,6 +64,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 region: AWSRegion, reporting: InvocationReportingType,
                 endpointHostName: String, endpointPort: Int = 443,
                 requiresTLS: Bool? = nil, tableName: String,
+                consistentRead: Bool = true,
                 connectionTimeoutSeconds: Int64 = 10,
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
@@ -76,6 +80,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                            eventLoopProvider: eventLoopProvider,
                                            reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
+        self.consistentRead = consistentRead
 
         self.logger.trace("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
@@ -83,11 +88,13 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     public init(config: AWSGenericDynamoDBClientConfiguration<InvocationReportingType>,
                 reporting: InvocationReportingType,
                 tableName: String,
+                consistentRead: Bool = true,
                 httpClient: HTTPOperationsClient? = nil) {
         self.logger = reporting.logger
         self.dynamodb = config.createAWSClient(reporting: reporting,
                                                httpClientOverride: httpClient)
         self.targetTableName = tableName
+        self.consistentRead = consistentRead
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
         self.logger.trace("AWSDynamoDBTable created with region '\(config.awsRegion)' and hostname: '\(endpointHostName)'")
@@ -98,11 +105,13 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     // the operations client, this generic type can be ignored.
     public init<OperationsClientInvocationReportingType: HTTPClientCoreInvocationReporting>(
                 operationsClient: AWSGenericDynamoDBTableOperationsClient<OperationsClientInvocationReportingType>,
+                consistentRead: Bool = true,
                 reporting: InvocationReportingType) {
         self.logger = reporting.logger
         self.dynamodb = operationsClient.config.createAWSClient(reporting: reporting,
                                                                 httpClientOverride: operationsClient.httpClient)
         self.targetTableName = operationsClient.tableName
+        self.consistentRead = consistentRead
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
         self.logger.trace("AWSDynamoDBTable created with region '\(operationsClient.config.awsRegion)' and hostname: '\(endpointHostName)'")
@@ -111,6 +120,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     public init<TraceContextType: InvocationTraceContext>(
                 config: AWSGenericDynamoDBClientConfiguration<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
                 tableName: String,
+                consistentRead: Bool = true,
                 logger: Logging.Logger = Logger(label: "AWSDynamoDBTable"),
                 internalRequestId: String = "none",
                 eventLoop: EventLoop? = nil,
@@ -122,6 +132,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                                eventLoopOverride: eventLoop, httpClientOverride: httpClient,
                                                outwardsRequestAggregator: outwardsRequestAggregator)
         self.targetTableName = tableName
+        self.consistentRead = consistentRead
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
         self.logger.trace("AWSDynamoDBTable created with region '\(config.awsRegion)' and hostname: '\(endpointHostName)'")
@@ -130,10 +141,12 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     public convenience init<TraceContextType: InvocationTraceContext, InvocationAttributesType: HTTPClientInvocationAttributes>(
         config: AWSGenericDynamoDBClientConfiguration<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
         tableName: String,
+        consistentRead: Bool = true,
         invocationAttributes: InvocationAttributesType,
         httpClient: HTTPOperationsClient? = nil)
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.init(config: config, tableName: tableName,
+                  consistentRead: consistentRead,
                   logger: invocationAttributes.logger,
                   internalRequestId: invocationAttributes.internalRequestId,
                   eventLoop: !config.ignoreInvocationEventLoop ? invocationAttributes.eventLoop : nil,
@@ -143,6 +156,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     
     public init<TraceContextType: InvocationTraceContext>(
                 operationsClient: AWSGenericDynamoDBTableOperationsClient<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
+                consistentRead: Bool = true,
                 logger: Logging.Logger = Logger(label: "AWSDynamoDBTable"),
                 internalRequestId: String = "none",
                 eventLoop: EventLoop? = nil,
@@ -153,6 +167,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                                                 eventLoopOverride: eventLoop, httpClientOverride: operationsClient.httpClient,
                                                                 outwardsRequestAggregator: outwardsRequestAggregator)
         self.targetTableName = operationsClient.tableName
+        self.consistentRead = consistentRead
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
         self.logger.trace("AWSDynamoDBTable created with region '\(operationsClient.config.awsRegion)' and hostname: '\(endpointHostName)'")
@@ -170,6 +185,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     }
     
     public init(tableName: String,
+                consistentRead: Bool = true,
                 credentialsProvider: CredentialsProvider,
                 awsRegion: AWSRegion,
                 endpointHostName endpointHostNameOptional: String? = nil,
@@ -207,6 +223,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                                eventLoopOverride: nil, httpClientOverride: nil,
                                                outwardsRequestAggregator: outwardsRequestAggregator)
         self.targetTableName = tableName
+        self.consistentRead = consistentRead
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
         self.logger.trace("AWSDynamoDBTable created with region '\(awsRegion)' and hostname: '\(endpointHostName)'")
@@ -214,9 +231,11 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     
     internal init(dynamodb: _AWSDynamoDBClient<InvocationReportingType>,
                   targetTableName: String,
+                  consistentRead: Bool = true,
                   logger: Logger) {
         self.dynamodb = dynamodb
         self.targetTableName = targetTableName
+        self.consistentRead = consistentRead
         self.logger = logger
     }
 
@@ -282,7 +301,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
         let attributeValue = try DynamoDBEncoder().encode(key)
 
         if let keyAttributes = attributeValue.M {
-            return DynamoDBModel.GetItemInput(consistentRead: true,
+            return DynamoDBModel.GetItemInput(consistentRead: self.consistentRead,
                                               key: keyAttributes,
                                               tableName: targetTableName)
         } else {
@@ -302,7 +321,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
             }
         }
 
-        let keysAndAttributes = KeysAndAttributes(consistentRead: true,
+        let keysAndAttributes = KeysAndAttributes(consistentRead: self.consistentRead,
                                                   keys: keys)
         
         return DynamoDBModel.BatchGetItemInput(requestItems: [self.targetTableName: keysAndAttributes])

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
@@ -27,7 +27,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
     -> EventLoopFuture<[ReturnedType]> {
         return query(forPartitionKey: partitionKey,
                      sortKeyCondition: sortKeyCondition,
-                     consistentRead: true)
+                     consistentRead: self.consistentRead)
     }
 
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
@@ -39,7 +39,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                      sortKeyCondition: sortKeyCondition,
                      limit: limit,
                      exclusiveStartKey: exclusiveStartKey,
-                     consistentRead: true)
+                     consistentRead: self.consistentRead)
     }
 
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
@@ -53,7 +53,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                      limit: limit,
                      scanIndexForward: scanIndexForward,
                      exclusiveStartKey: exclusiveStartKey,
-                     consistentRead: true)
+                     consistentRead: self.consistentRead)
     }
 
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
@@ -61,7 +61,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
     -> EventLoopFuture<[TypedDatabaseItem<AttributesType, ItemType>]> {
         return monomorphicQuery(forPartitionKey: partitionKey,
                                 sortKeyCondition: sortKeyCondition,
-                                consistentRead: true)
+                                consistentRead: self.consistentRead)
     }
 
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
@@ -75,7 +75,7 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                 limit: limit,
                                 scanIndexForward: scanIndexForward,
                                 exclusiveStartKey: exclusiveStartKey,
-                                consistentRead: true)
+                                consistentRead: self.consistentRead)
     }
     
 #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -81,6 +81,9 @@ public typealias StandardWriteEntry<ItemType: Codable> = WriteEntry<StandardPrim
 
 public protocol DynamoDBCompositePrimaryKeyTable {
     var eventLoop: EventLoop { get }
+    // This property doesn't really belong on the protocol but provides
+    // access to the property for the protocol's extensions
+    var consistentRead: Bool { get }
 
     /**
      * Insert item is a non-destructive API. If an item already exists with the specified key this
@@ -453,6 +456,14 @@ public protocol DynamoDBCompositePrimaryKeyTable {
         additionalWhereClause: String?, nextToken: String?) async throws -> ([TypedDatabaseItem<AttributesType, ItemType>], String?)
     
 #endif
+}
+
+public extension DynamoDBCompositePrimaryKeyTable {
+    // provide a default value for the table's `consistentRead`
+    // maintains backwards compatibility
+    var consistentRead: Bool {
+        return true
+    }
 }
 
 // For async/await APIs, simply delegate to the EventLoopFuture implementation until support is dropped for Swift <5.5


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add consistentRead as a property on the table. Allows a developer to specify if consistent reads should be used for operations on that table.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
