### PR TITLE
Add option to escape single quotes in PartiQL statements

### DIFF
--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -29,6 +29,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     internal let dynamodb: _AWSDynamoDBClient<InvocationReportingType>
     internal let targetTableName: String
     public let consistentRead: Bool
+    public let escapeSingleQuoteInPartiQL: Bool
     internal let logger: Logger
 
     public init(accessKeyId: String, secretAccessKey: String,
@@ -36,6 +37,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 endpointHostName: String, endpointPort: Int = 443,
                 requiresTLS: Bool? = nil, tableName: String,
                 consistentRead: Bool = true,
+                escapeSingleQuoteInPartiQL: Bool = false,
                 connectionTimeoutSeconds: Int64 = 10,
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
@@ -56,6 +58,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                            reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
         self.consistentRead = consistentRead
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
 
         self.logger.trace("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
@@ -65,6 +68,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 endpointHostName: String, endpointPort: Int = 443,
                 requiresTLS: Bool? = nil, tableName: String,
                 consistentRead: Bool = true,
+                escapeSingleQuoteInPartiQL: Bool = false,
                 connectionTimeoutSeconds: Int64 = 10,
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
@@ -81,6 +85,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                            reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
         self.consistentRead = consistentRead
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
 
         self.logger.trace("AWSDynamoDBTable created with region '\(region)' and hostname: '\(endpointHostName)'")
     }
@@ -89,12 +94,14 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 reporting: InvocationReportingType,
                 tableName: String,
                 consistentRead: Bool = true,
+                escapeSingleQuoteInPartiQL: Bool = false,
                 httpClient: HTTPOperationsClient? = nil) {
         self.logger = reporting.logger
         self.dynamodb = config.createAWSClient(reporting: reporting,
                                                httpClientOverride: httpClient)
         self.targetTableName = tableName
         self.consistentRead = consistentRead
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
         self.logger.trace("AWSDynamoDBTable created with region '\(config.awsRegion)' and hostname: '\(endpointHostName)'")
@@ -106,12 +113,14 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     public init<OperationsClientInvocationReportingType: HTTPClientCoreInvocationReporting>(
                 operationsClient: AWSGenericDynamoDBTableOperationsClient<OperationsClientInvocationReportingType>,
                 consistentRead: Bool = true,
+                escapeSingleQuoteInPartiQL: Bool = false,
                 reporting: InvocationReportingType) {
         self.logger = reporting.logger
         self.dynamodb = operationsClient.config.createAWSClient(reporting: reporting,
                                                                 httpClientOverride: operationsClient.httpClient)
         self.targetTableName = operationsClient.tableName
         self.consistentRead = consistentRead
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
         self.logger.trace("AWSDynamoDBTable created with region '\(operationsClient.config.awsRegion)' and hostname: '\(endpointHostName)'")
@@ -121,6 +130,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 config: AWSGenericDynamoDBClientConfiguration<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
                 tableName: String,
                 consistentRead: Bool = true,
+                escapeSingleQuoteInPartiQL: Bool = false,
                 logger: Logging.Logger = Logger(label: "AWSDynamoDBTable"),
                 internalRequestId: String = "none",
                 eventLoop: EventLoop? = nil,
@@ -133,6 +143,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                                outwardsRequestAggregator: outwardsRequestAggregator)
         self.targetTableName = tableName
         self.consistentRead = consistentRead
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
         self.logger.trace("AWSDynamoDBTable created with region '\(config.awsRegion)' and hostname: '\(endpointHostName)'")
@@ -142,6 +153,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
         config: AWSGenericDynamoDBClientConfiguration<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
         tableName: String,
         consistentRead: Bool = true,
+        escapeSingleQuoteInPartiQL: Bool = false,
         invocationAttributes: InvocationAttributesType,
         httpClient: HTTPOperationsClient? = nil)
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
@@ -157,6 +169,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     public init<TraceContextType: InvocationTraceContext>(
                 operationsClient: AWSGenericDynamoDBTableOperationsClient<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
                 consistentRead: Bool = true,
+                escapeSingleQuoteInPartiQL: Bool = false,
                 logger: Logging.Logger = Logger(label: "AWSDynamoDBTable"),
                 internalRequestId: String = "none",
                 eventLoop: EventLoop? = nil,
@@ -168,6 +181,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                                                 outwardsRequestAggregator: outwardsRequestAggregator)
         self.targetTableName = operationsClient.tableName
         self.consistentRead = consistentRead
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
         self.logger.trace("AWSDynamoDBTable created with region '\(operationsClient.config.awsRegion)' and hostname: '\(endpointHostName)'")
