### PR TITLE
Structured concurrency implementations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "CollectionConcurrencyKit",
+        "repositoryURL": "https://github.com/JohnSundell/CollectionConcurrencyKit",
+        "state": {
+          "branch": null,
+          "revision": "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+          "version": "0.2.0"
+        }
+      },
+      {
         "package": "smoke-aws",
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "7a38547e6ef16b53238ac2b41340cd00c07caa93",
-          "version": "2.15.0"
+          "revision": "1269598dca4f3f2b9e4fff1d99d504fbfadf154e",
+          "version": "2.16.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
         .package(url: "https://github.com/amzn/smoke-http.git", from: "2.16.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
+        .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit", from :"0.2.0")
     ],
     targets: [
         .target(
@@ -39,6 +40,7 @@ let package = Package(
                 .product(name: "DynamoDBClient", package: "smoke-aws"),
                 .product(name: "SmokeHTTPClient", package: "smoke-http"),
                 .product(name: "_SmokeAWSHttpConcurrency", package: "smoke-aws"),
+                .product(name: "CollectionConcurrencyKit", package: "CollectionConcurrencyKit"),
             ]),
         .testTarget(
             name: "SmokeDynamoDBTests", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.42.37"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.14.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.16.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
     ],

--- a/Sources/SmokeDynamoDB/AWSDynamoDBClientConfiguration.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBClientConfiguration.swift
@@ -54,6 +54,7 @@ public struct AWSGenericDynamoDBClientConfiguration<InvocationReportingType: HTT
     public let traceContext: InvocationReportingType.TraceContextType
     public let reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
     public let ignoreInvocationEventLoop: Bool
+    public let enableAHCLogging: Bool
     
     internal let clientDelegate: JSONAWSHttpClientDelegate<DynamoDBError>
     internal let reportingProvider: (Logger, String, EventLoop?, OutwardsRequestAggregator?) -> InvocationReportingType
@@ -75,7 +76,8 @@ public struct AWSGenericDynamoDBClientConfiguration<InvocationReportingType: HTT
         eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
         reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
             = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
-        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil)
+        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil,
+        enableAHCLogging: Bool = false)
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
         
@@ -94,6 +96,7 @@ public struct AWSGenericDynamoDBClientConfiguration<InvocationReportingType: HTT
         self.traceContext = traceContext
         self.timeoutConfiguration = timeoutConfiguration
         self.reportingConfiguration = reportingConfiguration
+        self.enableAHCLogging = enableAHCLogging
                 
         self.reportingProvider = { (logger, internalRequestId, eventLoop, outwardsRequestAggregator) in
             return StandardHTTPClientCoreInvocationReporting(
@@ -120,7 +123,8 @@ public struct AWSGenericDynamoDBClientConfiguration<InvocationReportingType: HTT
         eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
         reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
             = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
-        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil)
+        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil,
+        enableAHCLogging: Bool = false)
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext> {
         self.init(credentialsProvider: credentialsProvider,
                   awsRegion: awsRegion,
@@ -136,7 +140,8 @@ public struct AWSGenericDynamoDBClientConfiguration<InvocationReportingType: HTT
                   retryConfiguration: retryConfiguration,
                   eventLoopProvider: eventLoopProvider,
                   reportingConfiguration: reportingConfiguration,
-                  connectionPoolConfiguration: connectionPoolConfiguration)
+                  connectionPoolConfiguration: connectionPoolConfiguration,
+                  enableAHCLogging: enableAHCLogging)
     }
     
     public func createOperationsClient(forTableName tableName: String)
@@ -153,7 +158,8 @@ public struct AWSGenericDynamoDBClientConfiguration<InvocationReportingType: HTT
             clientDelegate: self.clientDelegate,
             timeoutConfiguration: self.timeoutConfiguration,
             eventLoopProvider: .shared(self.eventLoopGroup),
