### PR TITLE
Fix PartiQL for bulk write update statement

### DIFF
--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
@@ -64,11 +64,11 @@ extension DynamoDBCompositePrimaryKeyTable {
         let elements = attributeDifferences.map { attributeDifference -> String in
             switch attributeDifference {
             case .update(path: let path, value: let value):
-                return "SET \"\(path)\"=\(value)"
+                return "SET \(path)=\(value)"
             case .remove(path: let path):
-                return "REMOVE \"\(path)\""
+                return "REMOVE \(path)"
             case .listAppend(path: let path, value: let value):
-                return "SET \"\(path)\"=list_append(\(path),\(value))"
+                return "SET \(path)=list_append(\(path),\(value))"
             }
         }
         
@@ -175,7 +175,7 @@ extension DynamoDBCompositePrimaryKeyTable {
         
         return try (0..<maxIndex).flatMap { index -> [AttributeDifference] in
             let newPath = "\(path)[\(index)]"
-            
+
             // if both new and existing attributes are present
             if index < newAttribute.count && index < existingAttribute.count {
                 return try diffAttribute(path: newPath, newAttribute: newAttribute[index], existingAttribute: existingAttribute[index])
@@ -234,9 +234,9 @@ extension DynamoDBCompositePrimaryKeyTable {
     
     private func combinePath(basePath: String?, newComponent: String) -> String {
         if let basePath = basePath {
-            return "\(basePath).\(newComponent)"
+            return "\(basePath).\"\(newComponent)\""
         } else {
-            return newComponent
+            return "\"\(newComponent)\""
         }
     }
     


### PR DESCRIPTION
*Issue #, if available:*

Issue #84 

*Description of changes:*

Prior to this change the list update statement enclosed into quotations attribute name along with the index. This together meant that the update operation was for a field name that included index literal instead of a particular index inside the list.

After this update, each individual path component is escaped if it appears in a SET/REMOVE statement. Index is not escaped.

Added unit tests to ensure nested lists are handled correctly. Also updated existing  tests.

Also tested with a client:

Testing is done with commit `38634b5f2d5b41659076fbf6714107f2fe68db9c`.

Initial insert:

```
        struct TestStruct: Codable {
            var list: [String]
        }
        typealias TestDatabaseItem = StandardTypedDatabaseItem<TestStruct>
        typealias TestWriteEntry = StandardWriteEntry<TestStruct>
        try await dynamodbTable.monomorphicBulkWrite([
            TestWriteEntry.insert(
                new: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["one", "two"])
                )
            )
        ])
```

```
{
  "PK": {
    "S": "konstantin"
  },
  "SK": {
    "S": "konstantin"
  },
  "CreateDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "LastUpdatedDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "list": {
    "L": [
      {
        "S": "one"
      },
      {
        "S": "two"
      }
    ]
  },
  "RowType": {
    "S": "TestStruct"
  },
  "RowVersion": {
    "N": "1"
  }
}
```

Test for `SET`:

```
        try await dynamodbTable.monomorphicBulkWrite([
            TestWriteEntry.update(
                new: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["four", "two"])),
                existing: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["one", "two"]))
            )
        ])
```

```
{
  "PK": {
    "S": "konstantin"
  },
  "SK": {
    "S": "konstantin"
  },
  "CreateDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "LastUpdatedDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "list": {
    "L": [
      {
        "S": "one"
      },
      {
        "S": "two"
      }
    ]
  },
  "list[0]": {
    "S": "four"
  },
  "RowType": {
    "S": "TestStruct"
  },
  "RowVersion": {
    "N": "1"
  }
}
```

Test for `REMOVE`, the item is unchanged. Second entry is not removed, because I think it was removing "list[1]":

```
        try await dynamodbTable.monomorphicBulkWrite([
            TestWriteEntry.update(
                new: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["one"])),
                existing: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["one", "two"]))
            )
        ])
```

```
{
  "PK": {
    "S": "konstantin"
  },
  "SK": {
    "S": "konstantin"
  },
  "CreateDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "LastUpdatedDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "list": {
    "L": [
      {
        "S": "one"
      },
      {
        "S": "two"
      }
    ]
  },
  "RowType": {
    "S": "TestStruct"
  },
  "RowVersion": {
    "N": "1"
  }
}
```

Test `list_append`, didn't work.

```
        try await dynamodbTable.monomorphicBulkWrite([
            TestWriteEntry.update(
                new: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["one","two","three"])),
                existing: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["one", "two"]))
            )
        ])
```

```
bodyData={
  "Statements" : [
    {
      "ConsistentRead" : true,
      "Statement" : "UPDATE \"<...>\" SET \"list\"=list_append(list,['three']) WHERE PK='konstantin' AND SK='konstantin' AND RowVersion=1"
    }
  ]
}

bodyData={"Responses":[{"Error":{"Code":"ValidationError","Message":"Statement wasn't well formed, can't be processed: Unexpected keyword"}}]}
```

After the update:

Test for `SET`:

```
        try await dynamodbTable.monomorphicBulkWrite([
            TestWriteEntry.update(
                new: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["four", "two"])),
                existing: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["one", "two"]))
            )
        ])
```

```
bodyData={
  "Statements" : [
    {
      "ConsistentRead" : true,
      "Statement" : "UPDATE \"<table name>\" SET \"list\"[0]='four' WHERE PK='konstantin' AND SK='konstantin' AND RowVersion=1"
    }
  ]
}
```

```
{
  "PK": {
    "S": "konstantin"
  },
  "SK": {
    "S": "konstantin"
  },
  "CreateDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "LastUpdatedDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "list": {
    "L": [
      {
        "S": "four"
      },
      {
        "S": "two"
      }
    ]
  },
  "RowType": {
    "S": "TestStruct"
  },
  "RowVersion": {
    "N": "1"
  }
}
```

Test for `REMOVE`:

```
        try await dynamodbTable.monomorphicBulkWrite([
            TestWriteEntry.update(
                new: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["one"])),
                existing: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["one", "two"]))
            )
        ])
```

```
bodyData={
  "Statements" : [
    {
      "ConsistentRead" : true,
      "Statement" : "UPDATE \"<table name>\" REMOVE \"list\"[1] WHERE PK='konstantin' AND SK='konstantin' AND RowVersion=1"
    }
  ]
}
```

```
{
  "PK": {
    "S": "konstantin"
  },
  "SK": {
    "S": "konstantin"
  },
  "CreateDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "LastUpdatedDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "list": {
    "L": [
      {
        "S": "one"
      }
    ]
  },
  "RowType": {
    "S": "TestStruct"
  },
  "RowVersion": {
    "N": "1"
  }
}
```

Test `list_append`.

```
        try await dynamodbTable.monomorphicBulkWrite([
            TestWriteEntry.update(
                new: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["one","two","three"])),
                existing: TestDatabaseItem.newItem(
                    withKey: .init(partitionKey: "konstantin", sortKey: "konstantin"),
                    andValue: TestStruct(list: ["one", "two"]))
            )
        ])
```

```
bodyData={
  "Statements" : [
    {
      "ConsistentRead" : true,
      "Statement" : "UPDATE \"<table name>\" SET \"list\"=list_append(\"list\",['three']) WHERE PK='konstantin' AND SK='konstantin' AND RowVersion=1"
    }
  ]
}
```

```
{
  "PK": {
    "S": "konstantin"
  },
  "SK": {
    "S": "konstantin"
  },
  "CreateDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "LastUpdatedDate": {
    "S": "2023-06-23T19:00:40.244Z"
  },
  "list": {
    "L": [
      {
        "S": "one"
      },
      {
        "S": "two"
      },
      {
        "S": "three"
      }
    ]
  },
  "RowType": {
    "S": "TestStruct"
  },
  "RowVersion": {
    "N": "1"
  }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