@@ -176,10 +190,12 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     public convenience init<TraceContextType: InvocationTraceContext, InvocationAttributesType: HTTPClientInvocationAttributes>(
         operationsClient: AWSGenericDynamoDBTableOperationsClient<StandardHTTPClientCoreInvocationReporting<TraceContextType>>,
         consistentRead: Bool = true,
+        escapeSingleQuoteInPartiQL: Bool = false,
         invocationAttributes: InvocationAttributesType)
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.init(operationsClient: operationsClient,
                   consistentRead: consistentRead,
+                  escapeSingleQuoteInPartiQL: escapeSingleQuoteInPartiQL,
                   logger: invocationAttributes.logger,
                   internalRequestId: invocationAttributes.internalRequestId,
                   eventLoop: !operationsClient.config.ignoreInvocationEventLoop ? invocationAttributes.eventLoop : nil,
@@ -188,6 +204,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     
     public init(tableName: String,
                 consistentRead: Bool = true,
+                escapeSingleQuoteInPartiQL: Bool = false,
                 credentialsProvider: CredentialsProvider,
                 awsRegion: AWSRegion,
                 endpointHostName endpointHostNameOptional: String? = nil,
@@ -226,6 +243,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                                                outwardsRequestAggregator: outwardsRequestAggregator)
         self.targetTableName = tableName
         self.consistentRead = consistentRead
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
         
         let endpointHostName = self.dynamodb.httpClient.endpointHostName
         self.logger.trace("AWSDynamoDBTable created with region '\(awsRegion)' and hostname: '\(endpointHostName)'")
@@ -234,10 +252,12 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     internal init(dynamodb: _AWSDynamoDBClient<InvocationReportingType>,
                   targetTableName: String,
                   consistentRead: Bool = true,
+                  escapeSingleQuoteInPartiQL: Bool = false,
                   logger: Logger) {
         self.dynamodb = dynamodb
         self.targetTableName = targetTableName
         self.consistentRead = consistentRead
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
         self.logger = logger
     }
 

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
@@ -28,6 +28,7 @@ import NIO
 public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
     internal let dynamodbGenerator: _AWSDynamoDBClientGenerator
     internal let targetTableName: String
+    internal let escapeSingleQuoteInPartiQL: Bool
 
     public init(accessKeyId: String, secretAccessKey: String,
                 region: AWSRegion,
@@ -37,7 +38,8 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSCore.SmokeAWSClientReportingConfiguration<DynamoDBModel.DynamoDBModelOperations>
-                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>()) {
+                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
+                escapeSingleQuoteInPartiQL: Bool = false) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -51,6 +53,7 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
                                                              eventLoopProvider: eventLoopProvider,
                                                              reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
     }
 
     public init(credentialsProvider: CredentialsProvider,
@@ -61,7 +64,8 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSCore.SmokeAWSClientReportingConfiguration<DynamoDBModel.DynamoDBModelOperations>
-                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>()) {
+                    = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
+                escapeSingleQuoteInPartiQL: Bool = false) {
         self.dynamodbGenerator = _AWSDynamoDBClientGenerator(credentialsProvider: credentialsProvider,
                                                              awsRegion: region,
                                                              endpointHostName: endpointHostName,
@@ -71,6 +75,7 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
                                                              eventLoopProvider: eventLoopProvider,
                                                              reportingConfiguration: reportingConfiguration)
         self.targetTableName = tableName
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
     }
 
     /**
@@ -102,6 +107,7 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
         return AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType>(
             dynamodb: self.dynamodbGenerator.with(reporting: reporting),
             targetTableName: self.targetTableName,
+            escapeSingleQuoteInPartiQL: self.escapeSingleQuoteInPartiQL,
             logger: reporting.logger)
     }
     

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
@@ -285,6 +285,10 @@ extension DynamoDBCompositePrimaryKeyTable {
         return "{\(joinedElements)}"
     }
 
+    /// In PartiQL single quotes indicate start and end of an attribute. If, however,
+    /// the string itself contains a single quote then the database does not know
+    /// where the string should end. Therefore, need to escape single quote by
+    /// doubling it. E.g. 'foo'bar' becomes 'foo''bar'.
     private func sanitizeString(_ string: String) -> String {
         if self.escapeSingleQuoteInPartiQL {
             return string.replacingOccurrences(of: "'", with: "''")

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
@@ -285,10 +285,10 @@ extension DynamoDBCompositePrimaryKeyTable {
         return "{\(joinedElements)}"
     }
 
-    /// In PartiQL single quotes indicate start and end of an attribute. If, however,
-    /// the string itself contains a single quote then the database does not know
-    /// where the string should end. Therefore, need to escape single quote by
-    /// doubling it. E.g. 'foo'bar' becomes 'foo''bar'.
+    /// In PartiQL single quotes indicate start and end of a string attribute.
+    /// If, however, the string itself contains a single quote then the database
+    /// does not know where the string should end. Therefore, need to escape
+    /// single quote by doubling it. E.g. 'foo'bar' becomes 'foo''bar'.
     private func sanitizeString(_ string: String) -> String {
         if self.escapeSingleQuoteInPartiQL {
             return string.replacingOccurrences(of: "'", with: "''")

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
@@ -75,8 +75,8 @@ extension DynamoDBCompositePrimaryKeyTable {
         let combinedElements = elements.joined(separator: " ")
         
         return "UPDATE \"\(tableName)\" \(combinedElements) "
-            + "WHERE \(AttributesType.partitionKeyAttributeName)='\(newItem.compositePrimaryKey.partitionKey)' "
-            + "AND \(AttributesType.sortKeyAttributeName)='\(newItem.compositePrimaryKey.sortKey)' "
+            + "WHERE \(AttributesType.partitionKeyAttributeName)='\(sanitizeString(newItem.compositePrimaryKey.partitionKey))' "
+            + "AND \(AttributesType.sortKeyAttributeName)='\(sanitizeString(newItem.compositePrimaryKey.sortKey))' "
             + "AND \(RowStatus.CodingKeys.rowVersion.rawValue)=\(existingItem.rowStatus.rowVersion)"
     }
     
@@ -92,16 +92,16 @@ extension DynamoDBCompositePrimaryKeyTable {
     func getDeleteExpression<ItemType: DatabaseItem>(tableName: String,
                                                      existingItem: ItemType) throws -> String {
         return "DELETE FROM \"\(tableName)\" "
-            + "WHERE \(ItemType.AttributesType.partitionKeyAttributeName)='\(existingItem.compositePrimaryKey.partitionKey)' "
-            + "AND \(ItemType.AttributesType.sortKeyAttributeName)='\(existingItem.compositePrimaryKey.sortKey)' "
+            + "WHERE \(ItemType.AttributesType.partitionKeyAttributeName)='\(sanitizeString(existingItem.compositePrimaryKey.partitionKey))' "
+            + "AND \(ItemType.AttributesType.sortKeyAttributeName)='\(sanitizeString(existingItem.compositePrimaryKey.sortKey))' "
             + "AND \(RowStatus.CodingKeys.rowVersion.rawValue)=\(existingItem.rowStatus.rowVersion)"
     }
     
     func getDeleteExpression<AttributesType>(tableName: String,
                                              existingKey: CompositePrimaryKey<AttributesType>) throws -> String {
         return "DELETE FROM \"\(tableName)\" "
-            + "WHERE \(AttributesType.partitionKeyAttributeName)='\(existingKey.partitionKey)' "
-            + "AND \(AttributesType.sortKeyAttributeName)='\(existingKey.sortKey)'"
+            + "WHERE \(AttributesType.partitionKeyAttributeName)='\(sanitizeString(existingKey.partitionKey))' "
+            + "AND \(AttributesType.sortKeyAttributeName)='\(sanitizeString(existingKey.sortKey))'"
     }
     
     /*
@@ -143,7 +143,7 @@ extension DynamoDBCompositePrimaryKeyTable {
             return []
         } else if let newTypedAttribute = newAttribute.S, let existingTypedAttribute = existingAttribute.S {
             if newTypedAttribute != existingTypedAttribute {
-                return [.update(path: path, value: "'\(newTypedAttribute)'")]
+                return [.update(path: path, value: "'\(sanitizeString(newTypedAttribute))'")]
             }
         } else if newAttribute.SS != nil || existingAttribute.SS  != nil {
             throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to handle String Set types.")
@@ -255,7 +255,7 @@ extension DynamoDBCompositePrimaryKeyTable {
         } else if attribute.NULL != nil {
             return nil
         } else if let typedAttribute = attribute.S {
-            return "'\(typedAttribute)'"
+            return "'\(sanitizeString(typedAttribute))'"
         } else if attribute.SS != nil {
             throw SmokeDynamoDBError.unableToUpdateError(reason: "Unable to handle String Set types.")
         }
@@ -283,5 +283,13 @@ extension DynamoDBCompositePrimaryKeyTable {
         
         let joinedElements = elements.joined(separator: ", ")
         return "{\(joinedElements)}"
+    }
+
+    private func sanitizeString(_ string: String) -> String {
+        if self.escapeSingleQuoteInPartiQL {
+            return string.replacingOccurrences(of: "'", with: "''")
+        } else {
+            return string
+        }
     }
 }

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -86,6 +86,12 @@ public protocol DynamoDBCompositePrimaryKeyTable {
     var consistentRead: Bool { get }
 
     /**
+     * PartiQL string attributes cannot contain single quotes. Otherwise, PartiQL statement is consider to be invalid.
+     * This property controls if single quotes are escaped while formatting PartiQL statements.
+     */
+    var escapeSingleQuoteInPartiQL: Bool { get }
+
+    /**
      * Insert item is a non-destructive API. If an item already exists with the specified key this
      * API should fail.
      */
