### PR TITLE
Retry transactions on conflict

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,7 +31,7 @@ jobs:
         swift: ["5.6.3", "5.5.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.20.0
+      - uses: swift-actions/setup-swift@v1.22.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        swift: ["5.7.1"]
+        swift: ["5.7.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.20.0
+      - uses: swift-actions/setup-swift@v1.22.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable+updateItems.swift
@@ -295,13 +295,15 @@ public extension AWSDynamoDBCompositePrimaryKeyTable {
     
     func transactWrite<WriteEntryType: PolymorphicWriteEntry>(_ entries: [WriteEntryType]) async throws {
         let noConstraints: [EmptyPolymorphicTransactionConstraintEntry] = []
-        return try await transactWrite(entries, constraints: noConstraints)
+        return try await transactWrite(entries, constraints: noConstraints,
+                                       retriesRemaining: self.dynamodb.retryConfiguration.numRetries)
     }
     
     func transactWrite<WriteEntryType: PolymorphicWriteEntry,
                        TransactionConstraintEntryType: PolymorphicTransactionConstraintEntry>(
                         _ entries: [WriteEntryType], constraints: [TransactionConstraintEntryType]) async throws {
-        return try await transactWrite(entries, constraints: constraints, retriesRemaining: dynamodb.retryConfiguration.numRetries)
+        return try await transactWrite(entries, constraints: constraints,
+                                       retriesRemaining: self.dynamodb.retryConfiguration.numRetries)
     }
     
     private func transactWrite<WriteEntryType: PolymorphicWriteEntry,

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTable.swift
@@ -26,7 +26,7 @@ import AsyncHTTPClient
 import NIO
 import Metrics
 
-public struct TableMetrics {
+public struct AWSDynamoDBTableMetrics {
     // metric to record if the `TransactWrite` API is retried
     let transactWriteRetryCountRecorder: Metrics.Recorder?
     
@@ -40,7 +40,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
     internal let targetTableName: String
     public let consistentRead: Bool
     public let escapeSingleQuoteInPartiQL: Bool
-    public let tableMetrics: TableMetrics
+    public let tableMetrics: AWSDynamoDBTableMetrics
     internal let logger: Logger
 
     public init(accessKeyId: String, secretAccessKey: String,
@@ -54,7 +54,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSCore.SmokeAWSClientReportingConfiguration<DynamoDBModel.DynamoDBModelOperations>
                     = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
-                tableMetrics: TableMetrics = .init()) {
+                tableMetrics: AWSDynamoDBTableMetrics = .init()) {
         let staticCredentials = StaticCredentials(accessKeyId: accessKeyId,
                                                   secretAccessKey: secretAccessKey,
                                                   sessionToken: nil)
@@ -87,7 +87,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSCore.SmokeAWSClientReportingConfiguration<DynamoDBModel.DynamoDBModelOperations>
                     = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>(),
-                tableMetrics: TableMetrics = .init()) {
+                tableMetrics: AWSDynamoDBTableMetrics = .init()) {
         self.logger = reporting.logger
         self.dynamodb = _AWSDynamoDBClient(credentialsProvider: credentialsProvider,
                                            awsRegion: region, reporting: reporting,
@@ -111,7 +111,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 consistentRead: Bool = true,
                 escapeSingleQuoteInPartiQL: Bool = false,
                 httpClient: HTTPOperationsClient? = nil,
-                tableMetrics: TableMetrics = .init()) {
+                tableMetrics: AWSDynamoDBTableMetrics = .init()) {
         self.logger = reporting.logger
         self.dynamodb = config.createAWSClient(reporting: reporting,
                                                httpClientOverride: httpClient)
@@ -132,7 +132,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 consistentRead: Bool = true,
                 escapeSingleQuoteInPartiQL: Bool = false,
                 reporting: InvocationReportingType,
-                tableMetrics: TableMetrics = .init()) {
+                tableMetrics: AWSDynamoDBTableMetrics = .init()) {
         self.logger = reporting.logger
         self.dynamodb = operationsClient.config.createAWSClient(reporting: reporting,
                                                                 httpClientOverride: operationsClient.httpClient)
@@ -155,7 +155,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 eventLoop: EventLoop? = nil,
                 httpClient: HTTPOperationsClient? = nil,
                 outwardsRequestAggregator: OutwardsRequestAggregator? = nil,
-                tableMetrics: TableMetrics = .init())
+                tableMetrics: AWSDynamoDBTableMetrics = .init())
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.logger = logger
         self.dynamodb = config.createAWSClient(logger: logger, internalRequestId: internalRequestId,
@@ -177,7 +177,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
         escapeSingleQuoteInPartiQL: Bool = false,
         invocationAttributes: InvocationAttributesType,
         httpClient: HTTPOperationsClient? = nil,
-        tableMetrics: TableMetrics = .init())
+        tableMetrics: AWSDynamoDBTableMetrics = .init())
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.init(config: config, tableName: tableName,
                   consistentRead: consistentRead,
@@ -197,7 +197,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 internalRequestId: String = "none",
                 eventLoop: EventLoop? = nil,
                 outwardsRequestAggregator: OutwardsRequestAggregator? = nil,
-                tableMetrics: TableMetrics = .init())
+                tableMetrics: AWSDynamoDBTableMetrics = .init())
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.logger = logger
         self.dynamodb = operationsClient.config.createAWSClient(logger: logger, internalRequestId: internalRequestId,
@@ -217,7 +217,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
         consistentRead: Bool = true,
         escapeSingleQuoteInPartiQL: Bool = false,
         invocationAttributes: InvocationAttributesType,
-        tableMetrics: TableMetrics = .init())
+        tableMetrics: AWSDynamoDBTableMetrics = .init())
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<TraceContextType> {
         self.init(operationsClient: operationsClient,
                   consistentRead: consistentRead,
@@ -249,7 +249,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                 logger: Logging.Logger = Logger(label: "AWSDynamoDBTable"),
                 internalRequestId: String = "none",
                 outwardsRequestAggregator: OutwardsRequestAggregator? = nil,
-                tableMetrics: TableMetrics = .init())
+                tableMetrics: AWSDynamoDBTableMetrics = .init())
     where InvocationReportingType == StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext> {
         let config = AWSGenericDynamoDBClientConfiguration(
             credentialsProvider: credentialsProvider,
@@ -283,7 +283,7 @@ public class AWSDynamoDBCompositePrimaryKeyTable<InvocationReportingType: HTTPCl
                   consistentRead: Bool = true,
                   escapeSingleQuoteInPartiQL: Bool = false,
                   logger: Logger,
-                  tableMetrics: TableMetrics = .init()) {
+                  tableMetrics: AWSDynamoDBTableMetrics = .init()) {
         self.dynamodb = dynamodb
         self.targetTableName = targetTableName
         self.consistentRead = consistentRead

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
@@ -103,38 +103,42 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
     #endif
     
     public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(
-            reporting: NewInvocationReportingType) -> AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType> {
+            reporting: NewInvocationReportingType,
+            tableMetrics: TableMetrics = .init()) -> AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType> {
         return AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType>(
             dynamodb: self.dynamodbGenerator.with(reporting: reporting),
             targetTableName: self.targetTableName,
             escapeSingleQuoteInPartiQL: self.escapeSingleQuoteInPartiQL,
-            logger: reporting.logger)
+            logger: reporting.logger,
+            tableMetrics: tableMetrics)
     }
     
     public func with<NewTraceContextType: InvocationTraceContext>(
             logger: Logging.Logger,
             internalRequestId: String = "none",
             traceContext: NewTraceContextType,
-            eventLoop: EventLoop? = nil) -> AWSDynamoDBCompositePrimaryKeyTable<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
+            eventLoop: EventLoop? = nil,
+            tableMetrics: TableMetrics = .init()) -> AWSDynamoDBCompositePrimaryKeyTable<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
         let reporting = StandardHTTPClientCoreInvocationReporting(
             logger: logger,
             internalRequestId: internalRequestId,
             traceContext: traceContext,
             eventLoop: eventLoop)
 
-        return with(reporting: reporting)
+        return with(reporting: reporting, tableMetrics: tableMetrics)
     }
 
     public func with(
             logger: Logging.Logger,
             internalRequestId: String = "none",
-            eventLoop: EventLoop? = nil) -> AWSDynamoDBCompositePrimaryKeyTable<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>> {
+            eventLoop: EventLoop? = nil,
+            tableMetrics: TableMetrics = .init()) -> AWSDynamoDBCompositePrimaryKeyTable<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>> {
         let reporting = StandardHTTPClientCoreInvocationReporting(
             logger: logger,
             internalRequestId: internalRequestId,
             traceContext: AWSClientInvocationTraceContext(),
             eventLoop: eventLoop)
 
-        return with(reporting: reporting)
+        return with(reporting: reporting, tableMetrics: tableMetrics)
     }
 }

