### PR TITLE
InMemory transaction fixes.

### DIFF
--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable.swift
@@ -332,7 +332,7 @@ public protocol DynamoDBCompositePrimaryKeyTable {
     /**
      * Provides the ability to bulk write database rows in a transaction.
      * The transaction will comprise of the write entries specified in `entries`.
-     * The transaction will be cancelled if the contraints specified in `constraints` are not met (for example you can specify that an item
+     * The transaction will be cancelled if the constraints specified in `constraints` are not met (for example you can specify that an item
      * with a specified version must exist regardless of if it will be written to by the transaction).
      * The transaction will fail if the number of entries and constraints combined is greater than 100.
      */

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -21,6 +21,53 @@ import SmokeHTTPClient
 import DynamoDBModel
 import NIO
 
+private let itemAlreadyExistsMessage = "Row already exists."
+
+private struct InMemoryPolymorphicWriteEntryTransform: PolymorphicWriteEntryTransform {
+    typealias TableType = InMemoryDynamoDBCompositePrimaryKeyTableStore
+
+    let operation: () throws -> ()
+
+    init<AttributesType: PrimaryKeyAttributes, ItemType: Codable>(_ entry: WriteEntry<AttributesType, ItemType>, table: TableType) throws {
+        switch entry {
+        case .update(new: let new, existing: let existing):
+            operation = {
+                try table.updateItemInternal(newItem: new, existingItem: existing)
+            }
+        case .insert(new: let new):
+            operation = {
+                try table.insertItemInternal(new)
+            }
+        case .deleteAtKey(key: let key):
+            operation = {
+                table.deleteItemInternal(forKey: key)
+            }
+        case .deleteItem(existing: let existing):
+            operation = {
+                try table.deleteItemInternal(existingItem: existing)
+            }
+        }
+    }
+}
+
+private struct InMemoryPolymorphicTransactionConstraintTransform: PolymorphicTransactionConstraintTransform {
+    typealias TableType = InMemoryDynamoDBCompositePrimaryKeyTableStore
+    
+    let partitionKey: String
+    let sortKey: String
+    let rowVersion: Int
+    
+    init<AttributesType: PrimaryKeyAttributes, ItemType: Codable>(_ entry: TransactionConstraintEntry<AttributesType, ItemType>,
+                                                                  table: TableType) throws {
+        switch entry {
+        case .required(existing: let existing):
+            self.partitionKey = existing.compositePrimaryKey.partitionKey
+            self.sortKey = existing.compositePrimaryKey.sortKey
+            self.rowVersion = existing.rowStatus.rowVersion
+        }
+    }
+}
+
 internal class InMemoryDynamoDBCompositePrimaryKeyTableStore {
     
     internal var store: [String: [String: PolymorphicOperationReturnTypeConvertable]] = [:]
@@ -52,33 +99,38 @@ extension InMemoryDynamoDBCompositePrimaryKeyTableStore {
         let promise = eventLoop.makePromise(of: Void.self)
         
         accessQueue.async {
-            let partition = self.store[item.compositePrimaryKey.partitionKey]
-            
-            // if there is already a partition
-            var updatedPartition: [String: PolymorphicOperationReturnTypeConvertable]
-            if let partition = partition {
-                updatedPartition = partition
-                
-                // if the row already exists
-                if partition[item.compositePrimaryKey.sortKey] != nil {
-                    let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: item.compositePrimaryKey.partitionKey,
-                                                                          sortKey: item.compositePrimaryKey.sortKey,
-                                                                          message: "Row already exists.")
-                    
-                    promise.fail(error)
-                    return
-                }
-                
-                updatedPartition[item.compositePrimaryKey.sortKey] = item
-            } else {
-                updatedPartition = [item.compositePrimaryKey.sortKey: item]
+            do {
+                try self.insertItemInternal(item)
+                promise.succeed(())
+            } catch {
+                promise.fail(error)
             }
-            
-            self.store[item.compositePrimaryKey.partitionKey] = updatedPartition
-            promise.succeed(())
         }
         
         return promise.futureResult
+    }
+    
+    fileprivate func insertItemInternal<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>) throws {
+        let partition = self.store[item.compositePrimaryKey.partitionKey]
+        
+        // if there is already a partition
+        var updatedPartition: [String: PolymorphicOperationReturnTypeConvertable]
+        if let partition = partition {
+            updatedPartition = partition
+            
+            // if the row already exists
+            if partition[item.compositePrimaryKey.sortKey] != nil {
+                throw SmokeDynamoDBError.conditionalCheckFailed(partitionKey: item.compositePrimaryKey.partitionKey,
+                                                                sortKey: item.compositePrimaryKey.sortKey,
+                                                                message: itemAlreadyExistsMessage)
+            }
+            
+            updatedPartition[item.compositePrimaryKey.sortKey] = item
+        } else {
+            updatedPartition = [item.compositePrimaryKey.sortKey: item]
+        }
+        
+        self.store[item.compositePrimaryKey.partitionKey] = updatedPartition
     }
     
     func clobberItem<AttributesType, ItemType>(_ item: TypedDatabaseItem<AttributesType, ItemType>,
@@ -111,42 +163,141 @@ extension InMemoryDynamoDBCompositePrimaryKeyTableStore {
         let promise = eventLoop.makePromise(of: Void.self)
         
         accessQueue.async {
-            let partition = self.store[newItem.compositePrimaryKey.partitionKey]
+            do {
+                try self.updateItemInternal(newItem: newItem, existingItem: existingItem)
+                promise.succeed(())
+            } catch {
+                promise.fail(error)
+            }
+        }
+        
+        return promise.futureResult
+    }
+    
+    fileprivate func updateItemInternal<AttributesType, ItemType>(newItem: TypedDatabaseItem<AttributesType, ItemType>,
+                                                              existingItem: TypedDatabaseItem<AttributesType, ItemType>) throws {
+        let partition = self.store[newItem.compositePrimaryKey.partitionKey]
+        
+        // if there is already a partition
+        var updatedPartition: [String: PolymorphicOperationReturnTypeConvertable]
+        if let partition = partition {
+            updatedPartition = partition
             
-            // if there is already a partition
-            var updatedPartition: [String: PolymorphicOperationReturnTypeConvertable]
-            if let partition = partition {
-                updatedPartition = partition
-                
-                // if the row already exists
-                if let actuallyExistingItem = partition[newItem.compositePrimaryKey.sortKey] {
-                    if existingItem.rowStatus.rowVersion != actuallyExistingItem.rowStatus.rowVersion ||
-                        existingItem.createDate.iso8601 != actuallyExistingItem.createDate.iso8601 {
-                        let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: newItem.compositePrimaryKey.partitionKey,
-                                                                              sortKey: newItem.compositePrimaryKey.sortKey,
-                                                                              message: "Trying to overwrite incorrect version.")
-                        promise.fail(error)
-                        return
-                    }
-                } else {
-                    let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: newItem.compositePrimaryKey.partitionKey,
-                                                                          sortKey: newItem.compositePrimaryKey.sortKey,
-                                                                          message: "Existing item does not exist.")
-                    promise.fail(error)
-                    return
+            // if the row already exists
+            if let actuallyExistingItem = partition[newItem.compositePrimaryKey.sortKey] {
+                if existingItem.rowStatus.rowVersion != actuallyExistingItem.rowStatus.rowVersion ||
+                    existingItem.createDate.iso8601 != actuallyExistingItem.createDate.iso8601 {
+                    throw SmokeDynamoDBError.conditionalCheckFailed(partitionKey: newItem.compositePrimaryKey.partitionKey,
+                                                                    sortKey: newItem.compositePrimaryKey.sortKey,
+                                                                    message: "Trying to overwrite incorrect version.")
                 }
-                
-                updatedPartition[newItem.compositePrimaryKey.sortKey] = newItem
             } else {
-                let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: newItem.compositePrimaryKey.partitionKey,
-                                                                      sortKey: newItem.compositePrimaryKey.sortKey,
-                                                                      message: "Existing item does not exist.")
+                throw SmokeDynamoDBError.conditionalCheckFailed(partitionKey: newItem.compositePrimaryKey.partitionKey,
+                                                                sortKey: newItem.compositePrimaryKey.sortKey,
+                                                                message: "Existing item does not exist.")
+            }
+            
+            updatedPartition[newItem.compositePrimaryKey.sortKey] = newItem
+        } else {
+            throw SmokeDynamoDBError.conditionalCheckFailed(partitionKey: newItem.compositePrimaryKey.partitionKey,
+                                                            sortKey: newItem.compositePrimaryKey.sortKey,
+                                                            message: "Existing item does not exist.")
+        }
+        
+        self.store[newItem.compositePrimaryKey.partitionKey] = updatedPartition
+    }
+    
+    func bulkWrite<WriteEntryType: PolymorphicWriteEntry,
+                       TransactionConstraintEntryType: PolymorphicTransactionConstraintEntry>(
+                        _ entries: [WriteEntryType], constraints: [TransactionConstraintEntryType],
+                        isTransaction: Bool, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        let promise = eventLoop.makePromise(of: Void.self)
+        
+        accessQueue.async {
+            let entryCount = entries.count + constraints.count
+            let context = StandardPolymorphicWriteEntryContext<InMemoryPolymorphicWriteEntryTransform,
+                                                               InMemoryPolymorphicTransactionConstraintTransform>(table: self)
+                
+            if entryCount > AWSDynamoDBLimits.maximumUpdatesPerTransactionStatement {
+                let error = SmokeDynamoDBError.transactionSizeExceeded(attemptedSize: entryCount,
+                                                                       maximumSize: AWSDynamoDBLimits.maximumUpdatesPerTransactionStatement)
                 promise.fail(error)
                 return
             }
             
-            self.store[newItem.compositePrimaryKey.partitionKey] = updatedPartition
-            promise.succeed(())
+            let store = self.store
+            let errors = constraints.compactMap { entry -> SmokeDynamoDBError? in
+                let transform: InMemoryPolymorphicTransactionConstraintTransform
+                do {
+                    transform = try entry.handle(context: context)
+                } catch {
+                    return SmokeDynamoDBError.unexpectedError(cause: error)
+                }
+                
+                guard let partition = store[transform.partitionKey],
+                        let item = partition[transform.sortKey],
+                            item.rowStatus.rowVersion == transform.rowVersion else {
+                    return SmokeDynamoDBError.conditionalCheckFailed(partitionKey: transform.partitionKey,
+                                                                     sortKey: transform.sortKey,
+                                                                     message: "Item doesn't exist or doesn't have correct version")
+                }
+                
+                return nil
+            }
+            
+            if !errors.isEmpty {
+                let error = SmokeDynamoDBError.transactionCanceled(reasons: errors)
+                
+                promise.fail(error)
+                return
+            }
+            
+            let writeErrors = entries.compactMap { entry -> SmokeDynamoDBError? in
+                let transform: InMemoryPolymorphicWriteEntryTransform
+                do {
+                    transform = try entry.handle(context: context)
+                } catch {
+                    return SmokeDynamoDBError.unexpectedError(cause: error)
+                }
+                
+                do {
+                    try transform.operation()
+                } catch let error {
+                    if let typedError = error as? SmokeDynamoDBError {
+                        if case .conditionalCheckFailed(let partitionKey, let sortKey, let message) = typedError, isTransaction {
+                            if message == itemAlreadyExistsMessage {
+                                return .duplicateItem(partitionKey: partitionKey, sortKey: sortKey, message: message)
+                            } else {
+                                return .transactionConditionalCheckFailed(partitionKey: partitionKey,
+                                                                          sortKey: sortKey, message: message)
+                            }
+                        }
+                        return typedError
+                    }
+                    
+                    // return unexpected error
+                    return SmokeDynamoDBError.unexpectedError(cause: error)
+                }
+                
+                return nil
+            }
+                                        
+            if writeErrors.count > 0 {
+                let error: Swift.Error
+                if isTransaction {
+                    // restore the state prior to the transaction
+                    self.store = store
+                    
+                    error = SmokeDynamoDBError.transactionCanceled(reasons: writeErrors)
+                } else {
+                    error = SmokeDynamoDBError.batchErrorsReturned(errorCount: writeErrors.count, messageMap: [:])
+                }
+                
+                promise.fail(error)
+                return
+            }
+            
+            promise.succeed()
         }
         
         return promise.futureResult
@@ -300,11 +451,15 @@ extension InMemoryDynamoDBCompositePrimaryKeyTableStore {
         let promise = eventLoop.makePromise(of: Void.self)
         
         accessQueue.async {
-            self.store[key.partitionKey]?[key.sortKey] = nil
+            self.deleteItemInternal(forKey: key)
             promise.succeed(())
         }
         
         return promise.futureResult
+    }
+    
+    fileprivate func deleteItemInternal<AttributesType>(forKey key: CompositePrimaryKey<AttributesType>) {
+        self.store[key.partitionKey]?[key.sortKey] = nil
     }
     
     func deleteItem<ItemType: DatabaseItem>(existingItem: ItemType,
@@ -312,48 +467,47 @@ extension InMemoryDynamoDBCompositePrimaryKeyTableStore {
         let promise = eventLoop.makePromise(of: Void.self)
         
         accessQueue.async {
-            let partition = self.store[existingItem.compositePrimaryKey.partitionKey]
-            
-            // if there is already a partition
-            var updatedPartition: [String: PolymorphicOperationReturnTypeConvertable]
-            if let partition = partition {
-                updatedPartition = partition
-                
-                // if the row already exists
-                if let actuallyExistingItem = partition[existingItem.compositePrimaryKey.sortKey] {
-                    if existingItem.rowStatus.rowVersion != actuallyExistingItem.rowStatus.rowVersion ||
-                        existingItem.createDate.iso8601 != actuallyExistingItem.createDate.iso8601 {
-                        let error = SmokeDynamoDBError.conditionalCheckFailed(partitionKey: existingItem.compositePrimaryKey.partitionKey,
-                                                                              sortKey: existingItem.compositePrimaryKey.sortKey,
-                                                                              message: "Trying to delete incorrect version.")
-                        
-                        promise.fail(error)
-                        return
-                    }
-                } else {
-                    let error =  SmokeDynamoDBError.conditionalCheckFailed(partitionKey: existingItem.compositePrimaryKey.partitionKey,
-                                                                           sortKey: existingItem.compositePrimaryKey.sortKey,
-                                                                           message: "Existing item does not exist.")
-                    
-                    promise.fail(error)
-                    return
-                }
-                
-                updatedPartition[existingItem.compositePrimaryKey.sortKey] = nil
-            } else {
-                let error =  SmokeDynamoDBError.conditionalCheckFailed(partitionKey: existingItem.compositePrimaryKey.partitionKey,
-                                                                       sortKey: existingItem.compositePrimaryKey.sortKey,
-                                                                       message: "Existing item does not exist.")
-                
+            do {
+                try self.deleteItemInternal(existingItem: existingItem)
+                promise.succeed(())
+            } catch {
                 promise.fail(error)
-                return
             }
-            
-            self.store[existingItem.compositePrimaryKey.partitionKey] = updatedPartition
-            promise.succeed(())
         }
         
         return promise.futureResult
+    }
+    
+    fileprivate func deleteItemInternal<ItemType: DatabaseItem>(existingItem: ItemType) throws {
+        let partition = self.store[existingItem.compositePrimaryKey.partitionKey]
+        
+        // if there is already a partition
+        var updatedPartition: [String: PolymorphicOperationReturnTypeConvertable]
+        if let partition = partition {
+            updatedPartition = partition
+            
+            // if the row already exists
+            if let actuallyExistingItem = partition[existingItem.compositePrimaryKey.sortKey] {
+                if existingItem.rowStatus.rowVersion != actuallyExistingItem.rowStatus.rowVersion ||
+                    existingItem.createDate.iso8601 != actuallyExistingItem.createDate.iso8601 {
+                    throw SmokeDynamoDBError.conditionalCheckFailed(partitionKey: existingItem.compositePrimaryKey.partitionKey,
+                                                                    sortKey: existingItem.compositePrimaryKey.sortKey,
+                                                                    message: "Trying to delete incorrect version.")
+                }
+            } else {
+                throw SmokeDynamoDBError.conditionalCheckFailed(partitionKey: existingItem.compositePrimaryKey.partitionKey,
+                                                                sortKey: existingItem.compositePrimaryKey.sortKey,
+                                                                message: "Existing item does not exist.")
+            }
+            
+            updatedPartition[existingItem.compositePrimaryKey.sortKey] = nil
+        } else {
+            throw SmokeDynamoDBError.conditionalCheckFailed(partitionKey: existingItem.compositePrimaryKey.partitionKey,
+                                                            sortKey: existingItem.compositePrimaryKey.sortKey,
+                                                            message: "Existing item does not exist.")
+        }
+        
+        self.store[existingItem.compositePrimaryKey.partitionKey] = updatedPartition
     }
     
     func deleteItems<AttributesType>(forKeys keys: [CompositePrimaryKey<AttributesType>],

--- a/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
+++ b/Sources/SmokeDynamoDB/InMemoryDynamoDBCompositePrimaryKeyTableStore.swift
@@ -237,9 +237,15 @@ extension InMemoryDynamoDBCompositePrimaryKeyTableStore {
                 guard let partition = store[transform.partitionKey],
                         let item = partition[transform.sortKey],
                             item.rowStatus.rowVersion == transform.rowVersion else {
-                    return SmokeDynamoDBError.conditionalCheckFailed(partitionKey: transform.partitionKey,
-                                                                     sortKey: transform.sortKey,
-                                                                     message: "Item doesn't exist or doesn't have correct version")
+                    if isTransaction {
+                        return SmokeDynamoDBError.transactionConditionalCheckFailed(partitionKey: transform.partitionKey,
+                                                                                    sortKey: transform.sortKey,
+                                                                                    message: "Item doesn't exist or doesn't have correct version")
+                    } else {
+                        return SmokeDynamoDBError.conditionalCheckFailed(partitionKey: transform.partitionKey,
+                                                                         sortKey: transform.sortKey,
+                                                                         message: "Item doesn't exist or doesn't have correct version")
+                    }
                 }
                 
                 return nil

--- a/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
+++ b/Tests/SmokeDynamoDBTests/InMemoryDynamoDBCompositePrimaryKeyTableTests.swift
@@ -770,6 +770,13 @@ class InMemoryDynamoDBCompositePrimaryKeyTableTests: XCTestCase {
         } catch SmokeDynamoDBError.transactionCanceled(reasons: let reasons) {
             // one required item exists, one already exists
             XCTAssertEqual(1, reasons.count)
+            
+            if let first = reasons.first {
+                guard case .duplicateItem = first else {
+                    XCTFail("Unexpected error")
+                    return
+                }
+            }
         } catch {
             XCTFail()
         }


### PR DESCRIPTION
*Issue #, if available:* #89

*Description of changes:* Fixes to InMemoryDynamoDBCompositePrimaryKeyTable for transactions
1. Perform all updates for the transaction atomically 
2. If the transaction fails, revert the store to its state before the transaction
3. Throw the `DuplicateItem` error reason correctly if a row exists prior to the transaction
4. Throw the `transactionConditionalCheckFailed` correctly if a constraint fails.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