@@ -463,6 +469,12 @@ public extension DynamoDBCompositePrimaryKeyTable {
     // maintains backwards compatibility
     var consistentRead: Bool {
         return true
+    }
+
+    // provide a default value for the table's `escapeSingleQuoteInPartiQL`
+    // maintains backwards compatibility
+    var escapeSingleQuoteInPartiQL: Bool {
+        return false
     }
 }
 

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTable.swift
@@ -42,6 +42,7 @@ public typealias ExecuteItemFilterType = (String, String, String, PolymorphicOpe
 public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryKeyTable {
 
     public let eventLoop: EventLoop
+    public let escapeSingleQuoteInPartiQL: Bool
     internal let storeWrapper: InMemoryDynamoDBCompositePrimaryKeyTableStore
     
     public var store: [String: [String: PolymorphicOperationReturnTypeConvertable]] {
@@ -53,15 +54,19 @@ public class InMemoryDynamoDBCompositePrimaryKeyTable: DynamoDBCompositePrimaryK
     }
     
     public init(eventLoop: EventLoop,
-                executeItemFilter: ExecuteItemFilterType? = nil) {
+                executeItemFilter: ExecuteItemFilterType? = nil,
+                escapeSingleQuoteInPartiQL: Bool = false) {
         self.eventLoop = eventLoop
         self.storeWrapper = InMemoryDynamoDBCompositePrimaryKeyTableStore(executeItemFilter: executeItemFilter)
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
     }
     
     internal init(eventLoop: EventLoop,
-                  storeWrapper: InMemoryDynamoDBCompositePrimaryKeyTableStore) {
+                  storeWrapper: InMemoryDynamoDBCompositePrimaryKeyTableStore,
+                  escapeSingleQuoteInPartiQL: Bool = false) {
         self.eventLoop = eventLoop
         self.storeWrapper = storeWrapper
+        self.escapeSingleQuoteInPartiQL = escapeSingleQuoteInPartiQL
     }
     
     public func on(eventLoop: EventLoop) -> InMemoryDynamoDBCompositePrimaryKeyTable {


### PR DESCRIPTION
This update affects monomophicBulkWrite and deleteItems.

*Issue #, if available:*

#68 

*Description of changes:*

Added an option `escapeSingleQuoteInPartiQL` in `AWSDynamoDBCompositePrimaryKeyTableGenerator` and `AWSDynamoDBCompositePrimaryKeyTable` to escape single quotes in generated PartiQL statements. The `escapeSingleQuoteInPartiQL` option is disable by default making this change backwards compatible.

I did have to add `escapeSingleQuoteInPartiQL` to the `DynamoDBCompositePrimaryKeyTable` protocol because PartiQL methods are an extension of the protocol.

The single quotes will optionally be replaced in `monomophicBulkWrite` and `deleteItems` for

* Partition keys
* Sort keys
* New and updated "S" items.

I added new unit tests to cover conditions where escaping single quotes is enabled.

I tested `monomophicBulkWrite` and `deleteItems` with DynamoDB service. Sample code:

```
    func test() async throws {
        let theStruct = TestTypeA(firstly: "f'irstly", secondly: "s'econdly")
        let payloadA = TestTypeC(theString: "fi''rstly", theNumber: 4, theStruct: theStruct,
                                 theList: ["thirdl'y", "fourt''hly"])
        let payloadB = TestTypeC(theString: "fi''rstly", theNumber: 4, theStruct: theStruct,
                                 theList: ["thirdl'y", "eigth''ly", "n'inthly", "tenth'''ly"])

        let compositeKey = StandardCompositePrimaryKey(partitionKey: "pa'rtition''Key",
                                                       sortKey: "so'rt''Key")
        let databaseItemA = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadA)
        let databaseItemB = TypedDatabaseItem.newItem(withKey: compositeKey, andValue: payloadB)

        // Test 1 - insert
        //let entries = [WriteEntry.insert(new: databaseItemA)]
        //try await self.dynamodbTable.monomorphicBulkWrite(entries)

        // Test 2 - update
        //let entries = [WriteEntry.update(new: databaseItemB, existing: databaseItemA)]

        // Test 3 - delete by item
        //let entries = [WriteEntry.deleteItem(existing: databaseItemB)]
        //try await self.dynamodbTable.monomorphicBulkWrite(entries)

        // Test 3.a - delete by item
        //try await self.dynamodbTable.deleteItems(existingItems: [databaseItemA])

        // Test 4 - delete by key
        //let entries: [WriteEntry<StandardPrimaryKeyAttributes, TestTypeC>] = [WriteEntry.deleteAtKey(key: compositeKey)]
        //try await self.dynamodbTable.deleteItems(existingItems: [databaseItemA])

        // Test 4.a - delete by key
        //try await self.dynamodbTable.deleteItems(forKeys: [compositeKey])
    }
```

Example of initialization:

```
        self.dynamodbTableGenerator = AWSDynamoDBCompositePrimaryKeyTableGenerator(credentialsProvider: credentialsProvider,
                                                                                   region: region,
                                                                                   endpointHostName: dynamodbEndpointHostName,
                                                                                   tableName: dynamodbTableName,
                                                                                   eventLoopProvider: .shared(eventLoopGroup),
                                                                                   escapeSingleQuoteInPartiQL: true) // NEW
        self.dynamodbTable = self.dynamodbTableGenerator.with(logger: logger)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