--- a/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
+++ b/Sources/SmokeDynamoDB/AWSDynamoDBCompositePrimaryKeyTableGenerator.swift
@@ -104,7 +104,8 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
     
     public func with<NewInvocationReportingType: HTTPClientCoreInvocationReporting>(
             reporting: NewInvocationReportingType,
-            tableMetrics: TableMetrics = .init()) -> AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType> {
+            tableMetrics: AWSDynamoDBTableMetrics = .init())
+    -> AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType> {
         return AWSDynamoDBCompositePrimaryKeyTable<NewInvocationReportingType>(
             dynamodb: self.dynamodbGenerator.with(reporting: reporting),
             targetTableName: self.targetTableName,
@@ -118,7 +119,8 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
             internalRequestId: String = "none",
             traceContext: NewTraceContextType,
             eventLoop: EventLoop? = nil,
-            tableMetrics: TableMetrics = .init()) -> AWSDynamoDBCompositePrimaryKeyTable<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
+            tableMetrics: AWSDynamoDBTableMetrics = .init())
+    -> AWSDynamoDBCompositePrimaryKeyTable<StandardHTTPClientCoreInvocationReporting<NewTraceContextType>> {
         let reporting = StandardHTTPClientCoreInvocationReporting(
             logger: logger,
             internalRequestId: internalRequestId,
@@ -132,7 +134,8 @@ public class AWSDynamoDBCompositePrimaryKeyTableGenerator {
             logger: Logging.Logger,
             internalRequestId: String = "none",
             eventLoop: EventLoop? = nil,
-            tableMetrics: TableMetrics = .init()) -> AWSDynamoDBCompositePrimaryKeyTable<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>> {
+            tableMetrics: AWSDynamoDBTableMetrics = .init())
+    -> AWSDynamoDBCompositePrimaryKeyTable<StandardHTTPClientCoreInvocationReporting<AWSClientInvocationTraceContext>> {
         let reporting = StandardHTTPClientCoreInvocationReporting(
             logger: logger,
             internalRequestId: internalRequestId,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 

1. Adds the ability to retry with exponential backoff when there is a conflict with a transaction. This will allow the transaction to succeed or fail with another error such as `DuplicateItem`.
2. Adds the ability to optionally provide a `AWSDynamoDBTableMetrics` instance; within this instance a `Metrics.Recorder` can be provided to record the number of retries.

Verified the change with concurrent transactions that attempt to create the same row. As expected, the transaction first fails with a conflict and then fails on the retry with `DuplicateItem`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