-            connectionPoolConfiguration: self.connectionPoolConfiguration)
+            connectionPoolConfiguration: self.connectionPoolConfiguration,
+            enableAHCLogging: enableAHCLogging)
     }
     
     internal func createAWSClient(logger: Logger, internalRequestId: String,

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+DynamoDBTableAsync.swift
@@ -406,4 +406,317 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             throw error.asUnrecognizedSmokeDynamoDBError()
         }
     }
+    
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    func insertItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) async throws {
+        let putItemInput = try getInputForInsert(item)
+        
+        try await putItem(forInput: putItemInput, withKey: item.compositePrimaryKey)
+    }
+    
+    func clobberItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) async throws {
+        let attributes = try getAttributes(forItem: item)
+        
+        let putItemInput = DynamoDBModel.PutItemInput(item: attributes,
+                                                      tableName: targetTableName)
+        
+        try await putItem(forInput: putItemInput, withKey: item.compositePrimaryKey)
+    }
+    
+    func updateItem<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                              existingItem: TypedDatabaseItem<AttributesType, ItemType>) async throws {
+        let putItemInput = try getInputForUpdateItem(newItem: newItem, existingItem: existingItem)
+                
+        try await putItem(forInput: putItemInput, withKey: newItem.compositePrimaryKey)
+    }
+    
+    func getItem<AttributesType, ItemType>(forKey key: CompositePrimaryKey<AttributesType>) async throws
+    -> TypedDatabaseItem<AttributesType, ItemType>? {
+        let getItemInput = try getInputForGetItem(forKey: key)
+            
+        self.logger.debug("dynamodb.getItem with key: \(key) and table name \(targetTableName)")
+        
+        do {
+            let attributeValue = try await self.dynamodb.getItem(input: getItemInput)
+            
+            if let item = attributeValue.item {
+                self.logger.debug("Value returned from DynamoDB.")
+                
+                do {
+                    let decodedItem: TypedDatabaseItem<AttributesType, ItemType>? =
+                        try DynamoDBDecoder().decode(DynamoDBModel.AttributeValue(M: item))
+                    return decodedItem
+                } catch {
+                    throw error.asUnrecognizedSmokeDynamoDBError()
+                }
+            } else {
+                self.logger.debug("No item returned from DynamoDB.")
+                
+                return nil
+            }
+        } catch {
+            if let typedError = error as? DynamoDBError {
+                throw typedError.asSmokeDynamoDBError()
+            }
+            
+            throw error.asUnrecognizedSmokeDynamoDBError()
+        }
+    }
+    
+    func deleteItem<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>) async throws {
+        let deleteItemInput = try getInputForDeleteItem(forKey: key)
+        
+        self.logger.debug("dynamodb.deleteItem with key: \(key) and table name \(targetTableName)")
+        _ = try await self.dynamodb.deleteItem(input: deleteItemInput)
+    }
+    
+    func deleteItem<AttributesType, ItemType>(existingItem: TypedDatabaseItem<AttributesType, ItemType>) async throws {
+        let deleteItemInput = try getInputForDeleteItem(existingItem: existingItem)
+        
+        let logMessage = "dynamodb.deleteItem with key: \(existingItem.compositePrimaryKey), "
+            + " version \(existingItem.rowStatus.rowVersion) and table name \(targetTableName)"
+        
+        self.logger.debug("\(logMessage)")
+        _ = try await self.dynamodb.deleteItem(input: deleteItemInput)
+    }
+    
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             consistentRead: Bool) async throws
+    -> [ReturnedType] {
+        return try await partialQuery(forPartitionKey: partitionKey,
+                                      sortKeyCondition: sortKeyCondition,
+                                      exclusiveStartKey: nil,
+                                      consistentRead: consistentRead)
+    }
+    
+    // function to return a future with the results of a query call and all future paginated calls
+    private func partialQuery<ReturnedType: PolymorphicOperationReturnType>(
+            forPartitionKey partitionKey: String,
+            sortKeyCondition: AttributeCondition?,
+            exclusiveStartKey: String?,
+            consistentRead: Bool) async throws -> [ReturnedType] {
+        let paginatedItems: ([ReturnedType], String?) =
+            try await query(forPartitionKey: partitionKey,
+                  sortKeyCondition: sortKeyCondition,
+                  limit: nil,
+                  scanIndexForward: true,
+                  exclusiveStartKey: exclusiveStartKey,
+                  consistentRead: consistentRead)
+        
+        // if there are more items
+        if let lastEvaluatedKey = paginatedItems.1 {
+            // returns a future with all the results from all later paginated calls
+            let partialResult: [ReturnedType] = try await self.partialQuery(
+                forPartitionKey: partitionKey,
+                sortKeyCondition: sortKeyCondition,
+                exclusiveStartKey: lastEvaluatedKey,
+                consistentRead: consistentRead)
+                
+            // return the results from 'this' call and all later paginated calls
+            return paginatedItems.0 + partialResult
+        } else {
+            // this is it, all results have been obtained
+            return paginatedItems.0
+        }
+    }
+    
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             limit: Int?,
+                                                             exclusiveStartKey: String?,
+                                                             consistentRead: Bool) async throws
+    -> ([ReturnedType], String?) {
+        return try await query(forPartitionKey: partitionKey,
+                               sortKeyCondition: sortKeyCondition,
+                               limit: limit,
+                               scanIndexForward: true,
+                               exclusiveStartKey: exclusiveStartKey,
+                               consistentRead: consistentRead)
+    }
+    
+    func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
+                                                             sortKeyCondition: AttributeCondition?,
+                                                             limit: Int?,
+                                                             scanIndexForward: Bool,
+                                                             exclusiveStartKey: String?,
+                                                             consistentRead: Bool) async throws
+    -> ([ReturnedType], String?) {
+        let queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(partitionKey: partitionKey, targetTableName: targetTableName,
+                                                                          primaryKeyType: ReturnedType.AttributesType.self,
+                                                                          sortKeyCondition: sortKeyCondition, limit: limit,
+                                                                          scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                                                                          consistentRead: consistentRead)
+        
+        let logMessage = "dynamodb.query with partitionKey: \(partitionKey), " +
+            "sortKeyCondition: \(sortKeyCondition.debugDescription), and table name \(targetTableName)."
+        self.logger.debug("\(logMessage)")
+        
+        do {
+            let queryOutput = try await self.dynamodb.query(input: queryInput)
+            
+            let lastEvaluatedKey: String?
+            if let returnedLastEvaluatedKey = queryOutput.lastEvaluatedKey {
+                let encodedLastEvaluatedKey: Data
+                
+                do {
+                    encodedLastEvaluatedKey = try JSONEncoder().encode(returnedLastEvaluatedKey)
+                } catch {
+                    throw error.asUnrecognizedSmokeDynamoDBError()
+                }
+                
+                lastEvaluatedKey = String(data: encodedLastEvaluatedKey, encoding: .utf8)
+            } else {
+                lastEvaluatedKey = nil
+            }
+            
+            if let outputAttributeValues = queryOutput.items {
+                let items: [ReturnedType]
+                
+                do {
+                    items = try outputAttributeValues.map { values in
+                        let attributeValue = DynamoDBModel.AttributeValue(M: values)
+                        
+                        let decodedItem: ReturnTypeDecodable<ReturnedType> = try DynamoDBDecoder().decode(attributeValue)
+                                                        
+                        return decodedItem.decodedValue
+                    }
+                } catch {
+                    throw error.asUnrecognizedSmokeDynamoDBError()
+                }
+                
+                return (items, lastEvaluatedKey)
+            } else {
+                return ([], lastEvaluatedKey)
+            }
+        } catch {
+            if let typedError = error as? DynamoDBError {
+                throw typedError.asSmokeDynamoDBError()
+            }
+            
+            throw error.asUnrecognizedSmokeDynamoDBError()
+        }
+    }
+    
+    private func putItem<AttributesType>(forInput putItemInput: DynamoDBModel.PutItemInput,
+                                         withKey compositePrimaryKey: CompositePrimaryKey<AttributesType>) async throws {
+        let logMessage = "dynamodb.putItem with item: \(putItemInput.item) and table name \(targetTableName)."
+        self.logger.debug("\(logMessage)")
+        
+        do {
+            _ = try await self.dynamodb.putItem(input: putItemInput)
+        } catch DynamoDBError.conditionalCheckFailed(let errorPayload) {
+            throw SmokeDynamoDBError.conditionalCheckFailed(partitionKey: compositePrimaryKey.partitionKey,
+                                                            sortKey: compositePrimaryKey.sortKey,
+                                                            message: errorPayload.message)
+        } catch {
+            self.logger.warning("Error from AWSDynamoDBTable: \(error)")
+
+            throw SmokeDynamoDBError.unexpectedError(cause: error)
+        }
+    }
+    
+    func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                    sortKeyCondition: AttributeCondition?,
+                                                    consistentRead: Bool) async throws
+    -> [TypedDatabaseItem<AttributesType, ItemType>] {
+        return try await monomorphicPartialQuery(forPartitionKey: partitionKey,
+                                                 sortKeyCondition: sortKeyCondition,
+                                                 exclusiveStartKey: nil,
+                                                 consistentRead: consistentRead)
+    }
+    
+    // function to return a future with the results of a query call and all future paginated calls
+    private func monomorphicPartialQuery<AttributesType, ItemType>(
+            forPartitionKey partitionKey: String,
+            sortKeyCondition: AttributeCondition?,
+            exclusiveStartKey: String?,
+            consistentRead: Bool) async throws -> [TypedDatabaseItem<AttributesType, ItemType>] {
+        let paginatedItems: ([TypedDatabaseItem<AttributesType, ItemType>], String?) =
+            try await monomorphicQuery(forPartitionKey: partitionKey,
+                                       sortKeyCondition: sortKeyCondition,
+                                       limit: nil,
+                                       scanIndexForward: true,
+                                       exclusiveStartKey: nil,
+                                       consistentRead: consistentRead)
+        
+        // if there are more items
+        if let lastEvaluatedKey = paginatedItems.1 {
+            // returns a future with all the results from all later paginated calls
+            let partialResult: [TypedDatabaseItem<AttributesType, ItemType>] = try await self.monomorphicPartialQuery(
+                forPartitionKey: partitionKey,
+                sortKeyCondition: sortKeyCondition,
+                exclusiveStartKey: lastEvaluatedKey,
+                consistentRead: consistentRead)
+                
+            // return the results from 'this' call and all later paginated calls
+            return paginatedItems.0 + partialResult
+        } else {
+            // this is it, all results have been obtained
+            return paginatedItems.0
+        }
+    }
+    
+    func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
+                                                        sortKeyCondition: AttributeCondition?,
+                                                        limit: Int?,
+                                                        scanIndexForward: Bool,
+                                                        exclusiveStartKey: String?,
+                                                        consistentRead: Bool) async throws
+    -> ([TypedDatabaseItem<AttributesType, ItemType>], String?) {
+        let queryInput = try DynamoDBModel.QueryInput.forSortKeyCondition(
+                partitionKey: partitionKey, targetTableName: targetTableName,
+                primaryKeyType: AttributesType.self,
+                sortKeyCondition: sortKeyCondition, limit: limit,
+                scanIndexForward: scanIndexForward, exclusiveStartKey: exclusiveStartKey,
+                consistentRead: consistentRead)
+        
+        let logMessage = "dynamodb.query with partitionKey: \(partitionKey), " +
+            "sortKeyCondition: \(sortKeyCondition.debugDescription), and table name \(targetTableName)."
+        self.logger.debug("\(logMessage)")
+        
+        do {
+            let queryOutput = try await self.dynamodb.query(input: queryInput)
+            
+            let lastEvaluatedKey: String?
+            if let returnedLastEvaluatedKey = queryOutput.lastEvaluatedKey {
+                let encodedLastEvaluatedKey: Data
+                
+                do {
+                    encodedLastEvaluatedKey = try JSONEncoder().encode(returnedLastEvaluatedKey)
+                } catch {
+                    throw error.asUnrecognizedSmokeDynamoDBError()
+                }
+                
+                lastEvaluatedKey = String(data: encodedLastEvaluatedKey, encoding: .utf8)
+            } else {
+                lastEvaluatedKey = nil
+            }
+            
+            if let outputAttributeValues = queryOutput.items {
+                let items: [TypedDatabaseItem<AttributesType, ItemType>]
+                
+                do {
+                    items = try outputAttributeValues.map { values in
+                        let attributeValue = DynamoDBModel.AttributeValue(M: values)
+                        
+                        return try DynamoDBDecoder().decode(attributeValue)
+                    }
+                } catch {
+                    throw error.asUnrecognizedSmokeDynamoDBError()
+                }
+                
+                return (items, lastEvaluatedKey)
+            } else {
+                return ([], lastEvaluatedKey)
+            }
+        } catch {
+            if let typedError = error as? DynamoDBError {
+                throw typedError.asSmokeDynamoDBError()
+            }
+            
+            throw error.asUnrecognizedSmokeDynamoDBError()
+        }
+    }
+#endif
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+getItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+getItems.swift
@@ -25,6 +25,7 @@ import NIO
 // BatchGetItem has a maximum of 100 of items per request
 // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html
 private let maximumKeysPerGetItemBatch = 100
