### PR TITLE
Always SET path = newValue instead of listAppend

### DIFF
--- a/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
+++ b/Sources/SmokeDynamoDB/DynamoDBCompositePrimaryKeyTable+bulkUpdateSupport.swift
@@ -170,33 +170,7 @@ extension DynamoDBCompositePrimaryKeyTable {
     private func diffListAttribute(path: String,
                                    newAttribute: [DynamoDBModel.AttributeValue],
                                    existingAttribute: [DynamoDBModel.AttributeValue]) throws -> [AttributeDifference] {
-        let maxIndex = max(newAttribute.count, existingAttribute.count)
-        var haveAppendedAdditionalValues = false
-        
-        return try (0..<maxIndex).flatMap { index -> [AttributeDifference] in
-            let newPath = "\(path)[\(index)]"
-
-            // if both new and existing attributes are present
-            if index < newAttribute.count && index < existingAttribute.count {
-                return try diffAttribute(path: newPath, newAttribute: newAttribute[index], existingAttribute: existingAttribute[index])
-            } else if index < existingAttribute.count {
-                return [.remove(path: newPath)]
-            } else if index < newAttribute.count {
-                let additionalAttributes = Array(newAttribute[index...])
-                let newValue = try getFlattenedListAttribute(attribute: additionalAttributes)
-                
-                if !haveAppendedAdditionalValues {
-                    haveAppendedAdditionalValues = true
-                    
-                    return [.listAppend(path: path, value: newValue)]
-                } else {
-                    // values have already been appended to the list
-                    return []
-                }
-            }
-            
-            return []
-        }
+        return [ .update(path: path, value: try getFlattenedListAttribute(attribute: newAttribute))]
     }
     
     private func diffMapAttribute(path: String?,


### PR DESCRIPTION
*Issue #, if available:*
*Description of changes:*

When we update one of list elements and append a new element, statement fails validation. It is because we try to modify list while append it. The fix is to simply SET path = new_list without checking elements in the list

For example
```
UPDATE "XXXXXXXXXX" SET "drmGroupKeyIds"[0]."drmKeyId"='nDsc1DwjQXOG6XVqTfKYdA==' SET "drmGroupKeyIds"[1]."drmKeyId"='XXXXXX==' SET "drmGroupKeyIds"=list_append("drmGroupKeyIds",[{'drmGroupName': 'UHD', 'contentQuality': 'UHD', 'drmKeyId': 'XXXXX=='}]) ......
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
