### PR TITLE
Add an optional compositePrimaryKey property to transaction protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,35 @@ let constraintList: [TestPolymorphicTransactionConstraintEntry] = [
 try await table.transactWrite(entryList, constraints: constraintList)
 ```
 
+Both the `PolymorphicWriteEntry` and `PolymorphicTransactionConstraintEntry` conforming types can
+optionally provide a `compositePrimaryKey` property that will allow the API to return more information
+about failed transactions.
+
+```swift
+enum TestPolymorphicWriteEntry: PolymorphicWriteEntry {
+    case testTypeA(TestTypeAWriteEntry)
+    case testTypeB(TestTypeBWriteEntry)
+
+    func handle<Context: PolymorphicWriteEntryContext>(context: Context) throws -> Context.WriteEntryTransformType {
+        switch self {
+        case .testTypeA(let writeEntry):
+            return try context.transform(writeEntry)
+        case .testTypeB(let writeEntry):
+            return try context.transform(writeEntry)
+        }
+    }
+    
+    var compositePrimaryKey: StandardCompositePrimaryKey? {
+        switch self {
+        case .testTypeA(let writeEntry):
+            return writeEntry.compositePrimaryKey
+        case .testTypeA(let writeEntry):
+            return writeEntry.compositePrimaryKey
+        }
+    }
+}
+```
+
 ## Recording updates in a historical partition
 
 This package contains a number of convenience functions for storing versions of a row in a historical partition

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
@@ -320,21 +320,19 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                     key = nil
                 }
                 
+                let partitionKey = key?.partitionKey ?? entryKey?.partitionKey
+                let sortKey = key?.sortKey ?? entryKey?.sortKey
+                
                 // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteTransaction.html
                 switch cancellationReason.code {
                 case "None":
                     return nil
                 case "ConditionalCheckFailed":
-                    if let key = key {
-                        return SmokeDynamoDBError.conditionalCheckFailed(partitionKey: key.partitionKey,
-                                                                         sortKey: key.sortKey,
-                                                                         message: cancellationReason.message)
-                    } else {
-                        return SmokeDynamoDBError.transactionUnknown(code: cancellationReason.code, partitionKey: entryKey?.partitionKey,
-                                                                     sortKey: entryKey?.partitionKey, message: cancellationReason.message)
-                    }
+                    return SmokeDynamoDBError.conditionalCheckFailed(partitionKey: partitionKey ?? "Not provided",
+                                                                     sortKey: sortKey ?? "Not provided",
+                                                                     message: cancellationReason.message)
                 case "DuplicateItem":
-                    return SmokeDynamoDBError.duplicateItem(partitionKey: key?.partitionKey, sortKey: key?.sortKey,
+                    return SmokeDynamoDBError.duplicateItem(partitionKey: partitionKey, sortKey: sortKey,
                                                             message: cancellationReason.message)
                 case "ItemCollectionSizeLimitExceeded":
                     return SmokeDynamoDBError.transactionSizeExceeded(attemptedSize: entryCount,
@@ -347,11 +345,11 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
                 case "ThrottlingError":
                     return SmokeDynamoDBError.transactionThrottling(message: cancellationReason.message)
                 case "ValidationError":
-                    return SmokeDynamoDBError.transactionValidation(partitionKey: entryKey?.partitionKey, sortKey: entryKey?.sortKey,
+                    return SmokeDynamoDBError.transactionValidation(partitionKey: partitionKey, sortKey: sortKey,
                                                                     message: cancellationReason.message)
                 default:
-                    return SmokeDynamoDBError.transactionUnknown(code: cancellationReason.code, partitionKey: entryKey?.partitionKey,
-                                                                 sortKey: entryKey?.sortKey,message: cancellationReason.message)
+                    return SmokeDynamoDBError.transactionUnknown(code: cancellationReason.code, partitionKey: partitionKey,
+                                                                 sortKey: sortKey,message: cancellationReason.message)
                 }
             }
             

--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -44,6 +44,7 @@ public enum SmokeDynamoDBError: Error {
     case transactionConflict(message: String?)
     case transactionProvisionedThroughputExceeded(message: String?)
     case transactionThrottling(message: String?)
+    case transactionConditionalCheckFailed(partitionKey: String?, sortKey: String?, message: String?)
     case transactionValidation(partitionKey: String?, sortKey: String?, message: String?)
     case transactionUnknown(code: String?, partitionKey: String?, sortKey: String?, message: String?)
     case transactionCanceled(reasons: [SmokeDynamoDBError])

--- a/Sources/SmokeDynamoDB/PolymorphicWriteEntry.swift
+++ b/Sources/SmokeDynamoDB/PolymorphicWriteEntry.swift
@@ -18,7 +18,7 @@
 import DynamoDBModel
 
 // Conforming types are provided by the Table implementation to convert a `WriteEntry` into
-//something the table can use to perform the write.
+// something the table can use to perform the write.
 public protocol PolymorphicWriteEntryTransform {
     associatedtype TableType
 
@@ -26,7 +26,7 @@ public protocol PolymorphicWriteEntryTransform {
 }
 
 // Conforming types are provided by the Table implementation to convert a `WriteEntry` into
-//something the table can use to achieve the constraint.
+// something the table can use to achieve the constraint.
 public protocol PolymorphicTransactionConstraintTransform {
     associatedtype TableType
     
@@ -75,7 +75,7 @@ public struct EmptyPolymorphicTransactionConstraintEntry: PolymorphicTransaction
     }
 }
 
-// Helper Context type that enables transforming Write Entries into the to the table-provided transform type.
+// Helper Context type that enables transforming Write Entries into the table-provided transform type.
 public protocol PolymorphicWriteEntryContext {
     associatedtype WriteEntryTransformType: PolymorphicWriteEntryTransform
     associatedtype WriteTransactionConstraintType: PolymorphicTransactionConstraintTransform

--- a/Sources/SmokeDynamoDB/PolymorphicWriteEntry.swift
+++ b/Sources/SmokeDynamoDB/PolymorphicWriteEntry.swift
@@ -17,21 +17,35 @@
 
 import DynamoDBModel
 
+// Conforming types are provided by the Table implementation to convert a `WriteEntry` into
+//something the table can use to perform the write.
 public protocol PolymorphicWriteEntryTransform {
     associatedtype TableType
 
     init<AttributesType: PrimaryKeyAttributes, ItemType: Codable>(_ entry: WriteEntry<AttributesType, ItemType>, table: TableType) throws
 }
 
+// Conforming types are provided by the Table implementation to convert a `WriteEntry` into
+//something the table can use to achieve the constraint.
 public protocol PolymorphicTransactionConstraintTransform {
     associatedtype TableType
     
     init<AttributesType: PrimaryKeyAttributes, ItemType: Codable>(_ entry: TransactionConstraintEntry<AttributesType, ItemType>, table: TableType) throws
 }
 
+// Conforming types are provided by the application to express the different possible write entries
+// and how they can be converted to the table-provided transform type.
 public protocol PolymorphicWriteEntry {
 
     func handle<Context: PolymorphicWriteEntryContext>(context: Context) throws -> Context.WriteEntryTransformType
+    
+    var compositePrimaryKey: StandardCompositePrimaryKey? { get }
+}
+
+public extension PolymorphicWriteEntry {
+    var compositePrimaryKey: StandardCompositePrimaryKey? {
+        return nil
+    }
 }
 
 public typealias StandardTransactionConstraintEntry<ItemType: Codable> = TransactionConstraintEntry<StandardPrimaryKeyAttributes, ItemType>
@@ -40,9 +54,19 @@ public enum TransactionConstraintEntry<AttributesType: PrimaryKeyAttributes, Ite
     case required(existing: TypedDatabaseItem<AttributesType, ItemType>)
 }
 
+// Conforming types are provided by the application to express the different possible constraint entries
+// and how they can be converted to the table-provided transform type.
 public protocol PolymorphicTransactionConstraintEntry {
 
     func handle<Context: PolymorphicWriteEntryContext>(context: Context) throws -> Context.WriteTransactionConstraintType
+    
+    var compositePrimaryKey: StandardCompositePrimaryKey? { get }
+}
+
+public extension PolymorphicTransactionConstraintEntry {
+    var compositePrimaryKey: StandardCompositePrimaryKey? {
+        return nil
+    }
 }
 
 public struct EmptyPolymorphicTransactionConstraintEntry: PolymorphicTransactionConstraintEntry {
@@ -51,6 +75,7 @@ public struct EmptyPolymorphicTransactionConstraintEntry: PolymorphicTransaction
     }
 }
 
+// Helper Context type that enables transforming Write Entries into the to the table-provided transform type.
 public protocol PolymorphicWriteEntryContext {
     associatedtype WriteEntryTransformType: PolymorphicWriteEntryTransform
     associatedtype WriteTransactionConstraintType: PolymorphicTransactionConstraintTransform


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add an optional compositePrimaryKey property to transaction protocols. When provided this will allow error reasons to be matched with the corresponding compositePrimaryKey (such as for DuplicateItem).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