+private let millisecondsToNanoSeconds: UInt64 = 1000000
 
 /// DynamoDBTable conformance getItems function
 public extension AWSDynamoDBCompositePrimaryKeyTable {
@@ -67,7 +68,7 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                             let decodedItem: ReturnTypeDecodable<ReturnedType> = try DynamoDBDecoder().decode(attributeValue)
                             let decodedValue = decodedItem.decodedValue
                             let key = decodedValue.getItemKey()
-                                                            
+                            
                             self.outputItems[key] = decodedValue
                             return nil
                         } catch {
@@ -163,4 +164,111 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             }
         }
     }
+
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    /**
+     Helper type that manages the state of a getItems request.
+     
+     As suggested here - https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html - this helper type
+     monitors the unprocessed items returned in the response from DynamoDB and uses an exponential backoff algorithm to retry those items using
+     the same retry configuration as the underlying DynamoDB client.
+     */
+    private class GetItemsRetriableAsyncAwait<ReturnedType: PolymorphicOperationReturnType & BatchCapableReturnType> {
+        typealias OutputType = [CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType]
+        
+        let dynamodb: _AWSDynamoDBClient<InvocationReportingType>
+                
+        var retriesRemaining: Int
+        var input: BatchGetItemInput
+        var outputItems: OutputType = [:]
+        
+        init(initialInput: BatchGetItemInput,
+             dynamodb: _AWSDynamoDBClient<InvocationReportingType>) {
+            self.dynamodb = dynamodb
+            self.retriesRemaining = dynamodb.retryConfiguration.numRetries
+            self.input = initialInput
+        }
+        
+        func batchGetItem() async throws -> OutputType {
+            // submit the asynchronous request
+            let output = try await self.dynamodb.batchGetItem(input: self.input)
+            
+            let errors = output.responses?.flatMap({ (tableName, itemList) -> [Error] in
+                return itemList.compactMap { values -> Error? in
+                    do {
+                        let attributeValue = DynamoDBModel.AttributeValue(M: values)
+                        
+                        let decodedItem: ReturnTypeDecodable<ReturnedType> = try DynamoDBDecoder().decode(attributeValue)
+                        let decodedValue = decodedItem.decodedValue
+                        let key = decodedValue.getItemKey()
+                                                        
+                        self.outputItems[key] = decodedValue
+                        return nil
+                    } catch {
+                        return error
+                    }
+                }
+            }) ?? []
+            
+            if !errors.isEmpty {
+                throw SmokeDynamoDBError.multipleUnexpectedErrors(cause: errors)
+            }
+            
+            if let requestItems = output.unprocessedKeys, !requestItems.isEmpty {
+                self.input = BatchGetItemInput(requestItems: requestItems)
+                
+                return try await getMoreResults()
+            }
+            
+            return self.outputItems
+        }
+        
+        func getMoreResults() async throws -> OutputType {
+            let logger = self.dynamodb.reporting.logger
+            
+            // if there are retries remaining
+            if retriesRemaining > 0 {
+                // determine the required interval
+                let retryInterval = Int(self.dynamodb.retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
+                
+                let currentRetriesRemaining = retriesRemaining
+                retriesRemaining -= 1
+                
+                let remainingKeysCount = self.input.requestItems.count
+                
+                logger.warning(
+                    "Request retried for remaining items: \(remainingKeysCount). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
+                try await Task.sleep(nanoseconds: UInt64(retryInterval) * millisecondsToNanoSeconds)
+                
+                logger.debug("Reattempting request due to remaining retries: \(currentRetriesRemaining)")
+                return try await batchGetItem()
+            }
+            
+            throw SmokeDynamoDBError.batchAPIExceededRetries(retryCount: self.dynamodb.retryConfiguration.numRetries)
+        }
+    }
+    
+    func getItems<ReturnedType: PolymorphicOperationReturnType & BatchCapableReturnType>(
+        forKeys keys: [CompositePrimaryKey<ReturnedType.AttributesType>]) async throws
+    -> [CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType] {
+        let chunkedList = keys.chunked(by: maximumKeysPerGetItemBatch)
+        
+        let maps = try await chunkedList.concurrentMap { chunk -> [CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType] in
+            let input = try self.getInputForBatchGetItem(forKeys: chunk)
+            
+            let retriable = GetItemsRetriableAsyncAwait<ReturnedType>(
+                initialInput: input,
+                dynamodb: self.dynamodb)
+            
+            return try await retriable.batchGetItem()
+        }
+        
+        // maps is of type [[CompositePrimaryKey<ReturnedType.AttributesType>: ReturnedType]]
+        // with each map coming from each chunk of the original key list
+        return maps.reduce([:]) { (partialMap, chunkMap) in
+            // reduce the maps from the chunks into a single map
+            return partialMap.merging(chunkMap) { (_, new) in new }
+        }
+    }
+#endif
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+monomorphicGetItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+monomorphicGetItems.swift
@@ -25,6 +25,7 @@ import NIO
 // BatchGetItem has a maximum of 100 of items per request
 // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html
 private let maximumKeysPerGetItemBatch = 100
+private let millisecondsToNanoSeconds: UInt64 = 1000000
 
 /// DynamoDBTable conformance monomorphicGetItems function
 public extension AWSDynamoDBCompositePrimaryKeyTable {
@@ -162,4 +163,110 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
             }
         }
     }
+    
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    /**
+     Helper type that manages the state of a monomorphicGetItems request.
+     
+     As suggested here - https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html - this helper type
+     monitors the unprocessed items returned in the response from DynamoDB and uses an exponential backoff algorithm to retry those items using
+     the same retry configuration as the underlying DynamoDB client.
+     */
+    private class MonomorphicGetItemsRetriableAsyncAwait<AttributesType: PrimaryKeyAttributes, ItemType: Codable> {
+        typealias OutputType = [CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>]
+        
+        let dynamodb: _AWSDynamoDBClient<InvocationReportingType>
+                
+        var retriesRemaining: Int
+        var input: BatchGetItemInput
+        var outputItems: OutputType = [:]
+        
+        init(initialInput: BatchGetItemInput,
+             dynamodb: _AWSDynamoDBClient<InvocationReportingType>) {
+            self.dynamodb = dynamodb
+            self.retriesRemaining = dynamodb.retryConfiguration.numRetries
+            self.input = initialInput
+        }
+        
+        func batchGetItem() async throws -> OutputType {
+            // submit the asynchronous request
+            let output = try await self.dynamodb.batchGetItem(input: self.input)
+            
+            let errors = output.responses?.flatMap({ (tableName, itemList) -> [Error] in
+                return itemList.compactMap { values -> Error? in
+                    do {
+                        let attributeValue = DynamoDBModel.AttributeValue(M: values)
+                        
+                        let decodedValue: TypedDatabaseItem<AttributesType, ItemType> = try DynamoDBDecoder().decode(attributeValue)
+                        let key = decodedValue.compositePrimaryKey
+                                                        
+                        self.outputItems[key] = decodedValue
+                        return nil
+                    } catch {
+                        return error
+                    }
+                }
+            }) ?? []
+            
+            if !errors.isEmpty {
+                throw SmokeDynamoDBError.multipleUnexpectedErrors(cause: errors)
+            }
+            
+            if let requestItems = output.unprocessedKeys, !requestItems.isEmpty {
+                self.input = BatchGetItemInput(requestItems: requestItems)
+                
+                return try await getMoreResults()
+            }
+            
+            return self.outputItems
+        }
+        
+        func getMoreResults() async throws -> OutputType {
+            let logger = self.dynamodb.reporting.logger
+            
+            // if there are retries remaining
+            if retriesRemaining > 0 {
+                // determine the required interval
+                let retryInterval = Int(self.dynamodb.retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
+                
+                let currentRetriesRemaining = retriesRemaining
+                retriesRemaining -= 1
+                
+                let remainingKeysCount = self.input.requestItems.count
+                
+                logger.warning(
+                    "Request retried for remaining items: \(remainingKeysCount). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
+                try await Task.sleep(nanoseconds: UInt64(retryInterval) * millisecondsToNanoSeconds)
+                
+                logger.debug("Reattempting request due to remaining retries: \(currentRetriesRemaining)")
+                return try await batchGetItem()
+            }
+            
+            throw SmokeDynamoDBError.batchAPIExceededRetries(retryCount: self.dynamodb.retryConfiguration.numRetries)
+        }
+    }
+    
+    func monomorphicGetItems<AttributesType, ItemType>(
+        forKeys keys: [CompositePrimaryKey<AttributesType>]) async throws
+    -> [CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>] {
+        let chunkedList = keys.chunked(by: maximumKeysPerGetItemBatch)
+        
+        let maps = try await chunkedList.concurrentMap { chunk -> [CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>] in
+            let input = try self.getInputForBatchGetItem(forKeys: chunk)
+            
+            let retriable = MonomorphicGetItemsRetriableAsyncAwait<AttributesType, ItemType>(
+                initialInput: input,
+                dynamodb: self.dynamodb)
+            
+            return try await retriable.batchGetItem()
+        }
+        
+        // maps is of type [[CompositePrimaryKey<AttributesType>: TypedDatabaseItem<AttributesType, ItemType>]]
+        // with each map coming from each chunk of the original key list
+        return maps.reduce([:]) { (partialMap, chunkMap) in
+            // reduce the maps from the chunks into a single map
+            return partialMap.merging(chunkMap) { (_, new) in new }
+        }
+    }
+#endif
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBTableOperationsClient.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBTableOperationsClient.swift
@@ -46,7 +46,8 @@ public struct AWSGenericDynamoDBTableOperationsClient<InvocationReportingType: H
         eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
         reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
             = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
-        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil)
+        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil,
+        enableAHCLogging: Bool = false)
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.config = AWSGenericDynamoDBClientConfiguration(
             credentialsProvider: credentialsProvider,
@@ -63,7 +64,8 @@ public struct AWSGenericDynamoDBTableOperationsClient<InvocationReportingType: H
             retryConfiguration: retryConfiguration,
             eventLoopProvider: eventLoopProvider,
             reportingConfiguration: reportingConfiguration,
-            connectionPoolConfiguration: connectionPoolConfiguration)
+            connectionPoolConfiguration: connectionPoolConfiguration,
+            enableAHCLogging: enableAHCLogging)
         self.httpClient = self.config.createHTTPOperationsClient()
         self.tableName = tableName
     }
@@ -84,7 +86,8 @@ public struct AWSGenericDynamoDBTableOperationsClient<InvocationReportingType: H
         eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
         reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
             = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
-        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil)
+        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil,
+        enableAHCLogging: Bool = false)
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext> {
         self.init(tableName: tableName,
                   credentialsProvider: credentialsProvider,
@@ -101,7 +104,8 @@ public struct AWSGenericDynamoDBTableOperationsClient<InvocationReportingType: H
                   retryConfiguration: retryConfiguration,
                   eventLoopProvider: eventLoopProvider,
                   reportingConfiguration: reportingConfiguration,
-                  connectionPoolConfiguration: connectionPoolConfiguration)
+                  connectionPoolConfiguration: connectionPoolConfiguration,
+                  enableAHCLogging: enableAHCLogging)
     }
     
     internal init(config: AWSGenericDynamoDBClientConfiguration<InvocationReportingType>,

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+consistentReadQuery.swift
@@ -83,7 +83,8 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                                              sortKeyCondition: AttributeCondition?) async throws
     -> [ReturnedType] {
         return try await query(forPartitionKey: partitionKey,
-                               sortKeyCondition: sortKeyCondition).get()
+                               sortKeyCondition: sortKeyCondition,
+                               consistentRead: self.consistentRead)
     }
     
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
@@ -94,7 +95,8 @@ public extension DynamoDBCompositePrimaryKeyTable {
         return try await query(forPartitionKey: partitionKey,
                                sortKeyCondition: sortKeyCondition,
                                limit: limit,
-                               exclusiveStartKey: exclusiveStartKey).get()
+                               exclusiveStartKey: exclusiveStartKey,
+                               consistentRead: self.consistentRead)
     }
     
     func query<ReturnedType: PolymorphicOperationReturnType>(forPartitionKey partitionKey: String,
@@ -107,14 +109,16 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                sortKeyCondition: sortKeyCondition,
                                limit: limit,
                                scanIndexForward: scanIndexForward,
-                               exclusiveStartKey: exclusiveStartKey).get()
+                               exclusiveStartKey: exclusiveStartKey,
+                               consistentRead: self.consistentRead)
     }
     
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
                                                     sortKeyCondition: AttributeCondition?) async throws
     -> [TypedDatabaseItem<AttributesType, ItemType>] {
         return try await monomorphicQuery(forPartitionKey: partitionKey,
-                                          sortKeyCondition: sortKeyCondition).get()
+                                          sortKeyCondition: sortKeyCondition,
+                                          consistentRead: self.consistentRead)
     }
     
     func monomorphicQuery<AttributesType, ItemType>(forPartitionKey partitionKey: String,
@@ -127,7 +131,8 @@ public extension DynamoDBCompositePrimaryKeyTable {
                                           sortKeyCondition: sortKeyCondition,
                                           limit: limit,
                                           scanIndexForward: scanIndexForward,
-                                          exclusiveStartKey: exclusiveStartKey).get()
+                                          exclusiveStartKey: exclusiveStartKey,
+                                          consistentRead: self.consistentRead)
     }
 #endif
 }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -635,7 +635,7 @@ internal extension EventLoopFuture {
     /// function and want to get the result of this future.
     @inlinable
     func get() async throws -> Value {
-        return try await withUnsafeThrowingContinuation { cont in
+        return try await withCheckedThrowingContinuation { cont in
             self.whenComplete { result in
                 switch result {
                 case .success(let value):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Back ports the Structured concurrency implementation from `main` for the existing async/await APIs to avoid delegating to the EventLoopFuture APIs. This will allow these APIs to use the async/await based APIs of HTTPOperationsClient. Combined with https://github.com/amzn/smoke-http/pull/114, this will move retries and response decoding to the Swift Concurrency threads.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
